### PR TITLE
fix: follow-up CodeRabbit review (revision + directory)

### DIFF
--- a/electron/controllers/db-controller.ts
+++ b/electron/controllers/db-controller.ts
@@ -224,7 +224,6 @@ export function registerDatabaseController() {
   // ============================================================
 ipcMain.handle('db:revision-create', async (_event, params: {
     baseDraftId: number
-    revisionIndex: number
     revisionType: 'refine' | 'review-fix'
     userPrompt?: string
     reviewSourceId?: number
@@ -232,8 +231,8 @@ ipcMain.handle('db:revision-create', async (_event, params: {
     wordCount: number
   }) => {
     try {
-      const id = RevisionRepository.create(params)
-      return { success: true, id }
+      const created = RevisionRepository.create(params)
+      return { success: true, id: created.id, revisionIndex: created.revisionIndex }
     } catch (err) {
       return { success: false, error: String(err) }
     }

--- a/electron/repositories/revision-repository.ts
+++ b/electron/repositories/revision-repository.ts
@@ -46,20 +46,21 @@ function rowToMeta(row: Record<string, unknown>): RevisionMeta {
 }
 
 export class RevisionRepository {
-    /** 创建修稿（事务：先入内容池再建元数据） */
+    /**
+     * 创建修稿（事务内原子分配 revision_index，再入内容池 + 元数据）
+     * 不接受调用方传入序号，避免与落库结果不一致。
+     */
     static create(params: {
         baseDraftId: number
-        revisionIndex?: number
         revisionType: 'refine' | 'review-fix'
         userPrompt?: string
         reviewSourceId?: number
         content: string
         wordCount: number
-    }): number {
+    }): { id: number; revisionIndex: number } {
         const db = getProjectDb()
         if (!db) throw new Error('[RevisionRepository] 数据库未连接')
 
-        // 事务内原子分配 revision_index，避免 getNextIndex + create 竞态
         const tx = db.transaction(() => {
             const row = db.prepare(`
         SELECT MAX(revision_index) as maxIdx FROM revisions WHERE base_draft_id = ?
@@ -81,7 +82,7 @@ export class RevisionRepository {
                 contentId,
                 params.wordCount,
             )
-            return Number(result.lastInsertRowid)
+            return { id: Number(result.lastInsertRowid), revisionIndex }
         })
 
         return tx()
@@ -142,26 +143,34 @@ export class RevisionRepository {
         return (row.maxIdx ?? 0) + 1
     }
 
-    /** 标记为已合并 */
+    /** 标记为已合并（仅 pending → merged） */
     static markMerged(id: number, mergedToDraftId: number): void {
         const db = getProjectDb()
         if (!db) return
 
-        db.prepare(`
+        const result = db.prepare(`
       UPDATE revisions
       SET status = 'merged', merged_to_draft_id = ?, updated_at = datetime('now')
-      WHERE id = ?
+      WHERE id = ? AND status = 'pending'
     `).run(mergedToDraftId, id)
+
+        if (result.changes === 0) {
+            throw new Error(`[RevisionRepository] 无法合并修稿 #${id}：不存在或非 pending 状态`)
+        }
     }
 
-    /** 标记为已弃用 */
+    /** 标记为已弃用（仅 pending → discarded） */
     static markDiscarded(id: number): void {
         const db = getProjectDb()
         if (!db) return
 
-        db.prepare(`
+        const result = db.prepare(`
       UPDATE revisions SET status = 'discarded', updated_at = datetime('now')
-      WHERE id = ?
+      WHERE id = ? AND status = 'pending'
     `).run(id)
+
+        if (result.changes === 0) {
+            throw new Error(`[RevisionRepository] 无法弃用修稿 #${id}：不存在或非 pending 状态`)
+        }
     }
 }

--- a/src/components/dialogs/DirectoryConfigDialog.tsx
+++ b/src/components/dialogs/DirectoryConfigDialog.tsx
@@ -52,16 +52,32 @@ export default function DirectoryConfigDialog({ isOpen, onClose, existingCount, 
     let params: DirectoryWorkflowParams
 
     if (rangeMode === 'full') {
+      // 追加全量：若已无剩余章节则拒绝（覆盖模式仍可从第 1 章重生成）
+      if (overwriteMode === 'append' && existingCount >= total) {
+        toast.warning(text('没有可追加生成的章节', 'No chapters remain to generate.'))
+        return
+      }
       params = { mode: overwriteMode === 'full' ? 'full' : 'append', count: 0 }
     } else if (rangeMode === 'front') {
       if (existingCount > 0 && overwriteMode === 'append') {
-        params = { mode: 'append', startChapter: existingCount + 1, count: Number(frontN) || 50 }
+        if (existingCount >= total) {
+          toast.warning(text('没有可追加生成的章节', 'No chapters remain to generate.'))
+          return
+        }
+        const remaining = total - existingCount
+        const count = Math.min(remaining, Math.max(1, Number(frontN) || 50))
+        params = { mode: 'append', startChapter: existingCount + 1, count }
       } else {
-        params = { mode: 'full', count: Number(frontN) || 50 }
+        params = { mode: 'full', count: Math.min(total, Math.max(1, Number(frontN) || 50)) }
       }
     } else {
-      const start = Number(rangeStart) || 1
-      const end = Math.max(start, Number(rangeEnd) || start)
+      // 指定范围：提交时归一化，不依赖 blur；全书已有蓝图时拒绝追加
+      if (existingCount >= total) {
+        toast.warning(text('没有可追加生成的章节', 'No chapters remain to generate.'))
+        return
+      }
+      const start = Math.min(total, Math.max(1, Number(rangeStart) || 1))
+      const end = Math.min(total, Math.max(start, Number(rangeEnd) || start))
       params = { mode: 'append', startChapter: start, count: Math.max(1, end - start + 1) }
     }
 

--- a/src/services/workflows/commands/refine-draft.command.ts
+++ b/src/services/workflows/commands/refine-draft.command.ts
@@ -54,8 +54,6 @@ export class RefineDraftCommand extends BaseWorkflowCommand<string> {
     const baseDraft = await parseDraftMeta(this.params.draftPath)
     if (!baseDraft) throw new Error('找不到基准草稿版本')
 
-    const revIndex = await ipc.invoke('db:revision-next-index', baseDraft.id)
-
     // 清理该草稿下已有的 pending 状态修稿，保证只保留最新的一条
     const pendingRevs = await ipc.invoke('db:revision-get-pending', baseDraft.id)
     for (const rev of pendingRevs) {
@@ -64,11 +62,12 @@ export class RefineDraftCommand extends BaseWorkflowCommand<string> {
 
     const createRes = await ipc.invoke('db:revision-create', {
       baseDraftId: baseDraft.id,
-      revisionIndex: revIndex,
       revisionType: 'refine',
       content: cleanRefined,
       wordCount: cleanRefined.length,
-    }) as { success: boolean; id: number }
+    }) as { success: boolean; id: number; revisionIndex?: number }
+
+    const revIndex = createRes.revisionIndex ?? 0
 
     const { useEditorStore } = await import('../../../stores/editor-store')
     useEditorStore.getState().openFile({

--- a/src/services/workflows/commands/refine-from-review.command.ts
+++ b/src/services/workflows/commands/refine-from-review.command.ts
@@ -45,8 +45,6 @@ export class RefineFromReviewCommand extends BaseWorkflowCommand<string> {
     const baseDraft = await parseDraftMeta(this.params.draftPath)
     if (!baseDraft) throw new Error('找不到基准草稿版本')
 
-    const revIndex = await ipc.invoke('db:revision-next-index', baseDraft.id)
-
     // 清理该草稿下已有的 pending 状态修稿，保证只保留最新的一条
     const pendingRevs = await ipc.invoke('db:revision-get-pending', baseDraft.id)
     for (const rev of pendingRevs) {
@@ -55,12 +53,13 @@ export class RefineFromReviewCommand extends BaseWorkflowCommand<string> {
 
     const createRes = await ipc.invoke('db:revision-create', {
       baseDraftId: baseDraft.id,
-      revisionIndex: revIndex,
       revisionType: 'review-fix',
       content: cleanRefined,
       wordCount: cleanRefined.length,
       userPrompt: this.params.userRefinePrompt,
-    }) as { success: boolean; id: number }
+    }) as { success: boolean; id: number; revisionIndex?: number }
+
+    const revIndex = createRes.revisionIndex ?? 0
 
     const { useEditorStore } = await import('../../../stores/editor-store')
     useEditorStore.getState().openFile({

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -310,7 +310,7 @@ export interface DatabaseChannels {
   'db:draft-delete': { args: [id: number]; return: { success: boolean; error?: string } }
 
   // 5. revisions
-  'db:revision-create': { args: [params: { baseDraftId: number; revisionIndex: number; revisionType: 'refine' | 'review-fix'; userPrompt?: string; reviewSourceId?: number; content: string; wordCount: number }]; return: { success: boolean; id?: number; error?: string } }
+  'db:revision-create': { args: [params: { baseDraftId: number; revisionType: 'refine' | 'review-fix'; userPrompt?: string; reviewSourceId?: number; content: string; wordCount: number }]; return: { success: boolean; id?: number; revisionIndex?: number; error?: string } }
   'db:revision-list': { args: [baseDraftId: number]; return: RevisionMeta[] }
   'db:revision-get-pending': { args: [baseDraftId: number]; return: RevisionMeta[] }
   'db:revision-get-full': { args: [id: number]; return: RevisionFull | null }


### PR DESCRIPTION
## Summary
- Revision create no longer accepts/ignores caller `revisionIndex`; returns allocated index
- `markMerged` / `markDiscarded` only transition from `pending`
- Directory config validates ranges on submit and rejects when no chapters remain

## Context
Follow-up to CodeRabbit review on awesome-ai-apps PR after b88de99.