### PR TITLE
test: fix locale-dependent project lifecycle assertions

### DIFF
--- a/src/stores/__tests__/project-close-lifecycle.test.ts
+++ b/src/stores/__tests__/project-close-lifecycle.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ProjectData } from '../../shared/ipc-channels'
 import { useEditorStore } from '../editor-store'
+import { useLocaleStore } from '../locale-store'
 import { useProjectStore } from '../project-store'
 import { useWorkflowStore } from '../workflow-store'
 
@@ -86,6 +87,7 @@ function deferred<T>() {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  useLocaleStore.setState({ locale: 'zh-CN' })
   useProjectStore.setState({
     currentProject: project('A'),
     fileTree: [{ name: 'A', path: 'A', isDir: true }],


### PR DESCRIPTION
## 根因

`useLocaleStore` 在模块初始化时读取 `navigator.language`。项目生命周期测试断言中文提示，却没有固定测试 locale：中文本机为 `zh-CN`，GitHub 英文 Windows runner 为 `en-US`，因此云端恰有 14 项中文文案断言失败。

## 修复

- 仅在 `project-close-lifecycle.test.ts` 的 `beforeEach` 显式设置 `locale: 'zh-CN'`。
- 不修改运行时代码、系统语言首启规则、英文界面或错误处理。

## 证据

- 强制 `navigator.language = 'en-US'` 且移除固定行：23 项中恰 14 项失败，收到英文 alert 文案/标题。
- 恢复固定行后，同一强制英文环境：23/23 通过；临时复现代码已移除。
- 本地全量 Vitest：131 files / 686 tests
- typecheck、变更文件 ESLint、git diff --check：通过
- 独立冻结复审：P0-P2 none，Standards PASS，Spec PASS

合并后重新运行 `master` 上的完整 Windows 云端构建。