### PR TITLE
Fix Windows cloud installer smoke false positive

### DIFF
--- a/electron/__tests__/package-contract.test.ts
+++ b/electron/__tests__/package-contract.test.ts
@@ -176,7 +176,7 @@ describe('release dependency contract', () => {
 
     expect(
       createHash('sha256').update(releaseMonitor).digest('hex'),
-    ).toBe('60ddd9ff3ee76cc470ebd1641d6441ace8333bd38a2675a64f0fbfed9bebaab1')
+    ).toBe('21f0740dc6fb4e4a0e988216435e1baf855f20ccb24ee87be82102982232a30f')
   })
 
   it('blocks direct Windows artifact builds outside the release gate', () => {

--- a/electron/security/__tests__/windows-safe-file-system.test.ts
+++ b/electron/security/__tests__/windows-safe-file-system.test.ts
@@ -159,7 +159,7 @@ describe.runIf(process.platform === 'win32')('Windows handle-bound secure file s
       .rejects.toThrow('SECURE_FS_REPARSE_POINT')
     expect(fs.existsSync(path.join(outsideRoot, 'new-folder'))).toBe(false)
     expect(fs.existsSync(path.join(outsideRoot, 'result.txt'))).toBe(false)
-  })
+  }, REAL_WINDOWS_MULTI_HELPER_TIMEOUT_MS)
 
   it('keeps ordinary non-reparse reads, recursive mkdir, atomic writes, and enumeration working', async () => {
     const fixture = fixtureRoot()

--- a/scripts/__tests__/release-win-verify.test.ts
+++ b/scripts/__tests__/release-win-verify.test.ts
@@ -223,7 +223,12 @@ async function stopGateMonitor(controlPath: string, monitor: ReturnType<typeof s
   }
 }
 
-async function startArmedCommand(root: string, targetSource: string, environment: NodeJS.ProcessEnv = {}): Promise<{
+async function startArmedExecutable(
+  root: string,
+  targetExecutable: string,
+  targetArguments: string[],
+  environment: NodeJS.ProcessEnv = {},
+): Promise<{
   armedPath: string
   releasePath: string
   resultPath: string
@@ -240,14 +245,17 @@ async function startArmedCommand(root: string, targetSource: string, environment
       '--release-path', releasePath,
       '--result-path', resultPath,
       '--',
-      process.execPath,
-      '-e',
-      targetSource,
+      targetExecutable,
+      ...targetArguments,
     ],
     { windowsHide: true, stdio: 'ignore', env: { ...process.env, ...environment } },
   )
   await waitForFile(armedPath)
   return { armedPath, releasePath, resultPath, child }
+}
+
+async function startArmedCommand(root: string, targetSource: string, environment: NodeJS.ProcessEnv = {}) {
+  return await startArmedExecutable(root, process.execPath, ['-e', targetSource], environment)
 }
 
 async function runShortLivedDescendantFaultScenario(): Promise<Record<string, unknown>> {
@@ -865,7 +873,7 @@ $missing = Initialize-AiNovelGateRootIdentity -RootProcessId 2147483646 -RootPro
       Missing: false,
     })
     expect(Number(result.Stored)).toBeGreaterThan(0)
-  })
+  }, 15_000)
 
   windowsIt('keeps cross-process window events on the dedicated WinEventHook message loop', () => {
     const root = mkdtempSync(join(tmpdir(), 'ai-novel-release-gate-window-event-'))
@@ -942,10 +950,332 @@ finally {
       }),
       expect.objectContaining({
         kind: 'process-tree',
-        reason: 'monitor-failure',
+        reason: 'deferred-process-failure',
       }),
     ]))
   }, 60_000)
+
+  windowsIt('preserves an armed launch result before failing closed for a nonzero PowerShell descendant', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ai-novel-release-gate-preserve-result-'))
+    const controlPath = join(root, 'control.jsonl')
+    const statusPath = join(root, 'status.json')
+    const evidencePath = join(root, 'evidence')
+    const monitor = spawn(
+      'powershell.exe',
+      [
+        '-NoProfile',
+        '-ExecutionPolicy',
+        'Bypass',
+        '-File',
+        releaseMonitorScript,
+        '-ControlPath',
+        controlPath,
+        '-StatusPath',
+        statusPath,
+        '-EvidencePath',
+        evidencePath,
+      ],
+      { windowsHide: true, stdio: 'ignore' },
+    )
+    let gate: Awaited<ReturnType<typeof startArmedCommand>> | undefined
+
+    try {
+      await waitForGateStatus(statusPath, 'ready')
+      gate = await startArmedCommand(
+        root,
+        "const { spawnSync } = require('node:child_process'); const result = spawnSync('powershell.exe', ['-NoProfile', '-Command', 'Start-Sleep -Seconds 1; exit 37'], { stdio: 'ignore' }); process.exit(result.status ?? 1)",
+      )
+      if (gate.child.pid == null) throw new Error('The armed gate did not expose a PID')
+      appendFileSync(
+        controlPath,
+        `${JSON.stringify({
+          sequence: 1,
+          state: 'running',
+          step: 'preserve-launch-result-after-powershell-failure',
+          rootProcessId: gate.child.pid,
+          rootProcessStartTimeTicks: windowsProcessStartTimeTicks(gate.child.pid),
+          relatedTargetNames: ['node', 'powershell'],
+        })}\n`,
+        'utf8',
+      )
+      await waitForGateStatus(statusPath, 'monitoring')
+      writeFileSync(gate.releasePath, 'release', 'utf8')
+
+      expect(await settleWithin(gate.child, 15_000)).toEqual({ code: 37, signal: null })
+      expect(readJsonWhenAvailable(gate.resultPath)).toMatchObject({
+        state: 'completed',
+        targetExitCode: 37,
+        targetSignal: null,
+      })
+
+      appendFileSync(
+        controlPath,
+        `${JSON.stringify({
+          sequence: 2,
+          state: 'step-complete',
+          step: 'preserve-launch-result-after-powershell-failure',
+        })}\n`,
+        'utf8',
+      )
+      const failed = await waitForGateStatus(statusPath, 'failed', 15_000)
+      const events = readFileSync(join(evidencePath, 'process-events.jsonl'), 'utf8')
+        .trim()
+        .split(/\r?\n/)
+        .filter(Boolean)
+        .map(line => JSON.parse(line) as Record<string, unknown>)
+      const powerShellFailure = events.find(event => {
+        const identity = event.processIdentity as Record<string, unknown> | null
+        return event.kind === 'process-exit'
+          && event.exitCode === 37
+          && identity?.processName === 'powershell'
+      })
+
+      expect(failed.failure).toContain('nonzero exit code 37')
+      expect(readFileSync(join(evidencePath, 'process-events.jsonl'), 'utf8')).not.toContain('exit 37')
+      expect(powerShellFailure).toEqual(expect.objectContaining({
+        step: 'preserve-launch-result-after-powershell-failure',
+        processIdentity: expect.objectContaining({
+          identityCaptured: true,
+          commandLineCaptured: true,
+          commandLineRedacted: true,
+        }),
+      }))
+      expect((powerShellFailure?.processIdentity as Record<string, unknown>)).not.toHaveProperty('commandLine')
+    } finally {
+      if (gate) {
+        gate.child.kill()
+        await settleWithin(gate.child).catch(() => undefined)
+      }
+      await stopGateMonitor(controlPath, monitor)
+      rmSync(root, { recursive: true, force: true })
+    }
+  }, 45_000)
+
+  windowsIt('accepts the three exact electron-builder probes from one captured installer instance', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ai-novel-release-gate-nsis-probes-'))
+    const controlPath = join(root, 'control.jsonl')
+    const statusPath = join(root, 'status.json')
+    const evidencePath = join(root, 'evidence')
+    const sourcePath = join(root, 'ExactNsisProbeParent.cs')
+    const installerPath = join(root, 'ai-novel-writer-setup-0.4.0.exe')
+    const probeResultPath = join(root, 'probe-results.txt')
+    const systemPowerShell = join(
+      process.env.SystemRoot ?? 'C:\\Windows',
+      'System32',
+      'WindowsPowerShell',
+      'v1.0',
+      'powershell.exe',
+    )
+    writeFileSync(sourcePath, String.raw`
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+
+internal static class ExactNsisProbeParent {
+  [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+  private struct StartupInfo {
+    public int cb;
+    public string lpReserved;
+    public string lpDesktop;
+    public string lpTitle;
+    public int dwX;
+    public int dwY;
+    public int dwXSize;
+    public int dwYSize;
+    public int dwXCountChars;
+    public int dwYCountChars;
+    public int dwFillAttribute;
+    public int dwFlags;
+    public short wShowWindow;
+    public short cbReserved2;
+    public IntPtr lpReserved2;
+    public IntPtr hStdInput;
+    public IntPtr hStdOutput;
+    public IntPtr hStdError;
+  }
+
+  [StructLayout(LayoutKind.Sequential)]
+  private struct ProcessInformation {
+    public IntPtr hProcess;
+    public IntPtr hThread;
+    public uint dwProcessId;
+    public uint dwThreadId;
+  }
+
+  [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+  private static extern bool CreateProcess(
+    string applicationName,
+    StringBuilder commandLine,
+    IntPtr processAttributes,
+    IntPtr threadAttributes,
+    bool inheritHandles,
+    uint creationFlags,
+    IntPtr environment,
+    string currentDirectory,
+    ref StartupInfo startupInfo,
+    out ProcessInformation processInformation
+  );
+
+  [DllImport("kernel32.dll", SetLastError = true)]
+  private static extern uint WaitForSingleObject(IntPtr handle, uint milliseconds);
+
+  [DllImport("kernel32.dll", SetLastError = true)]
+  private static extern bool GetExitCodeProcess(IntPtr process, out uint exitCode);
+
+  [DllImport("kernel32.dll", SetLastError = true)]
+  private static extern bool CloseHandle(IntPtr handle);
+
+  private static int RunProbe(string powerShellPath, string payload) {
+    StartupInfo startupInfo = new StartupInfo();
+    startupInfo.cb = Marshal.SizeOf(startupInfo);
+    ProcessInformation processInformation;
+    StringBuilder commandLine = new StringBuilder(
+      "\"" + powerShellPath + "\" -C \"" + payload + "\""
+    );
+    if (!CreateProcess(
+      powerShellPath,
+      commandLine,
+      IntPtr.Zero,
+      IntPtr.Zero,
+      false,
+      0x08000000,
+      IntPtr.Zero,
+      null,
+      ref startupInfo,
+      out processInformation
+    )) return -Marshal.GetLastWin32Error();
+    try {
+      if (WaitForSingleObject(processInformation.hProcess, 30000) != 0) return -9001;
+      uint exitCode;
+      if (!GetExitCodeProcess(processInformation.hProcess, out exitCode)) return -Marshal.GetLastWin32Error();
+      return unchecked((int)exitCode);
+    }
+    finally {
+      CloseHandle(processInformation.hThread);
+      CloseHandle(processInformation.hProcess);
+    }
+  }
+
+  public static int Main(string[] args) {
+    string[] payloads = new[] {
+      "if (Get-Command Get-CimInstance -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }",
+      "if ((Get-ExecutionPolicy -Scope Process) -eq 'Restricted') { exit 1 } else { exit 0 }",
+      "if ((Get-CimInstance -ClassName Win32_Process | ? {$_.Path -and $_.Path.StartsWith('C:\\ai-novel-release-probe-empty', 'CurrentCultureIgnoreCase')}).Count -gt 0) { exit 0 } else { exit 1 }"
+    };
+    int[] results = new int[payloads.Length];
+    for (int index = 0; index < payloads.Length; index++) {
+      results[index] = RunProbe(args[0], payloads[index]);
+    }
+    File.WriteAllText(args[1], String.Join(",", results));
+    return 0;
+  }
+}
+`, 'utf8')
+    execFileSync(
+      'powershell.exe',
+      [
+        '-NoProfile',
+        '-ExecutionPolicy',
+        'Bypass',
+        '-Command',
+        `Add-Type -Path ${quotePowerShell(sourcePath)} -OutputAssembly ${quotePowerShell(installerPath)} -OutputType ConsoleApplication`,
+      ],
+      { windowsHide: true, stdio: 'ignore' },
+    )
+    const monitor = spawn(
+      'powershell.exe',
+      [
+        '-NoProfile',
+        '-ExecutionPolicy',
+        'Bypass',
+        '-File',
+        releaseMonitorScript,
+        '-ControlPath',
+        controlPath,
+        '-StatusPath',
+        statusPath,
+        '-EvidencePath',
+        evidencePath,
+      ],
+      { windowsHide: true, stdio: 'ignore' },
+    )
+    let gate: Awaited<ReturnType<typeof startArmedExecutable>> | undefined
+
+    try {
+      await waitForGateStatus(statusPath, 'ready')
+      gate = await startArmedExecutable(root, installerPath, [systemPowerShell, probeResultPath])
+      if (gate.child.pid == null) throw new Error('The armed gate did not expose a PID')
+      appendFileSync(
+        controlPath,
+        `${JSON.stringify({
+          sequence: 1,
+          state: 'running',
+          step: 'smoke:win-installer',
+          rootProcessId: gate.child.pid,
+          rootProcessStartTimeTicks: windowsProcessStartTimeTicks(gate.child.pid),
+          relatedTargetNames: ['ai-novel-writer-setup-0.4.0', 'powershell'],
+        })}\n`,
+        'utf8',
+      )
+      await waitForGateStatus(statusPath, 'monitoring')
+      writeFileSync(gate.releasePath, 'release', 'utf8')
+      expect(await settleWithin(gate.child, 30_000)).toEqual({ code: 0, signal: null })
+      const probeResults = readFileSync(probeResultPath, 'utf8').split(',').map(Number)
+      expect(probeResults).toHaveLength(3)
+      expect(probeResults.every(exitCode => exitCode === 0 || exitCode === 1)).toBe(true)
+      expect(probeResults.at(-1)).toBe(1)
+
+      appendFileSync(
+        controlPath,
+        `${JSON.stringify({ sequence: 2, state: 'step-complete', step: 'smoke:win-installer' })}\n`,
+        'utf8',
+      )
+      await waitForGateStatus(statusPath, 'step-completed', 30_000)
+      const rawEvidence = readFileSync(join(evidencePath, 'process-events.jsonl'), 'utf8')
+      const events = rawEvidence.trim().split(/\r?\n/).filter(Boolean).map(line => JSON.parse(line) as Record<string, unknown>)
+      const powerShellExits = events.filter(event => {
+        const identity = event.processIdentity as Record<string, unknown> | undefined
+        return event.kind === 'process-exit' && identity?.processName === 'powershell'
+      })
+
+      expect(powerShellExits).toHaveLength(3)
+      expect(powerShellExits.map(event => event.exitClassification)).toEqual(
+        probeResults.map(exitCode => exitCode === 0 ? 'succeeded' : 'expected-nsis-powershell-probe'),
+      )
+      for (const event of powerShellExits) {
+        const identity = event.processIdentity as Record<string, unknown>
+        expect(identity).toMatchObject({
+          parentExecutablePath: installerPath,
+          commandLineCaptured: true,
+          commandLineRedacted: true,
+        })
+        expect(identity.parentProcessStartTimeTicks).toEqual(expect.any(String))
+        expect(identity).not.toHaveProperty('commandLine')
+      }
+      expect(rawEvidence).not.toContain('Get-CimInstance')
+    } finally {
+      if (gate) {
+        gate.child.kill()
+        await settleWithin(gate.child).catch(() => undefined)
+      }
+      await stopGateMonitor(controlPath, monitor)
+      rmSync(root, { recursive: true, force: true })
+    }
+  }, 60_000)
+
+  it('persists a minimal capture-failure event before failing closed', () => {
+    const monitor = readFileSync(releaseMonitorScript, 'utf8')
+    const captureGuard = monitor.indexOf('if (-not [bool]$processEvent.CaptureEstablished)')
+    const evidenceWrite = monitor.indexOf('Write-AiNovelGateProcessEventEvidence', captureGuard)
+    const captureClassification = monitor.indexOf("-ExitClassification 'capture-failure'", captureGuard)
+    const failClosed = monitor.indexOf('throw "Release gate could not retain a process handle', captureGuard)
+
+    expect(captureGuard).toBeGreaterThanOrEqual(0)
+    expect(evidenceWrite).toBeGreaterThan(captureGuard)
+    expect(captureClassification).toBeGreaterThan(evidenceWrite)
+    expect(failClosed).toBeGreaterThan(captureClassification)
+  })
 
   windowsIt('keeps a real command dormant when the monitor acknowledgement fails', async () => {
     const root = mkdtempSync(join(tmpdir(), 'ai-novel-release-gate-no-ack-'))

--- a/scripts/__tests__/smoke-win-installer.test.ts
+++ b/scripts/__tests__/smoke-win-installer.test.ts
@@ -988,6 +988,175 @@ $uncaptured = Get-GateExitFailure ([pscustomobject]@{ ProcessId = 704; ExitCode 
     expect(result.Uncaptured).toContain('could not capture the exit code')
   })
 
+  windowsIt('exempts only the known NSIS PowerShell probes during installer smoke steps', () => {
+    const output = runReleaseMonitorLibrary(`
+$system32 = Join-Path $env:SystemRoot 'System32\\WindowsPowerShell\\v1.0\\powershell.exe'
+$sysWow64 = Join-Path $env:SystemRoot 'SysWOW64\\WindowsPowerShell\\v1.0\\powershell.exe'
+$event = [pscustomobject]@{ ProcessId = 701; ExitCode = 1; ExitCodeCaptured = $true; JobMessage = 7 }
+$parentPath = 'C:\\temp\\ai-novel-writer-setup-0.4.0.exe'
+$parentStartTimeTicks = '638900000000000000'
+$parent = [pscustomobject]@{
+  processId = 700
+  startTimeTicks = $parentStartTimeTicks
+  identityCaptured = $true
+  executablePath = $parentPath
+}
+$system32Prefix = '"' + $system32 + '" -C "'
+$sysWow64Prefix = '"' + $sysWow64 + '" -C "'
+$availabilityPayload = 'if (Get-Command Get-CimInstance -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }'
+$policyPayload = 'if ((Get-ExecutionPolicy -Scope Process) -eq ''Restricted'') { exit 1 } else { exit 0 }'
+$runningProcessPayload = 'if ((Get-CimInstance -ClassName Win32_Process | ? {$_.Path -and $_.Path.StartsWith(''C:\\temp\\installed'', ''CurrentCultureIgnoreCase'')}).Count -gt 0) { exit 0 } else { exit 1 }'
+$availabilityCommand = $system32Prefix + $availabilityPayload + '"'
+$policyCommand = $system32Prefix + $policyPayload + '"'
+$runningProcessCommand = $sysWow64Prefix + $runningProcessPayload + '"'
+$arbitraryCommand = $system32Prefix + 'Write-Error ''not an NSIS probe''; exit 1"'
+$suffixedCommand = $availabilityCommand.Substring(0, $availabilityCommand.Length - 1) + '; Write-Error ''surplus action''"'
+$alternateSwitchCommand = $availabilityCommand.Replace(' -C ', ' -Command ')
+$lowercaseSwitchCommand = $availabilityCommand.Replace(' -C ', ' -c ')
+$changedPayloadCaseCommand = $availabilityCommand.Replace('Get-CimInstance', 'get-ciminstance')
+$pathCaseCommand = $availabilityCommand.Replace($system32, $system32.ToUpperInvariant())
+$wrongArgvZeroCommand = $availabilityCommand.Replace('"' + $system32 + '"', '"C:\\temp\\totally-unrelated.exe"')
+$extraWhitespaceCommand = $availabilityCommand.Replace(' -C ', '  -C ')
+
+function New-ProbeIdentity {
+  param(
+    [string]$ImagePath,
+    [string]$CommandLine,
+    [bool]$IdentityCaptured = $true,
+    [bool]$CommandLineCaptured = $true,
+    [Nullable[int]]$ParentProcessId = 700,
+    [AllowNull()][string]$ParentStartTimeTicks = $parentStartTimeTicks,
+    [AllowNull()][string]$ParentExecutablePath = $parentPath
+  )
+  return [pscustomobject]@{
+    processId = 701
+    identityCaptured = $IdentityCaptured
+    commandLineCaptured = $CommandLineCaptured
+    parentProcessId = $ParentProcessId
+    parentProcessStartTimeTicks = $ParentStartTimeTicks
+    parentExecutablePath = $ParentExecutablePath
+    executablePath = $ImagePath
+    commandLine = $CommandLine
+  }
+}
+
+function Test-SyntheticNsisProbe {
+  param(
+    [string]$Step,
+    $Event,
+    $Identity,
+    $Parent
+  )
+  return Test-AiNovelGateExpectedNsisPowerShellProbeExit -Step $Step -Event $Event -ProcessIdentity $Identity -ParentIdentity $Parent
+}
+
+$validAvailability = New-ProbeIdentity -ImagePath $system32 -CommandLine $availabilityCommand
+$validPolicy = New-ProbeIdentity -ImagePath $system32 -CommandLine $policyCommand
+$validRunningProcess = New-ProbeIdentity -ImagePath $sysWow64 -CommandLine $runningProcessCommand
+$wrongParent = [pscustomobject]@{ processId = 700; startTimeTicks = $parentStartTimeTicks; identityCaptured = $true; executablePath = 'C:\\temp\\unrelated.exe' }
+$relativeParent = [pscustomobject]@{ processId = 700; startTimeTicks = $parentStartTimeTicks; identityCaptured = $true; executablePath = 'ai-novel-writer-setup-0.4.0.exe' }
+$nonOne = [pscustomobject]@{ ProcessId = 701; ExitCode = 2; ExitCodeCaptured = $true; JobMessage = 7 }
+$abnormal = [pscustomobject]@{ ProcessId = 701; ExitCode = 1; ExitCodeCaptured = $true; JobMessage = 8 }
+
+[pscustomobject]@{
+  InstallerAvailability = Test-SyntheticNsisProbe -Step 'smoke:win-installer' -Event $event -Identity $validAvailability -Parent $parent
+  UpgradePolicy = Test-SyntheticNsisProbe -Step 'smoke:win-v025-upgrade' -Event $event -Identity $validPolicy -Parent $parent
+  SysWow64RunningProcess = Test-SyntheticNsisProbe -Step 'smoke:win-installer' -Event $event -Identity $validRunningProcess -Parent $parent
+  PathCaseOnly = Test-SyntheticNsisProbe -Step 'smoke:win-installer' -Event $event -Identity (New-ProbeIdentity -ImagePath $system32 -CommandLine $pathCaseCommand) -Parent $parent
+  OtherStep = Test-SyntheticNsisProbe -Step 'other-step' -Event $event -Identity $validAvailability -Parent $parent
+  ArbitraryPowerShell = Test-SyntheticNsisProbe -Step 'smoke:win-installer' -Event $event -Identity (New-ProbeIdentity -ImagePath $system32 -CommandLine $arbitraryCommand) -Parent $parent
+  SuffixedKnownCommand = Test-SyntheticNsisProbe -Step 'smoke:win-installer' -Event $event -Identity (New-ProbeIdentity -ImagePath $system32 -CommandLine $suffixedCommand) -Parent $parent
+  AlternateSwitch = Test-SyntheticNsisProbe -Step 'smoke:win-installer' -Event $event -Identity (New-ProbeIdentity -ImagePath $system32 -CommandLine $alternateSwitchCommand) -Parent $parent
+  LowercaseSwitch = Test-SyntheticNsisProbe -Step 'smoke:win-installer' -Event $event -Identity (New-ProbeIdentity -ImagePath $system32 -CommandLine $lowercaseSwitchCommand) -Parent $parent
+  ChangedPayloadCase = Test-SyntheticNsisProbe -Step 'smoke:win-installer' -Event $event -Identity (New-ProbeIdentity -ImagePath $system32 -CommandLine $changedPayloadCaseCommand) -Parent $parent
+  WrongArgvZero = Test-SyntheticNsisProbe -Step 'smoke:win-installer' -Event $event -Identity (New-ProbeIdentity -ImagePath $system32 -CommandLine $wrongArgvZeroCommand) -Parent $parent
+  ExtraWhitespace = Test-SyntheticNsisProbe -Step 'smoke:win-installer' -Event $event -Identity (New-ProbeIdentity -ImagePath $system32 -CommandLine $extraWhitespaceCommand) -Parent $parent
+  WrongParent = Test-SyntheticNsisProbe -Step 'smoke:win-installer' -Event $event -Identity $validAvailability -Parent $wrongParent
+  ReusedParentPid = Test-SyntheticNsisProbe -Step 'smoke:win-installer' -Event $event -Identity (New-ProbeIdentity -ImagePath $system32 -CommandLine $availabilityCommand -ParentStartTimeTicks '638899999999999999') -Parent $parent
+  ParentPathMismatch = Test-SyntheticNsisProbe -Step 'smoke:win-installer' -Event $event -Identity (New-ProbeIdentity -ImagePath $system32 -CommandLine $availabilityCommand -ParentExecutablePath 'C:\\temp\\other\\ai-novel-writer-setup-0.4.0.exe') -Parent $parent
+  RelativeInstallerParent = Test-SyntheticNsisProbe -Step 'smoke:win-installer' -Event $event -Identity (New-ProbeIdentity -ImagePath $system32 -CommandLine $availabilityCommand -ParentExecutablePath 'ai-novel-writer-setup-0.4.0.exe') -Parent $relativeParent
+  NonOneExit = Test-SyntheticNsisProbe -Step 'smoke:win-installer' -Event $nonOne -Identity $validAvailability -Parent $parent
+  AbnormalExit = Test-SyntheticNsisProbe -Step 'smoke:win-installer' -Event $abnormal -Identity $validAvailability -Parent $parent
+  ProductProcess = Test-SyntheticNsisProbe -Step 'smoke:win-installer' -Event $event -Identity (New-ProbeIdentity -ImagePath 'C:\\temp\\AI小说作家.exe' -CommandLine $availabilityCommand) -Parent $parent
+  RelativePowerShell = Test-SyntheticNsisProbe -Step 'smoke:win-installer' -Event $event -Identity (New-ProbeIdentity -ImagePath 'System32\\WindowsPowerShell\\v1.0\\powershell.exe' -CommandLine $availabilityCommand) -Parent $parent
+  MissingIdentity = Test-SyntheticNsisProbe -Step 'smoke:win-installer' -Event $event -Identity (New-ProbeIdentity -ImagePath $system32 -CommandLine $availabilityCommand -IdentityCaptured $false) -Parent $parent
+  MissingCommandLine = Test-SyntheticNsisProbe -Step 'smoke:win-installer' -Event $event -Identity (New-ProbeIdentity -ImagePath $system32 -CommandLine '' -CommandLineCaptured $false) -Parent $parent
+  MissingParentMetadata = Test-SyntheticNsisProbe -Step 'smoke:win-installer' -Event $event -Identity (New-ProbeIdentity -ImagePath $system32 -CommandLine $availabilityCommand -ParentProcessId $null) -Parent $parent
+} | ConvertTo-Json -Compress
+`)
+    const result = parseLastJsonLine(output)
+
+    expect(result.InstallerAvailability).toBe(true)
+    expect(result.UpgradePolicy).toBe(true)
+    expect(result.SysWow64RunningProcess).toBe(true)
+    expect(result.PathCaseOnly).toBe(true)
+    expect(result.OtherStep).toBe(false)
+    expect(result.ArbitraryPowerShell).toBe(false)
+    expect(result.SuffixedKnownCommand).toBe(false)
+    expect(result.AlternateSwitch).toBe(false)
+    expect(result.LowercaseSwitch).toBe(false)
+    expect(result.ChangedPayloadCase).toBe(false)
+    expect(result.WrongArgvZero).toBe(false)
+    expect(result.ExtraWhitespace).toBe(false)
+    expect(result.WrongParent).toBe(false)
+    expect(result.ReusedParentPid).toBe(false)
+    expect(result.ParentPathMismatch).toBe(false)
+    expect(result.RelativeInstallerParent).toBe(false)
+    expect(result.NonOneExit).toBe(false)
+    expect(result.AbnormalExit).toBe(false)
+    expect(result.ProductProcess).toBe(false)
+    expect(result.RelativePowerShell).toBe(false)
+    expect(result.MissingIdentity).toBe(false)
+    expect(result.MissingCommandLine).toBe(false)
+    expect(result.MissingParentMetadata).toBe(false)
+  })
+
+  windowsIt('keeps command-line secrets in memory and redacts them from process evidence', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ai-novel-release-evidence-redaction-'))
+    const secret = 'super-secret-cli-token'
+    try {
+      runReleaseMonitorLibrary(`
+New-Item -ItemType Directory -Path ${quotePowerShell(root)} -Force | Out-Null
+$event = [pscustomobject]@{
+  Kind = 'process-start'
+  ProcessId = 701
+  ExitCode = $null
+  CaptureEstablished = $true
+  ExitCodeCaptured = $false
+  JobMessage = 6
+  RecordedAt = '2026-01-01T00:00:00.0000000Z'
+}
+$identity = [pscustomobject]@{
+  processId = 701
+  startTimeTicks = '638900000000000000'
+  processName = 'powershell'
+  executablePath = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
+  commandLine = 'powershell.exe -Command Invoke-Thing --token ${secret}'
+  parentProcessId = 700
+  parentProcessStartTimeTicks = '638899999999999999'
+  parentExecutablePath = 'C:\\temp\\parent.exe'
+  identityCaptured = $true
+  commandLineCaptured = $true
+  identityCaptureError = $null
+}
+Write-AiNovelGateProcessEventEvidence -Path ${quotePowerShell(root)} -Step 'redaction-test' -Event $event -ProcessIdentity $identity -ExitClassification 'failure'
+`)
+      const rawEvidence = readFileSync(join(root, 'process-events.jsonl'), 'utf8')
+      const evidence = JSON.parse(rawEvidence.trim()) as {
+        processIdentity?: Record<string, unknown>
+      }
+
+      expect(rawEvidence).not.toContain(secret)
+      expect(evidence.processIdentity).not.toHaveProperty('commandLine')
+      expect(evidence.processIdentity).toMatchObject({
+        commandLineCaptured: true,
+        commandLineRedacted: true,
+      })
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
   windowsIt('does not treat a reused process ID as the process originally tracked by the release gate', () => {
     const output = runReleaseMonitorLibrary(`
 $ids = [System.Collections.Generic.HashSet[int]]::new()

--- a/scripts/monitor-win-release-gate.ps1
+++ b/scripts/monitor-win-release-gate.ps1
@@ -16,6 +16,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
@@ -28,15 +29,52 @@ namespace AiNovelReleaseGate {
     public bool CaptureEstablished { get; private set; }
     public bool ExitCodeCaptured { get; private set; }
     public uint JobMessage { get; private set; }
+    public string ProcessStartTimeTicks { get; private set; }
+    public string ProcessName { get; private set; }
+    public string ImagePath { get; private set; }
+    public string CommandLine { get; private set; }
+    public int? ParentProcessId { get; private set; }
+    public string ParentProcessStartTimeTicks { get; private set; }
+    public string ParentImagePath { get; private set; }
+    public bool IdentityCaptured { get; private set; }
+    public bool CommandLineCaptured { get; private set; }
+    public string IdentityCaptureError { get; private set; }
     public string RecordedAt { get; private set; }
 
-    internal JobProcessEvent(string kind, int processId, int? exitCode, bool captureEstablished, bool exitCodeCaptured, uint jobMessage) {
+    internal JobProcessEvent(
+      string kind,
+      int processId,
+      int? exitCode,
+      bool captureEstablished,
+      bool exitCodeCaptured,
+      uint jobMessage,
+      string processStartTimeTicks = null,
+      string processName = null,
+      string imagePath = null,
+      string commandLine = null,
+      int? parentProcessId = null,
+      string parentProcessStartTimeTicks = null,
+      string parentImagePath = null,
+      bool identityCaptured = false,
+      bool commandLineCaptured = false,
+      string identityCaptureError = null
+    ) {
       Kind = kind;
       ProcessId = processId;
       ExitCode = exitCode;
       CaptureEstablished = captureEstablished;
       ExitCodeCaptured = exitCodeCaptured;
       JobMessage = jobMessage;
+      ProcessStartTimeTicks = processStartTimeTicks;
+      ProcessName = processName;
+      ImagePath = imagePath;
+      CommandLine = commandLine;
+      ParentProcessId = parentProcessId;
+      ParentProcessStartTimeTicks = parentProcessStartTimeTicks;
+      ParentImagePath = parentImagePath;
+      IdentityCaptured = identityCaptured;
+      CommandLineCaptured = commandLineCaptured;
+      IdentityCaptureError = identityCaptureError;
       RecordedAt = DateTime.UtcNow.ToString("o");
     }
   }
@@ -51,12 +89,36 @@ namespace AiNovelReleaseGate {
     private const uint ProcessSetQuota = 0x0100;
     private const uint ProcessQueryLimitedInformation = 0x1000;
     private const uint Synchronize = 0x00100000;
+    private const int ProcessCommandLineInformation = 60;
     private const int WaitTimeout = 258;
 
     [StructLayout(LayoutKind.Sequential)]
     private struct JobObjectAssociateCompletionPort {
       public IntPtr CompletionKey;
       public IntPtr CompletionPort;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct NativeFileTime {
+      public uint LowDateTime;
+      public uint HighDateTime;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct NativeUnicodeString {
+      public ushort Length;
+      public ushort MaximumLength;
+      public IntPtr Buffer;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct ProcessBasicInformation {
+      public IntPtr Reserved1;
+      public IntPtr PebBaseAddress;
+      public IntPtr Reserved2_0;
+      public IntPtr Reserved2_1;
+      public UIntPtr UniqueProcessId;
+      public UIntPtr InheritedFromUniqueProcessId;
     }
 
     [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
@@ -82,6 +144,32 @@ namespace AiNovelReleaseGate {
 
     [DllImport("kernel32.dll", SetLastError = true)]
     private static extern bool GetExitCodeProcess(IntPtr process, out uint exitCode);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool GetProcessTimes(
+      IntPtr process,
+      out NativeFileTime creationTime,
+      out NativeFileTime exitTime,
+      out NativeFileTime kernelTime,
+      out NativeFileTime userTime
+    );
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern bool QueryFullProcessImageName(
+      IntPtr process,
+      uint flags,
+      StringBuilder executablePath,
+      ref int size
+    );
+
+    [DllImport("ntdll.dll")]
+    private static extern int NtQueryInformationProcess(
+      IntPtr process,
+      int processInformationClass,
+      IntPtr processInformation,
+      int processInformationLength,
+      out int returnLength
+    );
 
     [DllImport("kernel32.dll", SetLastError = true)]
     private static extern bool TerminateJobObject(IntPtr job, uint exitCode);
@@ -156,6 +244,149 @@ namespace AiNovelReleaseGate {
       }
     }
 
+    private static string TryReadProcessStartTimeTicks(IntPtr process) {
+      NativeFileTime creationTime;
+      NativeFileTime exitTime;
+      NativeFileTime kernelTime;
+      NativeFileTime userTime;
+      if (!GetProcessTimes(process, out creationTime, out exitTime, out kernelTime, out userTime)) return null;
+      long fileTime = ((long)creationTime.HighDateTime << 32) | creationTime.LowDateTime;
+      return DateTime.FromFileTimeUtc(fileTime).Ticks.ToString();
+    }
+
+    private static string TryReadProcessImagePath(IntPtr process) {
+      int size = 32768;
+      StringBuilder buffer = new StringBuilder(size);
+      if (!QueryFullProcessImageName(process, 0, buffer, ref size)) return null;
+      return buffer.ToString();
+    }
+
+    private static string TryReadProcessCommandLine(IntPtr process) {
+      int requiredLength;
+      NtQueryInformationProcess(
+        process,
+        ProcessCommandLineInformation,
+        IntPtr.Zero,
+        0,
+        out requiredLength
+      );
+      if (requiredLength <= 0) return null;
+      IntPtr buffer = Marshal.AllocHGlobal(requiredLength);
+      try {
+        int status = NtQueryInformationProcess(
+          process,
+          ProcessCommandLineInformation,
+          buffer,
+          requiredLength,
+          out requiredLength
+        );
+        if (status != 0) return null;
+        NativeUnicodeString value = (NativeUnicodeString)Marshal.PtrToStructure(buffer, typeof(NativeUnicodeString));
+        if (value.Buffer == IntPtr.Zero || value.Length == 0) return String.Empty;
+        return Marshal.PtrToStringUni(value.Buffer, value.Length / 2);
+      }
+      finally {
+        Marshal.FreeHGlobal(buffer);
+      }
+    }
+
+    private static int? TryReadParentProcessId(IntPtr process) {
+      int size = Marshal.SizeOf(typeof(ProcessBasicInformation));
+      IntPtr buffer = Marshal.AllocHGlobal(size);
+      try {
+        int returnedLength;
+        int status = NtQueryInformationProcess(
+          process,
+          0,
+          buffer,
+          size,
+          out returnedLength
+        );
+        if (status != 0) return null;
+        ProcessBasicInformation info = (ProcessBasicInformation)Marshal.PtrToStructure(buffer, typeof(ProcessBasicInformation));
+        ulong parentProcessId = info.InheritedFromUniqueProcessId.ToUInt64();
+        if (parentProcessId == 0 || parentProcessId > Int32.MaxValue) return null;
+        return unchecked((int)parentProcessId);
+      }
+      finally {
+        Marshal.FreeHGlobal(buffer);
+      }
+    }
+
+    private static void CaptureParentProcessIdentity(
+      int? parentProcessId,
+      out string parentProcessStartTimeTicks,
+      out string parentImagePath
+    ) {
+      parentProcessStartTimeTicks = null;
+      parentImagePath = null;
+      if (!parentProcessId.HasValue || parentProcessId.Value <= 0) return;
+      IntPtr parent = OpenProcess(
+        ProcessQueryLimitedInformation | Synchronize,
+        false,
+        unchecked((uint)parentProcessId.Value)
+      );
+      if (parent == IntPtr.Zero) return;
+      try {
+        parentProcessStartTimeTicks = TryReadProcessStartTimeTicks(parent);
+        parentImagePath = TryReadProcessImagePath(parent);
+      }
+      finally {
+        CloseHandle(parent);
+      }
+    }
+
+    private static void CaptureProcessIdentity(
+      IntPtr process,
+      int processId,
+      out string processStartTimeTicks,
+      out string processName,
+      out string imagePath,
+      out string commandLine,
+      out int? parentProcessId,
+      out string parentProcessStartTimeTicks,
+      out string parentImagePath,
+      out bool identityCaptured,
+      out bool commandLineCaptured,
+      out string captureError
+    ) {
+      processStartTimeTicks = null;
+      processName = null;
+      imagePath = null;
+      commandLine = null;
+      parentProcessId = null;
+      parentProcessStartTimeTicks = null;
+      parentImagePath = null;
+      identityCaptured = false;
+      commandLineCaptured = false;
+      captureError = null;
+      try {
+        processStartTimeTicks = TryReadProcessStartTimeTicks(process);
+        imagePath = TryReadProcessImagePath(process);
+        if (!String.IsNullOrEmpty(imagePath)) processName = Path.GetFileNameWithoutExtension(imagePath);
+        if (String.IsNullOrEmpty(processName)) {
+          try {
+            using (Process managedProcess = Process.GetProcessById(processId)) {
+              processName = managedProcess.ProcessName;
+            }
+          }
+          catch { }
+        }
+        identityCaptured = !String.IsNullOrEmpty(processStartTimeTicks);
+        commandLine = TryReadProcessCommandLine(process);
+        commandLineCaptured = !String.IsNullOrEmpty(commandLine);
+        parentProcessId = TryReadParentProcessId(process);
+        CaptureParentProcessIdentity(
+          parentProcessId,
+          out parentProcessStartTimeTicks,
+          out parentImagePath
+        );
+      }
+      catch (Exception exception) {
+        captureError = exception.Message;
+      }
+    }
+
     private void Pump() {
       while (!stopping) {
         uint message;
@@ -174,7 +405,31 @@ namespace AiNovelReleaseGate {
         if (message == JobObjectMsgNewProcess) {
           IntPtr process = OpenProcess(ProcessQueryLimitedInformation | Synchronize, false, unchecked((uint)processId));
           bool captured = process != IntPtr.Zero;
+          string processStartTimeTicks = null;
+          string processName = null;
+          string imagePath = null;
+          string commandLine = null;
+          int? parentProcessId = null;
+          string parentProcessStartTimeTicks = null;
+          string parentImagePath = null;
+          bool identityCaptured = false;
+          bool commandLineCaptured = false;
+          string identityCaptureError = null;
           if (captured) {
+            CaptureProcessIdentity(
+              process,
+              processId,
+              out processStartTimeTicks,
+              out processName,
+              out imagePath,
+              out commandLine,
+              out parentProcessId,
+              out parentProcessStartTimeTicks,
+              out parentImagePath,
+              out identityCaptured,
+              out commandLineCaptured,
+              out identityCaptureError
+            );
             IntPtr stale;
             if (processHandles.TryRemove(processId, out stale)) CloseHandle(stale);
             if (!processHandles.TryAdd(processId, process)) {
@@ -182,7 +437,24 @@ namespace AiNovelReleaseGate {
               captured = false;
             }
           }
-          events.Enqueue(new JobProcessEvent("process-start", processId, null, captured, false, message));
+          events.Enqueue(new JobProcessEvent(
+            "process-start",
+            processId,
+            null,
+            captured,
+            false,
+            message,
+            processStartTimeTicks,
+            processName,
+            imagePath,
+            commandLine,
+            parentProcessId,
+            parentProcessStartTimeTicks,
+            parentImagePath,
+            identityCaptured,
+            commandLineCaptured,
+            identityCaptureError
+          ));
           continue;
         }
         if (message == JobObjectMsgExitProcess || message == JobObjectMsgAbnormalExitProcess) {
@@ -647,15 +919,28 @@ function Assert-AiNovelGateProcessExitSucceeded {
     [Parameter(Mandatory = $true)]$Event
   )
 
+  $failure = Get-AiNovelGateProcessExitFailure -Step $Step -Event $Event
+  if ($null -ne $failure) {
+    throw $failure
+  }
+}
+
+function Get-AiNovelGateProcessExitFailure {
+  param(
+    [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Step,
+    [Parameter(Mandatory = $true)]$Event
+  )
+
   if (-not [bool]$Event.ExitCodeCaptured -or $null -eq $Event.ExitCode) {
-    throw "Release gate could not capture the exit code for job-contained PID $($Event.ProcessId)."
+    return "Release gate could not capture the exit code for job-contained PID $($Event.ProcessId)."
   }
   if ([uint32]$Event.JobMessage -eq 8) {
-    throw "Release gate step '$Step' observed an abnormal exit for job-contained PID $($Event.ProcessId) with code $($Event.ExitCode)."
+    return "Release gate step '$Step' observed an abnormal exit for job-contained PID $($Event.ProcessId) with code $($Event.ExitCode)."
   }
   if ([int]$Event.ExitCode -ne 0) {
-    throw "Release gate step '$Step' observed a nonzero exit code $($Event.ExitCode) for job-contained PID $($Event.ProcessId)."
+    return "Release gate step '$Step' observed a nonzero exit code $($Event.ExitCode) for job-contained PID $($Event.ProcessId)."
   }
+  return $null
 }
 
 function New-AiNovelGateAtomicMonitor {
@@ -705,11 +990,261 @@ function Complete-AiNovelGateAtomicMonitor {
   }
 }
 
+function Get-AiNovelGateProcessIdentity {
+  param(
+    [Parameter(Mandatory = $true)]$Event,
+    [long]$ExpectedStartTimeTicks = 0
+  )
+
+  # The C# completion-port worker captures these fields while it still owns a
+  # native process handle. Do not make a slow CIM call in this PowerShell loop:
+  # that would delay draining the next short-lived child event and lose the
+  # very command-line evidence this record is meant to preserve.
+  $identity = [ordered]@{
+    processId = [int]$Event.ProcessId
+    startTimeTicks = if ($null -ne $Event.ProcessStartTimeTicks) { [string]$Event.ProcessStartTimeTicks } else { $null }
+    processName = if ($null -ne $Event.ProcessName) { [string]$Event.ProcessName } else { $null }
+    executablePath = if ($null -ne $Event.ImagePath) { [string]$Event.ImagePath } else { $null }
+    commandLine = if ($null -ne $Event.CommandLine) { [string]$Event.CommandLine } else { $null }
+    parentProcessId = if ($null -ne $Event.ParentProcessId) { [int]$Event.ParentProcessId } else { $null }
+    parentProcessStartTimeTicks = if ($null -ne $Event.ParentProcessStartTimeTicks) { [string]$Event.ParentProcessStartTimeTicks } else { $null }
+    parentExecutablePath = if ($null -ne $Event.ParentImagePath) { [string]$Event.ParentImagePath } else { $null }
+    identityCaptured = [bool]$Event.IdentityCaptured
+    commandLineCaptured = [bool]$Event.CommandLineCaptured
+    identityCaptureError = if ($null -ne $Event.IdentityCaptureError) { [string]$Event.IdentityCaptureError } else { $null }
+  }
+  if (
+    $ExpectedStartTimeTicks -gt 0 -and
+    $identity.identityCaptured -and
+    [long]$identity.startTimeTicks -ne $ExpectedStartTimeTicks
+  ) {
+    $identity['identityCaptured'] = $false
+    $identity['identityCaptureError'] = 'process start identity did not match the tracked Job Object member'
+  }
+  return [pscustomobject]$identity
+}
+
+function Test-AiNovelGateSystemPowerShellImage {
+  param([AllowEmptyString()][string]$ImagePath)
+
+  if ([string]::IsNullOrWhiteSpace($ImagePath)) {
+    return $false
+  }
+  try {
+    # QueryFullProcessImageName returns an absolute image path. Reject a
+    # relative lookalike before normalization so the exception remains limited
+    # to the two Windows PowerShell binaries the NSIS stub can invoke.
+    if ($ImagePath -notmatch '^[A-Za-z]:\\') {
+      return $false
+    }
+    $systemRoot = [System.Environment]::GetEnvironmentVariable('SystemRoot')
+    if ([string]::IsNullOrWhiteSpace($systemRoot)) {
+      return $false
+    }
+    $windowsRoot = [System.IO.Path]::GetFullPath($systemRoot)
+    $expectedPaths = @(
+      [System.IO.Path]::GetFullPath((Join-Path $windowsRoot 'System32\WindowsPowerShell\v1.0\powershell.exe')),
+      [System.IO.Path]::GetFullPath((Join-Path $windowsRoot 'SysWOW64\WindowsPowerShell\v1.0\powershell.exe'))
+    )
+    $actual = [System.IO.Path]::GetFullPath($ImagePath)
+    return @($expectedPaths | Where-Object {
+      [string]::Equals($actual, $_, [System.StringComparison]::OrdinalIgnoreCase)
+    }).Count -eq 1
+  }
+  catch {
+    return $false
+  }
+}
+
+function Test-AiNovelGateNsisInstallerImage {
+  param([AllowEmptyString()][string]$ImagePath)
+
+  if ([string]::IsNullOrWhiteSpace($ImagePath)) {
+    return $false
+  }
+  try {
+    if ($ImagePath -notmatch '^[A-Za-z]:\\') {
+      return $false
+    }
+    $fileName = [System.IO.Path]::GetFileName($ImagePath)
+    return $fileName -match '^ai-novel-writer-setup-\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?\.exe$'
+  }
+  catch {
+    return $false
+  }
+}
+
+function Test-AiNovelGateKnownNsisPowerShellProbeCommand {
+  param(
+    [AllowEmptyString()][string]$CommandLine,
+    [AllowEmptyString()][string]$PowerShellImagePath
+  )
+
+  if (
+    [string]::IsNullOrWhiteSpace($CommandLine) -or
+    [string]::IsNullOrWhiteSpace($PowerShellImagePath)
+  ) {
+    return $false
+  }
+  # electron-builder 26.8.1 emits exactly three quoted Windows PowerShell
+  # command lines with the short -C switch. Bind argv[0] to the captured image
+  # path and preserve the template's literal spacing so this narrow exception
+  # cannot grow into a general PowerShell success override.
+  $quotedImage = '"' + $PowerShellImagePath + '"'
+  if (
+    $CommandLine.Length -le $quotedImage.Length -or
+    -not $CommandLine.StartsWith($quotedImage, [System.StringComparison]::OrdinalIgnoreCase)
+  ) {
+    return $false
+  }
+  # Windows paths are case-insensitive, but the switch, whitespace, and probe
+  # payload are versioned template literals and therefore compare ordinally.
+  $arguments = $CommandLine.Substring($quotedImage.Length)
+  $availabilityArguments =
+    ' -C "if (Get-Command Get-CimInstance -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }"'
+  $policyArguments =
+    ' -C "if ((Get-ExecutionPolicy -Scope Process) -eq ''Restricted'') { exit 1 } else { exit 0 }"'
+  if (
+    [string]::Equals($arguments, $availabilityArguments, [System.StringComparison]::Ordinal) -or
+    [string]::Equals($arguments, $policyArguments, [System.StringComparison]::Ordinal)
+  ) {
+    return $true
+  }
+
+  $runningProcessPrefix =
+    ' -C "if ((Get-CimInstance -ClassName Win32_Process | ? {$_.Path -and $_.Path.StartsWith('''
+  $runningProcessSuffix =
+    ''', ''CurrentCultureIgnoreCase'')}).Count -gt 0) { exit 0 } else { exit 1 }"'
+  if (
+    -not $arguments.StartsWith($runningProcessPrefix, [System.StringComparison]::Ordinal) -or
+    -not $arguments.EndsWith($runningProcessSuffix, [System.StringComparison]::Ordinal)
+  ) {
+    return $false
+  }
+  $installPathLength = $arguments.Length - $runningProcessPrefix.Length - $runningProcessSuffix.Length
+  if ($installPathLength -le 0) {
+    return $false
+  }
+  $installPath = $arguments.Substring($runningProcessPrefix.Length, $installPathLength)
+  return $installPath -notmatch "['`r`n]"
+}
+
+function Test-AiNovelGateSameAbsolutePath {
+  param(
+    [AllowEmptyString()][string]$Left,
+    [AllowEmptyString()][string]$Right
+  )
+
+  if (
+    [string]::IsNullOrWhiteSpace($Left) -or
+    [string]::IsNullOrWhiteSpace($Right) -or
+    $Left -notmatch '^[A-Za-z]:\\' -or
+    $Right -notmatch '^[A-Za-z]:\\'
+  ) {
+    return $false
+  }
+  try {
+    return [string]::Equals(
+      [System.IO.Path]::GetFullPath($Left),
+      [System.IO.Path]::GetFullPath($Right),
+      [System.StringComparison]::OrdinalIgnoreCase
+    )
+  }
+  catch {
+    return $false
+  }
+}
+
+function Test-AiNovelGateExpectedNsisPowerShellProbeExit {
+  param(
+    [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Step,
+    [Parameter(Mandatory = $true)]$Event,
+    [AllowNull()]$ProcessIdentity,
+    [AllowNull()]$ParentIdentity
+  )
+
+  # electron-builder's NSIS template deliberately treats exit 1 from these
+  # three probe commands as a normal branch: PowerShell availability,
+  # execution-policy availability, and "no process in INSTDIR". This exception
+  # applies only to installer smoke steps, not to a general PowerShell process.
+  if ($Step -notin @('smoke:win-installer', 'smoke:win-v025-upgrade')) {
+    return $false
+  }
+  if (
+    -not [bool]$Event.ExitCodeCaptured -or
+    $null -eq $Event.ExitCode -or
+    [uint32]$Event.JobMessage -ne 7 -or
+    [int]$Event.ExitCode -ne 1
+  ) {
+    return $false
+  }
+  if (
+    $null -eq $ProcessIdentity -or
+    -not [bool]$ProcessIdentity.identityCaptured -or
+    -not [bool]$ProcessIdentity.commandLineCaptured -or
+    $null -eq $ProcessIdentity.parentProcessId
+  ) {
+    return $false
+  }
+  if (-not (Test-AiNovelGateSystemPowerShellImage -ImagePath ([string]$ProcessIdentity.executablePath))) {
+    return $false
+  }
+  if (-not (Test-AiNovelGateKnownNsisPowerShellProbeCommand `
+    -CommandLine ([string]$ProcessIdentity.commandLine) `
+    -PowerShellImagePath ([string]$ProcessIdentity.executablePath))) {
+    return $false
+  }
+  if (
+    $null -eq $ParentIdentity -or
+    -not [bool]$ParentIdentity.identityCaptured -or
+    [int]$ParentIdentity.processId -ne [int]$ProcessIdentity.parentProcessId -or
+    [string]::IsNullOrWhiteSpace([string]$ParentIdentity.startTimeTicks) -or
+    [string]::IsNullOrWhiteSpace([string]$ProcessIdentity.parentProcessStartTimeTicks) -or
+    -not [string]::Equals(
+      [string]$ParentIdentity.startTimeTicks,
+      [string]$ProcessIdentity.parentProcessStartTimeTicks,
+      [System.StringComparison]::Ordinal
+    ) -or
+    -not (Test-AiNovelGateSameAbsolutePath `
+      -Left ([string]$ParentIdentity.executablePath) `
+      -Right ([string]$ProcessIdentity.parentExecutablePath))
+  ) {
+    return $false
+  }
+  return Test-AiNovelGateNsisInstallerImage -ImagePath ([string]$ParentIdentity.executablePath)
+}
+
+function ConvertTo-AiNovelGateProcessEvidenceIdentity {
+  param([AllowNull()]$ProcessIdentity)
+
+  if ($null -eq $ProcessIdentity) {
+    return $null
+  }
+  # The full command line is retained only in memory for the exact NSIS probe
+  # classifier. Diagnostics are downloadable artifacts, so persist only the
+  # fact that capture succeeded and never the argument payload itself.
+  return [pscustomobject][ordered]@{
+    processId = $ProcessIdentity.processId
+    startTimeTicks = $ProcessIdentity.startTimeTicks
+    processName = $ProcessIdentity.processName
+    executablePath = $ProcessIdentity.executablePath
+    parentProcessId = $ProcessIdentity.parentProcessId
+    parentProcessStartTimeTicks = $ProcessIdentity.parentProcessStartTimeTicks
+    parentExecutablePath = $ProcessIdentity.parentExecutablePath
+    identityCaptured = [bool]$ProcessIdentity.identityCaptured
+    commandLineCaptured = [bool]$ProcessIdentity.commandLineCaptured
+    commandLineRedacted = [bool]$ProcessIdentity.commandLineCaptured
+    identityCaptureError = $ProcessIdentity.identityCaptureError
+  }
+}
+
 function Write-AiNovelGateProcessEventEvidence {
   param(
     [Parameter(Mandatory = $true)][string]$Path,
     [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Step,
-    [Parameter(Mandatory = $true)]$Event
+    [Parameter(Mandatory = $true)]$Event,
+    [AllowNull()]$ProcessIdentity = $null,
+    [AllowEmptyString()][string]$ExitClassification = ''
   )
 
   [ordered]@{
@@ -720,6 +1255,8 @@ function Write-AiNovelGateProcessEventEvidence {
     captureEstablished = [bool]$Event.CaptureEstablished
     exitCodeCaptured = [bool]$Event.ExitCodeCaptured
     jobMessage = [uint32]$Event.JobMessage
+    processIdentity = ConvertTo-AiNovelGateProcessEvidenceIdentity -ProcessIdentity $ProcessIdentity
+    exitClassification = $ExitClassification
     recordedAt = [string]$Event.RecordedAt
     monitorStartedAt = $script:AiNovelGateMonitorStartedAt
   } | ConvertTo-Json -Compress | Add-Content -LiteralPath (Join-Path $Path 'process-events.jsonl') -Encoding utf8
@@ -797,6 +1334,7 @@ foreach ($requiredPath in @($ControlPath, $StatusPath, $EvidencePath)) {
 
 $trackedProcessIds = [System.Collections.Generic.HashSet[int]]::new()
 $trackedProcessStartTimeTicks = @{}
+$trackedProcessIdentities = @{}
 $trackedNames = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
 foreach ($name in @(
   'AI小说作家.exe',
@@ -818,6 +1356,8 @@ $completionQuietDeadline = $null
 $quietDeadline = $null
 $lastWindowSnapshot = @()
 $atomicMonitor = $null
+$deferredProcessFailure = $null
+$deferredProcessFailureDeadline = $null
 
 New-Item -ItemType Directory -Path $EvidencePath -Force | Out-Null
 try {
@@ -887,6 +1427,9 @@ try {
         $activeStep = [string]$control.step
         $trackedProcessIds.Clear()
         $trackedProcessStartTimeTicks.Clear()
+        $trackedProcessIdentities.Clear()
+        $deferredProcessFailure = $null
+        $deferredProcessFailureDeadline = $null
         $rootIdentityAccepted = Initialize-AiNovelGateRootIdentity `
           -RootProcessId ([int]$control.rootProcessId) `
           -RootProcessStartTimeTicks ([long]$control.rootProcessStartTimeTicks) `
@@ -928,6 +1471,9 @@ try {
         $activeStep = [string]$control.step
         $trackedProcessIds.Clear()
         $trackedProcessStartTimeTicks.Clear()
+        $trackedProcessIdentities.Clear()
+        $deferredProcessFailure = $null
+        $deferredProcessFailureDeadline = $null
         $completionDeadline = $null
         $completionQuietDeadline = $null
         $quietDeadline = New-AiNovelGateQuietDeadline `
@@ -939,10 +1485,90 @@ try {
 
     $windowEventSnapshots = @()
     foreach ($processEvent in @($atomicMonitor.Job.Drain())) {
+      $processIdentity = $null
+      $exitClassification = ''
+      if ([string]$processEvent.Kind -eq 'process-start') {
+        $processIdentity = Get-AiNovelGateProcessIdentity -Event $processEvent
+        if (-not [bool]$processEvent.CaptureEstablished) {
+          Write-AiNovelGateProcessEventEvidence `
+            -Path $EvidencePath `
+            -Step $activeStep `
+            -Event $processEvent `
+            -ProcessIdentity $processIdentity `
+            -ExitClassification 'capture-failure'
+          throw "Release gate could not retain a process handle for job-contained PID $($processEvent.ProcessId); its eventual exit code would be unobservable."
+        }
+        $eventStartTimeTicks = 0
+        try {
+          $eventStartTimeTicks = [long]$processEvent.ProcessStartTimeTicks
+        }
+        catch {
+          # Fall back to a direct identity read only for a legacy or degraded
+          # event that did not retain the creation time in the native worker.
+        }
+        if ($eventStartTimeTicks -gt 0) {
+          [void]$trackedProcessIds.Add([int]$processEvent.ProcessId)
+          $trackedProcessStartTimeTicks[[int]$processEvent.ProcessId] = $eventStartTimeTicks
+        } else {
+          [void](Add-AiNovelTrackedProcess `
+            -ProcessId ([int]$processEvent.ProcessId) `
+            -ProcessIds $trackedProcessIds `
+            -ProcessStartTimeTicks $trackedProcessStartTimeTicks)
+        }
+        $expectedStartTimeTicks = if ($trackedProcessStartTimeTicks.ContainsKey([int]$processEvent.ProcessId)) {
+          [long]$trackedProcessStartTimeTicks[[int]$processEvent.ProcessId]
+        } else { 0 }
+        $processIdentity = Get-AiNovelGateProcessIdentity `
+          -Event $processEvent `
+          -ExpectedStartTimeTicks $expectedStartTimeTicks
+        $trackedProcessIdentities[[int]$processEvent.ProcessId] = $processIdentity
+        try {
+          if ($null -ne $processIdentity.processName) {
+            [void]$trackedNames.Add([string]$processIdentity.processName)
+          }
+        }
+        catch {
+          # The event's durable Job Object record is still retained below.
+        }
+      }
+      elseif ([string]$processEvent.Kind -eq 'process-exit') {
+        if ($trackedProcessIdentities.ContainsKey([int]$processEvent.ProcessId)) {
+          $processIdentity = $trackedProcessIdentities[[int]$processEvent.ProcessId]
+        }
+        $parentIdentity = $null
+        try {
+          if (
+            $null -ne $processIdentity -and
+            $null -ne $processIdentity.parentProcessId -and
+            $trackedProcessIdentities.ContainsKey([int]$processIdentity.parentProcessId)
+          ) {
+            $parentIdentity = $trackedProcessIdentities[[int]$processIdentity.parentProcessId]
+          }
+        }
+        catch {
+          # Missing parent metadata remains fail-closed in the classifier.
+        }
+        $exitFailure = Get-AiNovelGateProcessExitFailure -Step $activeStep -Event $processEvent
+        if ($null -eq $exitFailure) {
+          $exitClassification = 'succeeded'
+        }
+        elseif (Test-AiNovelGateExpectedNsisPowerShellProbeExit `
+          -Step $activeStep `
+          -Event $processEvent `
+          -ProcessIdentity $processIdentity `
+          -ParentIdentity $parentIdentity) {
+          $exitClassification = 'expected-nsis-powershell-probe'
+        }
+        else {
+          $exitClassification = 'failure'
+        }
+      }
       Write-AiNovelGateProcessEventEvidence `
         -Path $EvidencePath `
         -Step $activeStep `
-        -Event $processEvent
+        -Event $processEvent `
+        -ProcessIdentity $processIdentity `
+        -ExitClassification $exitClassification
       if ([string]::IsNullOrWhiteSpace($activeStep)) {
         continue
       }
@@ -950,28 +1576,30 @@ try {
         throw "Release gate lost its Job Object completion-port stream (Win32 error $($processEvent.JobMessage))."
       }
       if ([string]$processEvent.Kind -eq 'process-start') {
-        if (-not [bool]$processEvent.CaptureEstablished) {
-          throw "Release gate could not retain a process handle for job-contained PID $($processEvent.ProcessId); its eventual exit code would be unobservable."
-        }
-        [void](Add-AiNovelTrackedProcess `
-          -ProcessId ([int]$processEvent.ProcessId) `
-          -ProcessIds $trackedProcessIds `
-          -ProcessStartTimeTicks $trackedProcessStartTimeTicks)
-        try {
-          $eventProcess = [System.Diagnostics.Process]::GetProcessById([int]$processEvent.ProcessId)
-          [void]$trackedNames.Add($eventProcess.ProcessName)
-          $eventProcess.Dispose()
-        }
-        catch {
-          # The Job Object still retains the lifecycle record even when the
-          # process has already disappeared from the ordinary process table.
-        }
+        continue
       }
       elseif ([string]$processEvent.Kind -eq 'process-exit') {
         # Job Object membership is the atomic boundary. A nonzero or abnormal
-        # exit from any descendant is a release-gate failure, even when the
-        # launcher's own command record happens to report success.
-        Assert-AiNovelGateProcessExitSucceeded -Step $activeStep -Event $processEvent
+        # exit from any descendant is still a release-gate failure, even when
+        # the launcher's own command record reports success. Do not terminate
+        # the Job Object here: the armed launcher must first get the chance to
+        # write its durable result.json. The failure is finalized on the
+        # explicit step-complete acknowledgement, or after a bounded drain
+        # deadline if the launcher never completes.
+        if ($exitClassification -eq 'expected-nsis-powershell-probe') {
+          continue
+        }
+        $exitFailure = Get-AiNovelGateProcessExitFailure -Step $activeStep -Event $processEvent
+        if ($null -ne $exitFailure -and $null -eq $deferredProcessFailure) {
+          $deferredProcessFailure = $exitFailure
+          $deferredProcessFailureDeadline = [DateTime]::UtcNow.AddSeconds(15)
+          Write-AiNovelGateProcessTreeEvidence `
+            -Path $EvidencePath `
+            -Step $activeStep `
+            -ProcessIds $trackedProcessIds `
+            -ProcessStartTimeTicks $trackedProcessStartTimeTicks `
+            -Reason 'process-failure-awaiting-launch-result'
+        }
       }
     }
 
@@ -1098,6 +1726,37 @@ try {
           -ProcessStartTimeTicks $trackedProcessStartTimeTicks
         exit 1
       }
+    }
+
+    if (
+      $null -ne $deferredProcessFailure -and (
+        $null -ne $completionDeadline -or
+        ([DateTime]::UtcNow -ge [DateTime]$deferredProcessFailureDeadline)
+      )
+    ) {
+      # A formal launch gate emits step-complete only after it has read the
+      # result sidecar. If a malformed launcher never does so, the bounded
+      # drain keeps this path fail-closed instead of allowing a failed child to
+      # run indefinitely.
+      $failure = [string]$deferredProcessFailure
+      Save-AiNovelSmokeFailureEvidence `
+        -Path $EvidencePath `
+        -Failure $failure `
+        -Windows $lastWindowSnapshot `
+        -ObservedProcessIds @($trackedProcessIds)
+      Write-AiNovelGateProcessTreeEvidence `
+        -Path $EvidencePath `
+        -Step $activeStep `
+        -ProcessIds $trackedProcessIds `
+        -ProcessStartTimeTicks $trackedProcessStartTimeTicks `
+        -Reason 'deferred-process-failure'
+      $script:AiNovelGateMonitorStoppedAt = [DateTime]::UtcNow.ToString('o')
+      Write-AiNovelGateStatus -State 'failed' -Step $activeStep -Failure $failure
+      Stop-AiNovelGateAtomicJob -AtomicMonitor $atomicMonitor
+      Stop-AiNovelGateProcesses `
+        -ProcessIds $trackedProcessIds `
+        -ProcessStartTimeTicks $trackedProcessStartTimeTicks
+      exit 1
     }
 
     if (


### PR DESCRIPTION
Fixes the v0.4.0 cloud qualification failure caused by electron-builder 26.8.1 NSIS probes that intentionally return exit code 1. The exception is fail-closed and limited to the three exact template commands, a captured system PowerShell image, and the same installer parent PID/start-time/path identity. Diagnostic artifacts redact command lines, capture failures are recorded before termination, and real CreateProcessW probe-chain tests cover the behavior. Verification: 142 test files and 792 tests passed; typecheck, lint, and diff checks passed; independent frozen review: Standards PASS and Spec PASS.