### PR TITLE
fix: run tests before release monitoring

### DIFF
--- a/electron/__tests__/package-contract.test.ts
+++ b/electron/__tests__/package-contract.test.ts
@@ -68,12 +68,10 @@ describe('release dependency contract', () => {
     expect(pkg.scripts?.['verify:github-update-release']).toBe('node scripts/verify-github-update-release.mjs')
   })
 
-  it('isolates release-monitor self-tests before the outer monitor starts', () => {
-    const selfTest = 'scripts/__tests__/release-win-verify.test.ts'
+  it('runs the full test suite before the outer monitor starts', () => {
     expect(pkg.scripts?.test).toBe('vitest run')
-    expect(pkg.scripts?.['test:release-monitor-selftest']).toBe(`vitest run ${selfTest}`)
-    expect(pkg.scripts?.['test:release-workload']).toBe(`vitest run --exclude ${selfTest}`)
-    expect(pkg.scripts?.['test:release-monitor-selftest']).not.toBe(pkg.scripts?.['test:release-workload'])
+    expect(pkg.scripts?.['test:release-monitor-selftest']).toBeUndefined()
+    expect(pkg.scripts?.['test:release-workload']).toBeUndefined()
 
     const releaseGate = readFileSync('scripts/release-win-verify.mjs', 'utf8')
     const releaseMonitor = readFileSync('scripts/monitor-win-release-gate.ps1', 'utf8')
@@ -84,9 +82,8 @@ describe('release dependency contract', () => {
 
     expect(plan.status, plan.stderr || plan.error?.message).toBe(0)
     expect(JSON.parse(plan.stdout)).toEqual([
-      'test:release-monitor-selftest',
+      'test',
       'prepare:native-node',
-      'test:release-workload',
       'clean:build',
       'build:win:artifacts',
       'verify:win-update-artifacts',
@@ -98,7 +95,21 @@ describe('release dependency contract', () => {
       'verify:native-node',
       'final:quiet',
     ])
+    const releasePlan = JSON.parse(plan.stdout) as string[]
+    expect(releasePlan[0]).toBe('test')
+    expect(releasePlan.filter(step => step === 'test')).toHaveLength(1)
 
+    const preMonitorStepsDefinition = releaseGate.indexOf('export const releasePreMonitorSteps = [')
+    const releaseVerificationStepsDefinition = releaseGate.indexOf('export const releaseVerificationSteps = [')
+    const releaseFinalizationStepsDefinition = releaseGate.indexOf('export const releaseFinalizationSteps = [')
+    const preMonitorSteps = releaseGate.slice(
+      preMonitorStepsDefinition,
+      releaseVerificationStepsDefinition,
+    )
+    const releaseVerificationSteps = releaseGate.slice(
+      releaseVerificationStepsDefinition,
+      releaseFinalizationStepsDefinition,
+    )
     const preMonitorLoop = releaseGate.indexOf('for (const step of releasePreMonitorSteps)')
     const preMonitorInvocation = releaseGate.indexOf('await runPreMonitorSteps()')
     const monitorStartDefinition = releaseGate.indexOf('async function startReleaseMonitor()')
@@ -123,6 +134,11 @@ describe('release dependency contract', () => {
     )
     expect(preMonitorLoop).toBeGreaterThanOrEqual(0)
     expect(preMonitorInvocation).toBeGreaterThanOrEqual(0)
+    expect(preMonitorStepsDefinition).toBeGreaterThanOrEqual(0)
+    expect(releaseVerificationStepsDefinition).toBeGreaterThan(preMonitorStepsDefinition)
+    expect(releaseFinalizationStepsDefinition).toBeGreaterThan(releaseVerificationStepsDefinition)
+    expect(preMonitorSteps.match(/'test'/g) ?? []).toHaveLength(1)
+    expect(releaseVerificationSteps).not.toMatch(/'test(?:[^']*)?'/)
     expect(monitorStartDefinition).toBeGreaterThanOrEqual(0)
     expect(preMonitorInvocation).toBeLessThan(monitorStartCall)
     expect(monitorStartCall).toBeLessThan(finalizationFlagSet)

--- a/package.json
+++ b/package.json
@@ -17,8 +17,6 @@
     "typecheck": "tsc --noEmit",
     "check:i18n": "node scripts/check-i18n-coverage.mjs",
     "test": "vitest run",
-    "test:release-monitor-selftest": "vitest run scripts/__tests__/release-win-verify.test.ts",
-    "test:release-workload": "vitest run --exclude scripts/__tests__/release-win-verify.test.ts",
     "build": "tsc && vite build",
     "build:win": "pnpm run release:win:verify",
     "build:win:artifacts": "node scripts/require-release-gate.mjs && pnpm run rebuild:electron && tsc && vite build && electron-builder --win --x64 --publish never",

--- a/scripts/__tests__/release-win-verify.test.ts
+++ b/scripts/__tests__/release-win-verify.test.ts
@@ -464,7 +464,7 @@ describe('Windows release verification orchestration', () => {
     }
   }, 7_000)
 
-  windowsIt('stops after a failed pre-monitor self-test without starting release or finalization work', async () => {
+  windowsIt('stops after a failed full test preflight without starting release or finalization work', async () => {
     const root = mkdtempSync(join(tmpdir(), 'ai-novel-release-premonitor-failure-'))
     const isolatedTemp = join(root, 'temp')
     const fakePnpmCli = join(root, 'fake-pnpm.cjs')
@@ -478,7 +478,7 @@ describe('Windows release verification orchestration', () => {
         'const { appendFileSync } = require("node:fs")',
         'const [command, step] = process.argv.slice(2)',
         'appendFileSync(process.env.AI_NOVEL_RELEASE_STEP_MARKER, `${command} ${step}\\n`, "utf8")',
-        'process.exitCode = step === "test:release-monitor-selftest" ? 1 : 0',
+        'process.exitCode = step === "test" ? 1 : 0',
       ].join('\n'),
       'utf8',
     )
@@ -554,9 +554,9 @@ describe('Windows release verification orchestration', () => {
       expect(existsSync(join(evidencePath, 'monitor-control-log.jsonl'))).toBe(false)
 
       const steps = readFileSync(stepMarker, 'utf8').trim().split(/\r?\n/).filter(Boolean)
-      expect(steps).toEqual(['run test:release-monitor-selftest'])
+      expect(steps).toEqual(['run test'])
       expect(steps.join('\n')).not.toMatch(
-        /prepare:native-node|test:release-workload|build:win:artifacts|restore:native-node|verify:native-node/,
+        /prepare:native-node|build:win:artifacts|restore:native-node|verify:native-node/,
       )
 
       const entrypoints = readFileSync(entrypointMarker, 'utf8')
@@ -587,7 +587,7 @@ describe('Windows release verification orchestration', () => {
         'const { appendFileSync } = require("node:fs")',
         'const [command, step] = process.argv.slice(2)',
         'appendFileSync(process.env.AI_NOVEL_RELEASE_STEP_MARKER, `${command} ${step}\\n`, "utf8")',
-        'process.exitCode = step === "test:release-monitor-selftest" ? 0 : 98',
+        'process.exitCode = step === "test" ? 0 : 98',
       ].join('\n'),
       'utf8',
     )
@@ -684,7 +684,7 @@ describe('Windows release verification orchestration', () => {
       })
 
       const steps = readFileSync(stepMarker, 'utf8').trim().split(/\r?\n/).filter(Boolean)
-      expect(steps).toEqual(['run test:release-monitor-selftest'])
+      expect(steps).toEqual(['run test'])
       const entrypoints = readFileSync(entrypointMarker, 'utf8')
       expect(entrypoints).not.toMatch(
         /prepare-native-for-node\.mjs|node_modules[\\/]vitest[\\/]vitest\.mjs|release-win-launch-gate\.mjs/,

--- a/scripts/release-win-verify.mjs
+++ b/scripts/release-win-verify.mjs
@@ -16,12 +16,11 @@ import { join, resolve } from 'node:path'
 import { restoreNativeWithIndependentFallback } from './release-native-restore.mjs'
 
 export const releasePreMonitorSteps = [
-  'test:release-monitor-selftest',
+  'test',
 ]
 
 export const releaseVerificationSteps = [
   'prepare:native-node',
-  'test:release-workload',
   'clean:build',
   'build:win:artifacts',
   'verify:win-update-artifacts',


### PR DESCRIPTION
云构建证据表明，多份正常负向单元测试会故意启动非零子进程，与 outer release monitor 对任一 descendant 非零 fail-closed 的语义冲突。此修复将完整 pnpm test 作为唯一 preflight，在 monitor 启动前运行一次；outer monitor 仅覆盖原生准备、Windows 打包、校验和真实 app/installer/upgrade smoke，不增加任何进程或退出码白名单。验证：131 files / 692 tests，typecheck、lint、i18n、Node syntax、diff check 全通过；独立审查 P0-P2 无发现，Standards/Spec 均 PASS。