### PR TITLE
test: stabilize Windows monitor hash across EOLs

### DIFF
--- a/electron/__tests__/package-contract.test.ts
+++ b/electron/__tests__/package-contract.test.ts
@@ -3,7 +3,7 @@ import { createHash } from 'node:crypto'
 import { existsSync, readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 
-import { normalizeSourceEol } from '../../test/source-contract'
+import { readNormalizedSource } from '../../test/source-contract'
 
 const pkg = JSON.parse(readFileSync('package.json', 'utf8')) as {
   packageManager?: string
@@ -52,9 +52,7 @@ describe('release dependency contract', () => {
     expect(pkg.scripts?.['build:win:artifacts']).toContain('--publish never')
 
     const releaseGate = readFileSync('scripts/release-win-verify.mjs', 'utf8')
-    const releaseMonitor = normalizeSourceEol(
-      readFileSync('scripts/monitor-win-release-gate.ps1', 'utf8'),
-    )
+    const releaseMonitor = readNormalizedSource('scripts/monitor-win-release-gate.ps1')
     expect(releaseGate).toContain('monitor-win-release-gate.ps1')
     expect(releaseGate.indexOf("await waitForMonitorState(['ready']")).toBeLessThan(
       releaseGate.indexOf('for (const step of releaseVerificationSteps)'),
@@ -78,7 +76,7 @@ describe('release dependency contract', () => {
     expect(pkg.scripts?.['test:release-workload']).toBeUndefined()
 
     const releaseGate = readFileSync('scripts/release-win-verify.mjs', 'utf8')
-    const releaseMonitor = readFileSync('scripts/monitor-win-release-gate.ps1', 'utf8')
+    const releaseMonitor = readNormalizedSource('scripts/monitor-win-release-gate.ps1')
     const plan = spawnSync(process.execPath, ['scripts/release-win-verify.mjs', '--print-plan'], {
       cwd: process.cwd(),
       encoding: 'utf8',

--- a/test/source-contract.test.ts
+++ b/test/source-contract.test.ts
@@ -1,7 +1,10 @@
 import { createHash } from 'node:crypto'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
-import { normalizeSourceEol } from './source-contract'
+import { normalizeSourceEol, readNormalizedSource } from './source-contract'
 
 describe('source contract normalization', () => {
   it('treats LF, CRLF, and CR source text as the same source contract', () => {
@@ -13,5 +16,22 @@ describe('source contract normalization', () => {
     expect(normalizeSourceEol(cr)).toBe(lf)
     expect(createHash('sha256').update(normalizeSourceEol(crlf)).digest('hex'))
       .toBe(createHash('sha256').update(normalizeSourceEol(lf)).digest('hex'))
+  })
+
+  it('reads CRLF source files as their canonical LF source before hashing', () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), 'ai-novel-source-contract-'))
+    const sourcePath = join(fixtureRoot, 'monitor.ps1')
+    const canonicalSource = 'first\nsecond\n'
+
+    try {
+      writeFileSync(sourcePath, 'first\r\nsecond\r\n', 'utf8')
+
+      const source = readNormalizedSource(sourcePath)
+      expect(source).toBe(canonicalSource)
+      expect(createHash('sha256').update(source).digest('hex'))
+        .toBe('dbea9325179efe46ea2add94f7b6b745ca983fabb208dc6d34aa064623d7ee23')
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true })
+    }
   })
 })

--- a/test/source-contract.ts
+++ b/test/source-contract.ts
@@ -1,7 +1,17 @@
+import { readFileSync } from 'node:fs'
+
 /**
  * Source-level contract tests intentionally ignore checkout line endings.
  * Git may materialize the same tracked source as LF or CRLF on Windows.
  */
 export function normalizeSourceEol(source: string): string {
   return source.replace(/\r\n?/g, '\n')
+}
+
+/**
+ * Read a tracked source file through the same canonical EOL boundary used by
+ * source-contract assertions and content hashes.
+ */
+export function readNormalizedSource(sourcePath: string): string {
+  return normalizeSourceEol(readFileSync(sourcePath, 'utf8'))
 }


### PR DESCRIPTION
## Summary
- centralize source-file EOL normalization in the test contract helper
- route both package monitor reads through the same canonical LF boundary
- add a real CRLF fixture with a fixed canonical SHA-256 regression

## Evidence
- reproduces cloud run 30185981456 raw CRLF vs canonical LF hash mismatch
- 136/136 test files and 721/721 tests pass locally
- typecheck, ESLint, i18n coverage, and diff-check pass
- independent frozen Sol/MAX review: P0=0, P1=0, P2=0; Standards PASS; Spec PASS

No production runtime code or release publishing behavior is changed.