### PR TITLE
Refresh the release monitor contract hash

### DIFF
--- a/electron/__tests__/package-contract.test.ts
+++ b/electron/__tests__/package-contract.test.ts
@@ -176,7 +176,7 @@ describe('release dependency contract', () => {
 
     expect(
       createHash('sha256').update(releaseMonitor).digest('hex'),
-    ).toBe('a9b9cb0a38074c22247b227b0a2403719530b5f10077fad91ca06299403795a9')
+    ).toBe('5c32a06428cf382dd780d1ca31fbd9dae5fc5d872e0de8104f4c709be06aa768')
   })
 
   it('blocks direct Windows artifact builds outside the release gate', () => {


### PR DESCRIPTION
Updates the single normalized-source SHA-256 assertion required by the merged release-monitor change.

No implementation or test-logic changes.

Validation:
- package contract: 5/5
- full test suite: 136 files, 727/727
- lint, typecheck, i18n, diff check: passed