### PR TITLE
fix: verify complete NSIS process-check chain

### DIFF
--- a/electron/__tests__/package-contract.test.ts
+++ b/electron/__tests__/package-contract.test.ts
@@ -176,7 +176,7 @@ describe('release dependency contract', () => {
 
     expect(
       createHash('sha256').update(releaseMonitor).digest('hex'),
-    ).toBe('21f0740dc6fb4e4a0e988216435e1baf855f20ccb24ee87be82102982232a30f')
+    ).toBe('4a40bac5c020133819aee0b62dbb68f3ca410f2ddd85ff49c47d6a3f9a8f58a4')
   })
 
   it('blocks direct Windows artifact builds outside the release gate', () => {

--- a/scripts/__tests__/release-win-verify.test.ts
+++ b/scripts/__tests__/release-win-verify.test.ts
@@ -1041,6 +1041,12 @@ finally {
         }),
       }))
       expect((powerShellFailure?.processIdentity as Record<string, unknown>)).not.toHaveProperty('commandLine')
+    } catch (error) {
+      const eventPath = join(evidencePath, 'process-events.jsonl')
+      const diagnostics = existsSync(eventPath)
+        ? readFileSync(eventPath, 'utf8').trim().split(/\r?\n/).slice(-20).join('\n')
+        : 'process-events.jsonl was not created'
+      throw new Error(`${String(error)}\nRecent redacted process events:\n${diagnostics}`)
     } finally {
       if (gate) {
         gate.child.kill()
@@ -1051,7 +1057,7 @@ finally {
     }
   }, 45_000)
 
-  windowsIt('accepts the three exact electron-builder probes from one captured installer instance', async () => {
+  windowsIt('accepts the exact electron-builder process-check chain from one captured installer instance', async () => {
     const root = mkdtempSync(join(tmpdir(), 'ai-novel-release-gate-nsis-probes-'))
     const controlPath = join(root, 'control.jsonl')
     const statusPath = join(root, 'status.json')
@@ -1066,6 +1072,7 @@ finally {
       'v1.0',
       'powershell.exe',
     )
+    const systemCmd = join(process.env.SystemRoot ?? 'C:\\Windows', 'System32', 'cmd.exe')
     writeFileSync(sourcePath, String.raw`
 using System;
 using System.IO;
@@ -1126,15 +1133,13 @@ internal static class ExactNsisProbeParent {
   [DllImport("kernel32.dll", SetLastError = true)]
   private static extern bool CloseHandle(IntPtr handle);
 
-  private static int RunProbe(string powerShellPath, string payload) {
+  private static int RunCommand(string executablePath, string commandLineValue) {
     StartupInfo startupInfo = new StartupInfo();
     startupInfo.cb = Marshal.SizeOf(startupInfo);
     ProcessInformation processInformation;
-    StringBuilder commandLine = new StringBuilder(
-      "\"" + powerShellPath + "\" -C \"" + payload + "\""
-    );
+    StringBuilder commandLine = new StringBuilder(commandLineValue);
     if (!CreateProcess(
-      powerShellPath,
+      executablePath,
       commandLine,
       IntPtr.Zero,
       IntPtr.Zero,
@@ -1157,17 +1162,32 @@ internal static class ExactNsisProbeParent {
     }
   }
 
+  private static int RunProbe(string powerShellPath, string payload, bool quoteImage) {
+    string argvZero = quoteImage ? "\"" + powerShellPath + "\"" : powerShellPath;
+    return RunCommand(powerShellPath, argvZero + " -C \"" + payload + "\"");
+  }
+
+  private static int RunCmdProcessCheck(string cmdPath) {
+    string findPath = Path.Combine(Path.GetDirectoryName(cmdPath), "find.exe");
+    string commandLine =
+      "\"" + cmdPath + "\" /C tasklist /FI \"USERNAME eq %USERNAME%\" /FI \"IMAGENAME eq AI\u5c0f\u8bf4\u4f5c\u5bb6.exe\" /FO CSV | \"" +
+      findPath +
+      "\" \"AI\u5c0f\u8bf4\u4f5c\u5bb6.exe\"";
+    return RunCommand(cmdPath, commandLine);
+  }
+
   public static int Main(string[] args) {
     string[] payloads = new[] {
       "if (Get-Command Get-CimInstance -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }",
       "if ((Get-ExecutionPolicy -Scope Process) -eq 'Restricted') { exit 1 } else { exit 0 }",
       "if ((Get-CimInstance -ClassName Win32_Process | ? {$_.Path -and $_.Path.StartsWith('C:\\ai-novel-release-probe-empty', 'CurrentCultureIgnoreCase')}).Count -gt 0) { exit 0 } else { exit 1 }"
     };
-    int[] results = new int[payloads.Length];
+    int[] results = new int[payloads.Length + 1];
     for (int index = 0; index < payloads.Length; index++) {
-      results[index] = RunProbe(args[0], payloads[index]);
+      results[index] = RunProbe(args[0], payloads[index], index != 1);
     }
-    File.WriteAllText(args[1], String.Join(",", results));
+    results[3] = RunCmdProcessCheck(args[1]);
+    File.WriteAllText(args[2], String.Join(",", results));
     return 0;
   }
 }
@@ -1204,7 +1224,7 @@ internal static class ExactNsisProbeParent {
 
     try {
       await waitForGateStatus(statusPath, 'ready')
-      gate = await startArmedExecutable(root, installerPath, [systemPowerShell, probeResultPath])
+      gate = await startArmedExecutable(root, installerPath, [systemPowerShell, systemCmd, probeResultPath])
       if (gate.child.pid == null) throw new Error('The armed gate did not expose a PID')
       appendFileSync(
         controlPath,
@@ -1222,9 +1242,10 @@ internal static class ExactNsisProbeParent {
       writeFileSync(gate.releasePath, 'release', 'utf8')
       expect(await settleWithin(gate.child, 30_000)).toEqual({ code: 0, signal: null })
       const probeResults = readFileSync(probeResultPath, 'utf8').split(',').map(Number)
-      expect(probeResults).toHaveLength(3)
+      expect(probeResults).toHaveLength(4)
       expect(probeResults.every(exitCode => exitCode === 0 || exitCode === 1)).toBe(true)
-      expect(probeResults.at(-1)).toBe(1)
+      expect(probeResults.at(2)).toBe(1)
+      expect(probeResults.at(3)).toBe(1)
 
       appendFileSync(
         controlPath,
@@ -1238,10 +1259,23 @@ internal static class ExactNsisProbeParent {
         const identity = event.processIdentity as Record<string, unknown> | undefined
         return event.kind === 'process-exit' && identity?.processName === 'powershell'
       })
+      const cmdExit = events.find(event => {
+        const identity = event.processIdentity as Record<string, unknown> | undefined
+        return event.kind === 'process-exit'
+          && event.exitCode === 1
+          && identity?.processName === 'cmd'
+          && identity?.parentExecutablePath === installerPath
+      })
+      const findExit = events.find(event => {
+        const identity = event.processIdentity as Record<string, unknown> | undefined
+        return event.kind === 'process-exit'
+          && event.exitCode === 1
+          && identity?.processName === 'find'
+      })
 
       expect(powerShellExits).toHaveLength(3)
       expect(powerShellExits.map(event => event.exitClassification)).toEqual(
-        probeResults.map(exitCode => exitCode === 0 ? 'succeeded' : 'expected-nsis-powershell-probe'),
+        probeResults.slice(0, 3).map(exitCode => exitCode === 0 ? 'succeeded' : 'expected-nsis-powershell-probe'),
       )
       for (const event of powerShellExits) {
         const identity = event.processIdentity as Record<string, unknown>
@@ -1253,7 +1287,18 @@ internal static class ExactNsisProbeParent {
         expect(identity.parentProcessStartTimeTicks).toEqual(expect.any(String))
         expect(identity).not.toHaveProperty('commandLine')
       }
+      expect(cmdExit).toMatchObject({ exitClassification: 'expected-nsis-cmd-process-check' })
+      expect(findExit).toMatchObject({ exitClassification: 'expected-nsis-find-no-match' })
+      expect((cmdExit?.processIdentity as Record<string, unknown>)).not.toHaveProperty('commandLine')
+      expect((findExit?.processIdentity as Record<string, unknown>)).not.toHaveProperty('commandLine')
       expect(rawEvidence).not.toContain('Get-CimInstance')
+      expect(rawEvidence).not.toContain('tasklist /FI')
+    } catch (error) {
+      const eventPath = join(evidencePath, 'process-events.jsonl')
+      const diagnostics = existsSync(eventPath)
+        ? readFileSync(eventPath, 'utf8').trim().split(/\r?\n/).slice(-20).join('\n')
+        : 'process-events.jsonl was not created'
+      throw new Error(`${String(error)}\nRecent redacted process events:\n${diagnostics}`)
     } finally {
       if (gate) {
         gate.child.kill()

--- a/scripts/__tests__/smoke-win-installer.test.ts
+++ b/scripts/__tests__/smoke-win-installer.test.ts
@@ -1007,6 +1007,7 @@ $availabilityPayload = 'if (Get-Command Get-CimInstance -ErrorAction SilentlyCon
 $policyPayload = 'if ((Get-ExecutionPolicy -Scope Process) -eq ''Restricted'') { exit 1 } else { exit 0 }'
 $runningProcessPayload = 'if ((Get-CimInstance -ClassName Win32_Process | ? {$_.Path -and $_.Path.StartsWith(''C:\\temp\\installed'', ''CurrentCultureIgnoreCase'')}).Count -gt 0) { exit 0 } else { exit 1 }'
 $availabilityCommand = $system32Prefix + $availabilityPayload + '"'
+$unquotedAvailabilityCommand = $system32 + ' -C "' + $availabilityPayload + '"'
 $policyCommand = $system32Prefix + $policyPayload + '"'
 $runningProcessCommand = $sysWow64Prefix + $runningProcessPayload + '"'
 $arbitraryCommand = $system32Prefix + 'Write-Error ''not an NSIS probe''; exit 1"'
@@ -1060,6 +1061,7 @@ $abnormal = [pscustomobject]@{ ProcessId = 701; ExitCode = 1; ExitCodeCaptured =
 
 [pscustomobject]@{
   InstallerAvailability = Test-SyntheticNsisProbe -Step 'smoke:win-installer' -Event $event -Identity $validAvailability -Parent $parent
+  UnquotedInstallerAvailability = Test-SyntheticNsisProbe -Step 'smoke:win-installer' -Event $event -Identity (New-ProbeIdentity -ImagePath $system32 -CommandLine $unquotedAvailabilityCommand) -Parent $parent
   UpgradePolicy = Test-SyntheticNsisProbe -Step 'smoke:win-v025-upgrade' -Event $event -Identity $validPolicy -Parent $parent
   SysWow64RunningProcess = Test-SyntheticNsisProbe -Step 'smoke:win-installer' -Event $event -Identity $validRunningProcess -Parent $parent
   PathCaseOnly = Test-SyntheticNsisProbe -Step 'smoke:win-installer' -Event $event -Identity (New-ProbeIdentity -ImagePath $system32 -CommandLine $pathCaseCommand) -Parent $parent
@@ -1087,6 +1089,7 @@ $abnormal = [pscustomobject]@{ ProcessId = 701; ExitCode = 1; ExitCodeCaptured =
     const result = parseLastJsonLine(output)
 
     expect(result.InstallerAvailability).toBe(true)
+    expect(result.UnquotedInstallerAvailability).toBe(true)
     expect(result.UpgradePolicy).toBe(true)
     expect(result.SysWow64RunningProcess).toBe(true)
     expect(result.PathCaseOnly).toBe(true)
@@ -1109,6 +1112,309 @@ $abnormal = [pscustomobject]@{ ProcessId = 701; ExitCode = 1; ExitCodeCaptured =
     expect(result.MissingIdentity).toBe(false)
     expect(result.MissingCommandLine).toBe(false)
     expect(result.MissingParentMetadata).toBe(false)
+  })
+
+  windowsIt('exempts only the exact NSIS cmd and find no-process fallback chain', () => {
+    const output = runReleaseMonitorLibrary(`
+$cmdPath = Join-Path $env:SystemRoot 'System32\\cmd.exe'
+$findPath = Join-Path $env:SystemRoot 'System32\\find.exe'
+$installerPath = 'C:\\temp\\ai-novel-writer-setup-0.4.0.exe'
+$installerStart = '638900000000000000'
+$cmdStart = '638900000000000100'
+$event = [pscustomobject]@{ ProcessId = 701; ExitCode = 1; ExitCodeCaptured = $true; JobMessage = 7 }
+$installer = [pscustomobject]@{
+  processId = 700
+  startTimeTicks = $installerStart
+  executablePath = $installerPath
+  identityCaptured = $true
+}
+$cmdArguments = ' /C tasklist /FI "USERNAME eq %USERNAME%" /FI "IMAGENAME eq AI小说作家.exe" /FO CSV | "' + $findPath + '" "AI小说作家.exe"'
+$cmdCommand = '"' + $cmdPath + '"' + $cmdArguments
+$unquotedCmdCommand = $cmdPath + $cmdArguments
+$findCommand = '"' + $findPath + '"  "AI小说作家.exe"'
+
+function New-CmdIdentity {
+  param(
+    [string]$CommandLine = $cmdCommand,
+    [string]$ParentStart = $installerStart,
+    [string]$ParentPath = $installerPath
+  )
+  return [pscustomobject]@{
+    processId = 701
+    startTimeTicks = $cmdStart
+    processName = 'cmd'
+    executablePath = $cmdPath
+    commandLine = $CommandLine
+    commandLineCaptured = $true
+    identityCaptured = $true
+    parentProcessId = 700
+    parentProcessStartTimeTicks = $ParentStart
+    parentExecutablePath = $ParentPath
+  }
+}
+
+function New-FindIdentity {
+  param(
+    [string]$CommandLine = $findCommand,
+    [string]$ParentStart = $cmdStart,
+    [string]$ParentPath = $cmdPath
+  )
+  return [pscustomobject]@{
+    processId = 702
+    startTimeTicks = '638900000000000200'
+    processName = 'find'
+    executablePath = $findPath
+    commandLine = $CommandLine
+    commandLineCaptured = $true
+    identityCaptured = $true
+    parentProcessId = 701
+    parentProcessStartTimeTicks = $ParentStart
+    parentExecutablePath = $ParentPath
+  }
+}
+
+$cmd = New-CmdIdentity
+$find = New-FindIdentity
+$exitTwo = [pscustomobject]@{ ProcessId = 701; ExitCode = 2; ExitCodeCaptured = $true; JobMessage = 7 }
+$unrelatedInstaller = [pscustomobject]@{ processId = 700; startTimeTicks = $installerStart; executablePath = 'C:\\temp\\unrelated.exe'; identityCaptured = $true }
+$unverifiedFindParentKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+$verifiedFindParentKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+[void]$verifiedFindParentKeys.Add((Get-AiNovelGateProcessIdentityKey -ProcessIdentity $cmd))
+[pscustomobject]@{
+  CmdSystemImage = Test-AiNovelGateSystemUtilityImage -ImagePath $cmdPath -FileName 'cmd.exe'
+  CmdCommand = Test-AiNovelGateKnownNsisCmdProcessCheckCommand -CommandLine $cmdCommand -CmdImagePath $cmdPath
+  CmdParent = Test-AiNovelGateCapturedInstallerParent -ChildIdentity $cmd -ParentIdentity $installer
+  FindSystemImage = Test-AiNovelGateSystemUtilityImage -ImagePath $findPath -FileName 'find.exe'
+  FindCommand = Test-AiNovelGateKnownNsisFindNoMatchCommand -CommandLine $findCommand -FindImagePath $findPath
+  FindParent = Test-AiNovelGateCapturedParentIdentity -ChildIdentity $find -ParentIdentity $cmd
+  CmdCandidate = Test-AiNovelGateNsisCmdProcessCheckCandidate -Step 'smoke:win-installer' -Event $event -ProcessIdentity $cmd -ParentIdentity $installer
+  CmdWithoutFindEvent = Test-AiNovelGateExpectedNsisCmdProcessCheckExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity $cmd -ParentIdentity $installer -VerifiedFindParentKeys $unverifiedFindParentKeys
+  CmdAfterVerifiedFind = Test-AiNovelGateExpectedNsisCmdProcessCheckExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity $cmd -ParentIdentity $installer -VerifiedFindParentKeys $verifiedFindParentKeys
+  CmdUnquoted = Test-AiNovelGateExpectedNsisCmdProcessCheckExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity (New-CmdIdentity -CommandLine $unquotedCmdCommand) -ParentIdentity $installer -VerifiedFindParentKeys $verifiedFindParentKeys
+  FindExact = Test-AiNovelGateExpectedNsisFindNoMatchExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity $find -ParentIdentity $cmd -GrandParentIdentity $installer
+  CmdExtraCommand = Test-AiNovelGateExpectedNsisCmdProcessCheckExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity (New-CmdIdentity -CommandLine ($cmdCommand + ' & exit 1')) -ParentIdentity $installer -VerifiedFindParentKeys $verifiedFindParentKeys
+  CmdWrongProduct = Test-AiNovelGateExpectedNsisCmdProcessCheckExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity (New-CmdIdentity -CommandLine $cmdCommand.Replace('AI小说作家.exe', 'other.exe')) -ParentIdentity $installer -VerifiedFindParentKeys $verifiedFindParentKeys
+  CmdReusedParent = Test-AiNovelGateExpectedNsisCmdProcessCheckExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity (New-CmdIdentity -ParentStart '638899999999999999') -ParentIdentity $installer -VerifiedFindParentKeys $verifiedFindParentKeys
+  CmdWrongParent = Test-AiNovelGateExpectedNsisCmdProcessCheckExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity $cmd -ParentIdentity $unrelatedInstaller -VerifiedFindParentKeys $verifiedFindParentKeys
+  FindExtraArgument = Test-AiNovelGateExpectedNsisFindNoMatchExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity (New-FindIdentity -CommandLine ($findCommand + ' extra')) -ParentIdentity $cmd -GrandParentIdentity $installer
+  FindReusedCmdParent = Test-AiNovelGateExpectedNsisFindNoMatchExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity (New-FindIdentity -ParentStart '638899999999999999') -ParentIdentity $cmd -GrandParentIdentity $installer
+  FindWrongGrandParent = Test-AiNovelGateExpectedNsisFindNoMatchExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity $find -ParentIdentity $cmd -GrandParentIdentity $unrelatedInstaller
+  OtherStep = Test-AiNovelGateExpectedNsisCmdProcessCheckExit -Step 'other-step' -Event $event -ProcessIdentity $cmd -ParentIdentity $installer -VerifiedFindParentKeys $verifiedFindParentKeys
+  ExitTwo = Test-AiNovelGateExpectedNsisCmdProcessCheckExit -Step 'smoke:win-installer' -Event $exitTwo -ProcessIdentity $cmd -ParentIdentity $installer -VerifiedFindParentKeys $verifiedFindParentKeys
+} | ConvertTo-Json -Compress
+`)
+    const result = parseLastJsonLine(output)
+
+    expect(result).toMatchObject({
+      CmdSystemImage: true,
+      CmdCommand: true,
+      CmdParent: true,
+      FindSystemImage: true,
+      FindCommand: true,
+      FindParent: true,
+      CmdCandidate: true,
+      CmdWithoutFindEvent: false,
+      CmdAfterVerifiedFind: true,
+      CmdUnquoted: true,
+      FindExact: true,
+      CmdExtraCommand: false,
+      CmdWrongProduct: false,
+      CmdReusedParent: false,
+      CmdWrongParent: false,
+      FindExtraArgument: false,
+      FindReusedCmdParent: false,
+      FindWrongGrandParent: false,
+      OtherStep: false,
+      ExitTwo: false,
+    })
+  })
+
+  windowsIt('defers a NSIS cmd exit until the matching find no-match event is verified', () => {
+    const output = runReleaseMonitorLibrary(`
+$cmdPath = Join-Path $env:SystemRoot 'System32\\cmd.exe'
+$findPath = Join-Path $env:SystemRoot 'System32\\find.exe'
+$installerPath = 'C:\\temp\\ai-novel-writer-setup-0.4.0.exe'
+$installer = [pscustomobject]@{
+  processId = 700
+  startTimeTicks = '638900000000000000'
+  executablePath = $installerPath
+  identityCaptured = $true
+}
+$cmd = [pscustomobject]@{
+  processId = 701
+  startTimeTicks = '638900000000000100'
+  executablePath = $cmdPath
+  commandLine = '"' + $cmdPath + '" /C tasklist /FI "USERNAME eq %USERNAME%" /FI "IMAGENAME eq AI小说作家.exe" /FO CSV | "' + $findPath + '" "AI小说作家.exe"'
+  commandLineCaptured = $true
+  identityCaptured = $true
+  parentProcessId = 700
+  parentProcessStartTimeTicks = $installer.startTimeTicks
+  parentExecutablePath = $installerPath
+}
+$find = [pscustomobject]@{
+  processId = 702
+  startTimeTicks = '638900000000000200'
+  executablePath = $findPath
+  commandLine = '"' + $findPath + '"  "AI小说作家.exe"'
+  commandLineCaptured = $true
+  identityCaptured = $true
+  parentProcessId = 701
+  parentProcessStartTimeTicks = $cmd.startTimeTicks
+  parentExecutablePath = $cmdPath
+}
+$event = [pscustomobject]@{ ProcessId = 701; ExitCode = 1; ExitCodeCaptured = $true; JobMessage = 7 }
+$verifiedFindParents = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+$pendingCmdFailures = @{}
+$cmdKey = Get-AiNovelGateProcessIdentityKey -ProcessIdentity $cmd
+$cmdCandidate = Test-AiNovelGateNsisCmdProcessCheckCandidate -Step 'smoke:win-installer' -Event $event -ProcessIdentity $cmd -ParentIdentity $installer
+$storedPending = if ($cmdCandidate) {
+  Add-AiNovelGatePendingNsisCmdExitFailure -PendingNsisCmdExitFailures $pendingCmdFailures -ProcessIdentityKey $cmdKey -Failure (Get-AiNovelGateProcessExitFailure -Step 'smoke:win-installer' -Event $event)
+} else { $false }
+$beforeFind = Test-AiNovelGateExpectedNsisCmdProcessCheckExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity $cmd -ParentIdentity $installer -VerifiedFindParentKeys $verifiedFindParents
+$pendingBeforeFind = Get-AiNovelGatePendingNsisCmdExitFailure -PendingNsisCmdExitFailures $pendingCmdFailures
+$noFindDeferredFailure = $pendingBeforeFind
+$findVerified = Test-AiNovelGateExpectedNsisFindNoMatchExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity $find -ParentIdentity $cmd -GrandParentIdentity $installer
+$resolvedPending = if ($findVerified) {
+  Register-AiNovelGateVerifiedNsisFindParent -VerifiedFindParentKeys $verifiedFindParents -PendingNsisCmdExitFailures $pendingCmdFailures -ParentProcessIdentityKey (Get-AiNovelGateProcessIdentityKey -ProcessIdentity $cmd)
+} else { $false }
+$afterFind = Test-AiNovelGateExpectedNsisCmdProcessCheckExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity $cmd -ParentIdentity $installer -VerifiedFindParentKeys $verifiedFindParents
+$reusedPidCmd = [pscustomobject]@{
+  processId = $cmd.processId
+  startTimeTicks = '638900000000000999'
+  executablePath = $cmdPath
+  identityCaptured = $true
+}
+$unrelatedPending = @{}
+[void](Add-AiNovelGatePendingNsisCmdExitFailure -PendingNsisCmdExitFailures $unrelatedPending -ProcessIdentityKey $cmdKey -Failure 'synthetic pending cmd failure')
+$reusedPidResolved = Register-AiNovelGateVerifiedNsisFindParent -VerifiedFindParentKeys $verifiedFindParents -PendingNsisCmdExitFailures $unrelatedPending -ParentProcessIdentityKey (Get-AiNovelGateProcessIdentityKey -ProcessIdentity $reusedPidCmd)
+[pscustomobject]@{
+  CmdCandidate = $cmdCandidate
+  StoredPending = $storedPending
+  BeforeFind = $beforeFind
+  PendingBeforeFind = -not [string]::IsNullOrWhiteSpace($pendingBeforeFind)
+  NoFindDeferredFailure = $noFindDeferredFailure -like '*nonzero exit code 1*'
+  FindVerified = $findVerified
+  ResolvedPending = $resolvedPending
+  AfterFind = $afterFind
+  PendingCountAfterFind = $pendingCmdFailures.Count
+  ReusedPidResolved = $reusedPidResolved
+  ReusedPidPendingCount = $unrelatedPending.Count
+} | ConvertTo-Json -Compress
+`)
+    const result = parseLastJsonLine(output)
+
+    expect(result).toEqual({
+      CmdCandidate: true,
+      StoredPending: true,
+      BeforeFind: false,
+      PendingBeforeFind: true,
+      NoFindDeferredFailure: true,
+      FindVerified: true,
+      ResolvedPending: true,
+      AfterFind: true,
+      PendingCountAfterFind: 0,
+      ReusedPidResolved: false,
+      ReusedPidPendingCount: 1,
+    })
+  })
+
+  windowsIt('keeps a promoted NSIS cmd failure reversible across the next Drain only for its matching find identity', () => {
+    const output = runReleaseMonitorLibrary(`
+$cmdPath = Join-Path $env:SystemRoot 'System32\\cmd.exe'
+$findPath = Join-Path $env:SystemRoot 'System32\\find.exe'
+$installerPath = 'C:\\temp\\ai-novel-writer-setup-0.4.0.exe'
+$installer = [pscustomobject]@{
+  processId = 700
+  startTimeTicks = '638900000000000000'
+  executablePath = $installerPath
+  identityCaptured = $true
+}
+$cmd = [pscustomobject]@{
+  processId = 701
+  startTimeTicks = '638900000000000100'
+  executablePath = $cmdPath
+  commandLine = '"' + $cmdPath + '" /C tasklist /FI "USERNAME eq %USERNAME%" /FI "IMAGENAME eq AI小说作家.exe" /FO CSV | "' + $findPath + '" "AI小说作家.exe"'
+  commandLineCaptured = $true
+  identityCaptured = $true
+  parentProcessId = 700
+  parentProcessStartTimeTicks = $installer.startTimeTicks
+  parentExecutablePath = $installerPath
+}
+$find = [pscustomobject]@{
+  processId = 702
+  startTimeTicks = '638900000000000200'
+  executablePath = $findPath
+  commandLine = '"' + $findPath + '"  "AI小说作家.exe"'
+  commandLineCaptured = $true
+  identityCaptured = $true
+  parentProcessId = 701
+  parentProcessStartTimeTicks = $cmd.startTimeTicks
+  parentExecutablePath = $cmdPath
+}
+$event = [pscustomobject]@{ ProcessId = 701; ExitCode = 1; ExitCodeCaptured = $true; JobMessage = 7 }
+$now = [DateTime]::Parse('2026-07-27T00:00:00.0000000Z').ToUniversalTime()
+$cmdKey = Get-AiNovelGateProcessIdentityKey -ProcessIdentity $cmd
+$verifiedFindParents = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+$pending = @{}
+[void](Add-AiNovelGatePendingNsisCmdExitFailure -PendingNsisCmdExitFailures $pending -ProcessIdentityKey $cmdKey -Failure (Get-AiNovelGateProcessExitFailure -Step 'smoke:win-installer' -Event $event))
+$state = New-AiNovelGateDeferredNsisCmdExitFailureState
+
+# Drain 41: cmd.exe exits, then JobObjectMsgActiveProcessZero arrives. The
+# missing find.exe is now deferred, but it must not terminate this iteration.
+$promotedOnJobEmpty = Promote-AiNovelGatePendingNsisCmdExitFailure -State $state -PendingEntry (Get-AiNovelGatePendingNsisCmdExitFailureEntry -PendingNsisCmdExitFailures $pending) -NowUtc $now -CurrentDrain 41
+$firstDrainDoesNotTerminate = -not (Test-AiNovelGateDeferredNsisCmdExitFailureReady -State $state -NowUtc $now.AddSeconds(5) -CurrentDrain 41)
+
+# Drain 42: the completion port delivers the matching find.exe exit. It must
+# revoke the previously promoted cmd.exe failure rather than merely remove the
+# pending-map entry.
+$findVerified = Test-AiNovelGateExpectedNsisFindNoMatchExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity $find -ParentIdentity $cmd -GrandParentIdentity $installer
+$registeredFind = if ($findVerified) {
+  Register-AiNovelGateVerifiedNsisFindParent -VerifiedFindParentKeys $verifiedFindParents -PendingNsisCmdExitFailures $pending -ParentProcessIdentityKey $cmdKey
+} else { $false }
+$resolvedPromotedFailure = Resolve-AiNovelGateDeferredNsisCmdExitFailure -State $state -ProcessIdentityKey $cmdKey
+$secondDrainAfterFindDoesNotTerminate = -not (Test-AiNovelGateDeferredNsisCmdExitFailureReady -State $state -NowUtc $now.AddSeconds(5) -CurrentDrain 42)
+
+# A mismatched find identity may not clear the promoted failure; without a
+# verified matching find after the short grace it remains fail-closed.
+$noFindPending = @{}
+[void](Add-AiNovelGatePendingNsisCmdExitFailure -PendingNsisCmdExitFailures $noFindPending -ProcessIdentityKey $cmdKey -Failure 'synthetic pending cmd failure')
+$noFindState = New-AiNovelGateDeferredNsisCmdExitFailureState
+$noFindPromoted = Promote-AiNovelGatePendingNsisCmdExitFailure -State $noFindState -PendingEntry (Get-AiNovelGatePendingNsisCmdExitFailureEntry -PendingNsisCmdExitFailures $noFindPending) -NowUtc $now -CurrentDrain 51
+$wrongKeyDoesNotResolve = -not (Resolve-AiNovelGateDeferredNsisCmdExitFailure -State $noFindState -ProcessIdentityKey ($cmdKey + '-other'))
+$noFindFirstDrainDoesNotTerminate = -not (Test-AiNovelGateDeferredNsisCmdExitFailureReady -State $noFindState -NowUtc $now.AddSeconds(5) -CurrentDrain 51)
+$noFindGraceBlocksImmediateFailure = -not (Test-AiNovelGateDeferredNsisCmdExitFailureReady -State $noFindState -NowUtc $now.AddMilliseconds(100) -CurrentDrain 52)
+$noFindFailsClosedAfterGrace = Test-AiNovelGateDeferredNsisCmdExitFailureReady -State $noFindState -NowUtc $now.AddSeconds(2) -CurrentDrain 52
+[pscustomobject]@{
+  PromotedOnJobEmpty = $promotedOnJobEmpty
+  FirstDrainDoesNotTerminate = $firstDrainDoesNotTerminate
+  FindVerified = $findVerified
+  RegisteredFind = $registeredFind
+  ResolvedPromotedFailure = $resolvedPromotedFailure
+  PendingCountAfterFind = $pending.Count
+  SecondDrainAfterFindDoesNotTerminate = $secondDrainAfterFindDoesNotTerminate
+  NoFindPromoted = $noFindPromoted
+  WrongKeyDoesNotResolve = $wrongKeyDoesNotResolve
+  NoFindFirstDrainDoesNotTerminate = $noFindFirstDrainDoesNotTerminate
+  NoFindGraceBlocksImmediateFailure = $noFindGraceBlocksImmediateFailure
+  NoFindFailsClosedAfterGrace = $noFindFailsClosedAfterGrace
+} | ConvertTo-Json -Compress
+`)
+    const result = parseLastJsonLine(output)
+
+    expect(result).toEqual({
+      PromotedOnJobEmpty: true,
+      FirstDrainDoesNotTerminate: true,
+      FindVerified: true,
+      RegisteredFind: true,
+      ResolvedPromotedFailure: true,
+      PendingCountAfterFind: 0,
+      SecondDrainAfterFindDoesNotTerminate: true,
+      NoFindPromoted: true,
+      WrongKeyDoesNotResolve: true,
+      NoFindFirstDrainDoesNotTerminate: true,
+      NoFindGraceBlocksImmediateFailure: true,
+      NoFindFailsClosedAfterGrace: true,
+    })
   })
 
   windowsIt('keeps command-line secrets in memory and redacts them from process evidence', () => {
@@ -1565,7 +1871,7 @@ try {
     } finally {
       rmSync(fixtureRoot, { recursive: true, force: true })
     }
-  })
+  }, 15_000)
 
   windowsIt('rejects corruption in every extended v0.2.5 upgrade table', () => {
     const cases = [

--- a/scripts/monitor-win-release-gate.ps1
+++ b/scripts/monitor-win-release-gate.ps1
@@ -1086,20 +1086,15 @@ function Test-AiNovelGateKnownNsisPowerShellProbeCommand {
   ) {
     return $false
   }
-  # electron-builder 26.8.1 emits exactly three quoted Windows PowerShell
-  # command lines with the short -C switch. Bind argv[0] to the captured image
-  # path and preserve the template's literal spacing so this narrow exception
-  # cannot grow into a general PowerShell success override.
-  $quotedImage = '"' + $PowerShellImagePath + '"'
-  if (
-    $CommandLine.Length -le $quotedImage.Length -or
-    -not $CommandLine.StartsWith($quotedImage, [System.StringComparison]::OrdinalIgnoreCase)
-  ) {
+  # nsExec may remove the source template's argv[0] quotes when it launches a
+  # path without spaces. Bind either runtime form to the captured full image
+  # path; the switch, whitespace, and payload remain byte-for-byte literals.
+  $arguments = Get-AiNovelGateBoundCommandArguments `
+    -CommandLine $CommandLine `
+    -ImagePath $PowerShellImagePath
+  if ($null -eq $arguments) {
     return $false
   }
-  # Windows paths are case-insensitive, but the switch, whitespace, and probe
-  # payload are versioned template literals and therefore compare ordinally.
-  $arguments = $CommandLine.Substring($quotedImage.Length)
   $availabilityArguments =
     ' -C "if (Get-Command Get-CimInstance -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }"'
   $policyArguments =
@@ -1155,6 +1150,206 @@ function Test-AiNovelGateSameAbsolutePath {
   }
 }
 
+function Get-AiNovelGateBoundCommandArguments {
+  param(
+    [AllowEmptyString()][string]$CommandLine,
+    [AllowEmptyString()][string]$ImagePath
+  )
+
+  if (
+    [string]::IsNullOrWhiteSpace($CommandLine) -or
+    [string]::IsNullOrWhiteSpace($ImagePath)
+  ) {
+    return $null
+  }
+  $argvZero = ''
+  $arguments = ''
+  if ($CommandLine[0] -eq '"') {
+    $closingQuote = $CommandLine.IndexOf('"', 1)
+    if ($closingQuote -le 1) {
+      return $null
+    }
+    $argvZero = $CommandLine.Substring(1, $closingQuote - 1)
+    $arguments = $CommandLine.Substring($closingQuote + 1)
+  }
+  else {
+    $firstWhitespace = [regex]::Match($CommandLine, '\s')
+    if (-not $firstWhitespace.Success -or $firstWhitespace.Index -le 0) {
+      return $null
+    }
+    $argvZero = $CommandLine.Substring(0, $firstWhitespace.Index)
+    $arguments = $CommandLine.Substring($firstWhitespace.Index)
+  }
+  if (-not (Test-AiNovelGateSameAbsolutePath -Left $argvZero -Right $ImagePath)) {
+    return $null
+  }
+  return [string]$arguments
+}
+
+function Test-AiNovelGateSystemUtilityImage {
+  param(
+    [AllowEmptyString()][string]$ImagePath,
+    [Parameter(Mandatory = $true)][ValidateSet('cmd.exe', 'find.exe')][string]$FileName
+  )
+
+  if ([string]::IsNullOrWhiteSpace($ImagePath) -or $ImagePath -notmatch '^[A-Za-z]:\\') {
+    return $false
+  }
+  try {
+    $systemRoot = [System.Environment]::GetEnvironmentVariable('SystemRoot')
+    if ([string]::IsNullOrWhiteSpace($systemRoot)) {
+      return $false
+    }
+    $expectedPaths = @(
+      (Join-Path $systemRoot (Join-Path 'System32' $FileName))
+      (Join-Path $systemRoot (Join-Path 'SysWOW64' $FileName))
+    )
+    return @($expectedPaths | Where-Object {
+      Test-AiNovelGateSameAbsolutePath -Left $ImagePath -Right $_
+    }).Count -eq 1
+  }
+  catch {
+    return $false
+  }
+}
+
+function Test-AiNovelGateKnownNsisCmdProcessCheckCommand {
+  param(
+    [AllowEmptyString()][string]$CommandLine,
+    [AllowEmptyString()][string]$CmdImagePath
+  )
+
+  $arguments = Get-AiNovelGateBoundCommandArguments `
+    -CommandLine $CommandLine `
+    -ImagePath $CmdImagePath
+  if ($null -eq $arguments) {
+    return $false
+  }
+  try {
+    $expectedFindPath = Join-Path ([System.IO.Path]::GetDirectoryName($CmdImagePath)) 'find.exe'
+    $prefix = ' /C tasklist /FI "USERNAME eq %USERNAME%" /FI "IMAGENAME eq AI小说作家.exe" /FO CSV | "'
+    $suffix = '" "AI小说作家.exe"'
+    if (
+      -not $arguments.StartsWith($prefix, [System.StringComparison]::Ordinal) -or
+      -not $arguments.EndsWith($suffix, [System.StringComparison]::Ordinal)
+    ) {
+      return $false
+    }
+    $findPathLength = $arguments.Length - $prefix.Length - $suffix.Length
+    if ($findPathLength -le 0) {
+      return $false
+    }
+    $findPath = $arguments.Substring($prefix.Length, $findPathLength)
+    return Test-AiNovelGateSameAbsolutePath -Left $findPath -Right $expectedFindPath
+  }
+  catch {
+    return $false
+  }
+}
+
+function Test-AiNovelGateKnownNsisFindNoMatchCommand {
+  param(
+    [AllowEmptyString()][string]$CommandLine,
+    [AllowEmptyString()][string]$FindImagePath
+  )
+
+  $arguments = Get-AiNovelGateBoundCommandArguments `
+    -CommandLine $CommandLine `
+    -ImagePath $FindImagePath
+  return (
+    $null -ne $arguments -and
+    [string]::Equals($arguments, '  "AI小说作家.exe"', [System.StringComparison]::Ordinal)
+  )
+}
+
+function Test-AiNovelGateExpectedExitOne {
+  param(
+    [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Step,
+    [Parameter(Mandatory = $true)]$Event
+  )
+
+  return (
+    $Step -in @('smoke:win-installer', 'smoke:win-v025-upgrade') -and
+    [bool]$Event.ExitCodeCaptured -and
+    $null -ne $Event.ExitCode -and
+    [uint32]$Event.JobMessage -eq 7 -and
+    [int]$Event.ExitCode -eq 1
+  )
+}
+
+function Test-AiNovelGateCapturedParentIdentity {
+  param(
+    [AllowNull()]$ChildIdentity,
+    [AllowNull()]$ParentIdentity
+  )
+
+  if (
+    $null -eq $ChildIdentity -or
+    $null -eq $ParentIdentity -or
+    -not [bool]$ChildIdentity.identityCaptured -or
+    -not [bool]$ParentIdentity.identityCaptured -or
+    $null -eq $ChildIdentity.parentProcessId -or
+    [int]$ParentIdentity.processId -ne [int]$ChildIdentity.parentProcessId -or
+    [string]::IsNullOrWhiteSpace([string]$ParentIdentity.startTimeTicks) -or
+    [string]::IsNullOrWhiteSpace([string]$ChildIdentity.parentProcessStartTimeTicks) -or
+    -not [string]::Equals(
+      [string]$ParentIdentity.startTimeTicks,
+      [string]$ChildIdentity.parentProcessStartTimeTicks,
+      [System.StringComparison]::Ordinal
+    ) -or
+    -not (Test-AiNovelGateSameAbsolutePath `
+      -Left ([string]$ParentIdentity.executablePath) `
+      -Right ([string]$ChildIdentity.parentExecutablePath))
+  ) {
+    return $false
+  }
+  return $true
+}
+
+function Test-AiNovelGateCapturedInstallerParent {
+  param(
+    [AllowNull()]$ChildIdentity,
+    [AllowNull()]$ParentIdentity
+  )
+
+  return (
+    (Test-AiNovelGateCapturedParentIdentity `
+      -ChildIdentity $ChildIdentity `
+      -ParentIdentity $ParentIdentity) -and
+    (Test-AiNovelGateNsisInstallerImage -ImagePath ([string]$ParentIdentity.executablePath))
+  )
+}
+
+function Get-AiNovelGateProcessIdentityKey {
+  param([AllowNull()]$ProcessIdentity)
+
+  # A PID by itself can be reused. Keep the immutable creation time and
+  # canonical image path in the correlation key so a verified find.exe child
+  # cannot authorize a different cmd.exe instance.
+  if (
+    $null -eq $ProcessIdentity -or
+    -not [bool]$ProcessIdentity.identityCaptured -or
+    $null -eq $ProcessIdentity.processId -or
+    [int]$ProcessIdentity.processId -le 0 -or
+    [string]::IsNullOrWhiteSpace([string]$ProcessIdentity.startTimeTicks) -or
+    [string]::IsNullOrWhiteSpace([string]$ProcessIdentity.executablePath) -or
+    [string]$ProcessIdentity.executablePath -notmatch '^[A-Za-z]:\\'
+  ) {
+    return $null
+  }
+  try {
+    $startTimeTicks = [long]$ProcessIdentity.startTimeTicks
+    if ($startTimeTicks -le 0) {
+      return $null
+    }
+    $fullPath = [System.IO.Path]::GetFullPath([string]$ProcessIdentity.executablePath)
+    return ('{0}|{1}|{2}' -f [int]$ProcessIdentity.processId, $startTimeTicks, $fullPath)
+  }
+  catch {
+    return $null
+  }
+}
+
 function Test-AiNovelGateExpectedNsisPowerShellProbeExit {
   param(
     [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Step,
@@ -1167,15 +1362,7 @@ function Test-AiNovelGateExpectedNsisPowerShellProbeExit {
   # three probe commands as a normal branch: PowerShell availability,
   # execution-policy availability, and "no process in INSTDIR". This exception
   # applies only to installer smoke steps, not to a general PowerShell process.
-  if ($Step -notin @('smoke:win-installer', 'smoke:win-v025-upgrade')) {
-    return $false
-  }
-  if (
-    -not [bool]$Event.ExitCodeCaptured -or
-    $null -eq $Event.ExitCode -or
-    [uint32]$Event.JobMessage -ne 7 -or
-    [int]$Event.ExitCode -ne 1
-  ) {
+  if (-not (Test-AiNovelGateExpectedExitOne -Step $Step -Event $Event)) {
     return $false
   }
   if (
@@ -1194,24 +1381,274 @@ function Test-AiNovelGateExpectedNsisPowerShellProbeExit {
     -PowerShellImagePath ([string]$ProcessIdentity.executablePath))) {
     return $false
   }
+  return Test-AiNovelGateCapturedInstallerParent `
+    -ChildIdentity $ProcessIdentity `
+    -ParentIdentity $ParentIdentity
+}
+
+function Test-AiNovelGateNsisCmdProcessCheckCandidate {
+  param(
+    [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Step,
+    [Parameter(Mandatory = $true)]$Event,
+    [AllowNull()]$ProcessIdentity,
+    [AllowNull()]$ParentIdentity
+  )
+
+  if (-not (Test-AiNovelGateExpectedExitOne -Step $Step -Event $Event)) {
+    return $false
+  }
   if (
-    $null -eq $ParentIdentity -or
-    -not [bool]$ParentIdentity.identityCaptured -or
-    [int]$ParentIdentity.processId -ne [int]$ProcessIdentity.parentProcessId -or
-    [string]::IsNullOrWhiteSpace([string]$ParentIdentity.startTimeTicks) -or
-    [string]::IsNullOrWhiteSpace([string]$ProcessIdentity.parentProcessStartTimeTicks) -or
-    -not [string]::Equals(
-      [string]$ParentIdentity.startTimeTicks,
-      [string]$ProcessIdentity.parentProcessStartTimeTicks,
-      [System.StringComparison]::Ordinal
-    ) -or
-    -not (Test-AiNovelGateSameAbsolutePath `
-      -Left ([string]$ParentIdentity.executablePath) `
-      -Right ([string]$ProcessIdentity.parentExecutablePath))
+    $null -eq $ProcessIdentity -or
+    -not [bool]$ProcessIdentity.identityCaptured -or
+    -not [bool]$ProcessIdentity.commandLineCaptured -or
+    -not (Test-AiNovelGateSystemUtilityImage `
+      -ImagePath ([string]$ProcessIdentity.executablePath) `
+      -FileName 'cmd.exe') -or
+    -not (Test-AiNovelGateKnownNsisCmdProcessCheckCommand `
+      -CommandLine ([string]$ProcessIdentity.commandLine) `
+      -CmdImagePath ([string]$ProcessIdentity.executablePath))
   ) {
     return $false
   }
-  return Test-AiNovelGateNsisInstallerImage -ImagePath ([string]$ParentIdentity.executablePath)
+  return Test-AiNovelGateCapturedInstallerParent `
+    -ChildIdentity $ProcessIdentity `
+    -ParentIdentity $ParentIdentity
+}
+
+function Test-AiNovelGateExpectedNsisCmdProcessCheckExit {
+  param(
+    [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Step,
+    [Parameter(Mandatory = $true)]$Event,
+    [AllowNull()]$ProcessIdentity,
+    [AllowNull()]$ParentIdentity,
+    [AllowNull()]$VerifiedFindParentKeys
+  )
+
+  if (-not (Test-AiNovelGateNsisCmdProcessCheckCandidate `
+    -Step $Step `
+    -Event $Event `
+    -ProcessIdentity $ProcessIdentity `
+    -ParentIdentity $ParentIdentity)) {
+    return $false
+  }
+  $processIdentityKey = Get-AiNovelGateProcessIdentityKey -ProcessIdentity $ProcessIdentity
+  return (
+    $null -ne $VerifiedFindParentKeys -and
+    $null -ne $processIdentityKey -and
+    $VerifiedFindParentKeys.Contains($processIdentityKey)
+  )
+}
+
+function Register-AiNovelGateVerifiedNsisFindParent {
+  param(
+    [Parameter(Mandatory = $true)]$VerifiedFindParentKeys,
+    [Parameter(Mandatory = $true)][hashtable]$PendingNsisCmdExitFailures,
+    [AllowEmptyString()][string]$ParentProcessIdentityKey
+  )
+
+  if ([string]::IsNullOrWhiteSpace($ParentProcessIdentityKey)) {
+    return $false
+  }
+  [void]$VerifiedFindParentKeys.Add($ParentProcessIdentityKey)
+  $wasPending = $PendingNsisCmdExitFailures.ContainsKey($ParentProcessIdentityKey)
+  [void]$PendingNsisCmdExitFailures.Remove($ParentProcessIdentityKey)
+  return $wasPending
+}
+
+function Add-AiNovelGatePendingNsisCmdExitFailure {
+  param(
+    [Parameter(Mandatory = $true)][hashtable]$PendingNsisCmdExitFailures,
+    [AllowEmptyString()][string]$ProcessIdentityKey,
+    [AllowEmptyString()][string]$Failure
+  )
+
+  if (
+    [string]::IsNullOrWhiteSpace($ProcessIdentityKey) -or
+    [string]::IsNullOrWhiteSpace($Failure)
+  ) {
+    return $false
+  }
+  if (-not $PendingNsisCmdExitFailures.ContainsKey($ProcessIdentityKey)) {
+    # The failure text comes from the durable Job Object event and contains
+    # only step, PID, and exit code. Do not retain the command line here.
+    $PendingNsisCmdExitFailures[$ProcessIdentityKey] = $Failure
+  }
+  return $true
+}
+
+function Get-AiNovelGatePendingNsisCmdExitFailure {
+  param([Parameter(Mandatory = $true)][hashtable]$PendingNsisCmdExitFailures)
+
+  $entry = Get-AiNovelGatePendingNsisCmdExitFailureEntry `
+    -PendingNsisCmdExitFailures $PendingNsisCmdExitFailures
+  if ($null -eq $entry) {
+    return $null
+  }
+  return [string]$entry.Failure
+}
+
+function Get-AiNovelGatePendingNsisCmdExitFailureEntry {
+  param([Parameter(Mandatory = $true)][hashtable]$PendingNsisCmdExitFailures)
+
+  if ($PendingNsisCmdExitFailures.Count -eq 0) {
+    return $null
+  }
+  $entry = @($PendingNsisCmdExitFailures.GetEnumerator() | Sort-Object {
+    [string]$_.Key
+  } | Select-Object -First 1)
+  if ($entry.Count -ne 1) {
+    return $null
+  }
+  $processIdentityKey = [string]$entry[0].Key
+  $failure = [string]$entry[0].Value
+  if (
+    [string]::IsNullOrWhiteSpace($processIdentityKey) -or
+    [string]::IsNullOrWhiteSpace($failure)
+  ) {
+    return $null
+  }
+  return [pscustomobject][ordered]@{
+    processIdentityKey = $processIdentityKey
+    failure = $failure
+  }
+}
+
+function New-AiNovelGateDeferredNsisCmdExitFailureState {
+  return @{
+    failure = $null
+    source = ''
+    processIdentityKey = $null
+    correlationDeadline = $null
+    earliestFailureDrain = 0
+  }
+}
+
+function Clear-AiNovelGateDeferredNsisCmdExitFailureState {
+  param([Parameter(Mandatory = $true)][hashtable]$State)
+
+  $State.failure = $null
+  $State.source = ''
+  $State.processIdentityKey = $null
+  $State.correlationDeadline = $null
+  $State.earliestFailureDrain = 0
+}
+
+function Promote-AiNovelGatePendingNsisCmdExitFailure {
+  param(
+    [Parameter(Mandatory = $true)][hashtable]$State,
+    [AllowNull()]$PendingEntry,
+    [Parameter(Mandatory = $true)][DateTime]$NowUtc,
+    [Parameter(Mandatory = $true)][int]$CurrentDrain,
+    [ValidateRange(1, 10)][int]$CorrelationGraceSeconds = 1
+  )
+
+  if (
+    $null -ne $State.failure -or
+    $null -eq $PendingEntry -or
+    [string]::IsNullOrWhiteSpace([string]$PendingEntry.processIdentityKey) -or
+    [string]::IsNullOrWhiteSpace([string]$PendingEntry.failure)
+  ) {
+    return $false
+  }
+  # The terminal Job Object notification may precede the child find.exe
+  # completion record. Preserve the exact cmd.exe identity so only that
+  # process's verified find.exe child can revoke this deferred failure.
+  $State.failure = [string]$PendingEntry.failure
+  $State.source = 'nsis-cmd-awaiting-verified-find'
+  $State.processIdentityKey = [string]$PendingEntry.processIdentityKey
+  $State.correlationDeadline = $NowUtc.AddSeconds($CorrelationGraceSeconds)
+  $State.earliestFailureDrain = $CurrentDrain + 1
+  return $true
+}
+
+function Resolve-AiNovelGateDeferredNsisCmdExitFailure {
+  param(
+    [Parameter(Mandatory = $true)][hashtable]$State,
+    [AllowEmptyString()][string]$ProcessIdentityKey
+  )
+
+  if (
+    [string]::IsNullOrWhiteSpace($ProcessIdentityKey) -or
+    $State.source -ne 'nsis-cmd-awaiting-verified-find' -or
+    [string]::IsNullOrWhiteSpace([string]$State.processIdentityKey) -or
+    -not [string]::Equals(
+      [string]$State.processIdentityKey,
+      $ProcessIdentityKey,
+      [System.StringComparison]::OrdinalIgnoreCase
+    )
+  ) {
+    return $false
+  }
+  Clear-AiNovelGateDeferredNsisCmdExitFailureState -State $State
+  return $true
+}
+
+function Test-AiNovelGateDeferredNsisCmdExitFailureReady {
+  param(
+    [Parameter(Mandatory = $true)][hashtable]$State,
+    [Parameter(Mandatory = $true)][DateTime]$NowUtc,
+    [Parameter(Mandatory = $true)][int]$CurrentDrain
+  )
+
+  if ($null -eq $State.failure) {
+    return $false
+  }
+  # A malformed special state must never silently permit a release. The valid
+  # state, however, always waits through one later Drain() plus its short
+  # correlation grace so the next batch can deliver the matching find.exe.
+  if (
+    $State.source -ne 'nsis-cmd-awaiting-verified-find' -or
+    [string]::IsNullOrWhiteSpace([string]$State.processIdentityKey) -or
+    $null -eq $State.correlationDeadline -or
+    [int]$State.earliestFailureDrain -le 0
+  ) {
+    return $true
+  }
+  return (
+    $CurrentDrain -ge [int]$State.earliestFailureDrain -and
+    $NowUtc -ge [DateTime]$State.correlationDeadline
+  )
+}
+
+function Test-AiNovelGateExpectedNsisFindNoMatchExit {
+  param(
+    [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Step,
+    [Parameter(Mandatory = $true)]$Event,
+    [AllowNull()]$ProcessIdentity,
+    [AllowNull()]$ParentIdentity,
+    [AllowNull()]$GrandParentIdentity
+  )
+
+  if (-not (Test-AiNovelGateExpectedExitOne -Step $Step -Event $Event)) {
+    return $false
+  }
+  if (
+    $null -eq $ProcessIdentity -or
+    -not [bool]$ProcessIdentity.identityCaptured -or
+    -not [bool]$ProcessIdentity.commandLineCaptured -or
+    -not (Test-AiNovelGateSystemUtilityImage `
+      -ImagePath ([string]$ProcessIdentity.executablePath) `
+      -FileName 'find.exe') -or
+    -not (Test-AiNovelGateKnownNsisFindNoMatchCommand `
+      -CommandLine ([string]$ProcessIdentity.commandLine) `
+      -FindImagePath ([string]$ProcessIdentity.executablePath)) -or
+    -not (Test-AiNovelGateCapturedParentIdentity `
+      -ChildIdentity $ProcessIdentity `
+      -ParentIdentity $ParentIdentity) -or
+    $null -eq $ParentIdentity -or
+    -not [bool]$ParentIdentity.commandLineCaptured -or
+    -not (Test-AiNovelGateSystemUtilityImage `
+      -ImagePath ([string]$ParentIdentity.executablePath) `
+      -FileName 'cmd.exe') -or
+    -not (Test-AiNovelGateKnownNsisCmdProcessCheckCommand `
+      -CommandLine ([string]$ParentIdentity.commandLine) `
+      -CmdImagePath ([string]$ParentIdentity.executablePath))
+  ) {
+    return $false
+  }
+  return Test-AiNovelGateCapturedInstallerParent `
+    -ChildIdentity $ParentIdentity `
+    -ParentIdentity $GrandParentIdentity
 }
 
 function ConvertTo-AiNovelGateProcessEvidenceIdentity {
@@ -1358,6 +1795,10 @@ $lastWindowSnapshot = @()
 $atomicMonitor = $null
 $deferredProcessFailure = $null
 $deferredProcessFailureDeadline = $null
+$deferredNsisCmdExitFailure = New-AiNovelGateDeferredNsisCmdExitFailureState
+$verifiedNsisFindParentKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+$pendingNsisCmdExitFailures = @{}
+$drainSequence = 0
 
 New-Item -ItemType Directory -Path $EvidencePath -Force | Out-Null
 try {
@@ -1430,6 +1871,9 @@ try {
         $trackedProcessIdentities.Clear()
         $deferredProcessFailure = $null
         $deferredProcessFailureDeadline = $null
+        Clear-AiNovelGateDeferredNsisCmdExitFailureState -State $deferredNsisCmdExitFailure
+        $verifiedNsisFindParentKeys.Clear()
+        $pendingNsisCmdExitFailures.Clear()
         $rootIdentityAccepted = Initialize-AiNovelGateRootIdentity `
           -RootProcessId ([int]$control.rootProcessId) `
           -RootProcessStartTimeTicks ([long]$control.rootProcessStartTimeTicks) `
@@ -1474,6 +1918,9 @@ try {
         $trackedProcessIdentities.Clear()
         $deferredProcessFailure = $null
         $deferredProcessFailureDeadline = $null
+        Clear-AiNovelGateDeferredNsisCmdExitFailureState -State $deferredNsisCmdExitFailure
+        $verifiedNsisFindParentKeys.Clear()
+        $pendingNsisCmdExitFailures.Clear()
         $completionDeadline = $null
         $completionQuietDeadline = $null
         $quietDeadline = New-AiNovelGateQuietDeadline `
@@ -1484,6 +1931,8 @@ try {
     }
 
     $windowEventSnapshots = @()
+    $jobBecameEmpty = $false
+    $drainSequence += 1
     foreach ($processEvent in @($atomicMonitor.Job.Drain())) {
       $processIdentity = $null
       $exitClassification = ''
@@ -1536,6 +1985,7 @@ try {
           $processIdentity = $trackedProcessIdentities[[int]$processEvent.ProcessId]
         }
         $parentIdentity = $null
+        $grandParentIdentity = $null
         try {
           if (
             $null -ne $processIdentity -and
@@ -1543,6 +1993,12 @@ try {
             $trackedProcessIdentities.ContainsKey([int]$processIdentity.parentProcessId)
           ) {
             $parentIdentity = $trackedProcessIdentities[[int]$processIdentity.parentProcessId]
+            if (
+              $null -ne $parentIdentity.parentProcessId -and
+              $trackedProcessIdentities.ContainsKey([int]$parentIdentity.parentProcessId)
+            ) {
+              $grandParentIdentity = $trackedProcessIdentities[[int]$parentIdentity.parentProcessId]
+            }
           }
         }
         catch {
@@ -1559,9 +2015,61 @@ try {
           -ParentIdentity $parentIdentity) {
           $exitClassification = 'expected-nsis-powershell-probe'
         }
+        elseif (Test-AiNovelGateExpectedNsisFindNoMatchExit `
+          -Step $activeStep `
+          -Event $processEvent `
+          -ProcessIdentity $processIdentity `
+          -ParentIdentity $parentIdentity `
+          -GrandParentIdentity $grandParentIdentity) {
+          $parentProcessIdentityKey = Get-AiNovelGateProcessIdentityKey -ProcessIdentity $parentIdentity
+          if ($null -eq $parentProcessIdentityKey) {
+            $exitClassification = 'failure'
+          } else {
+            [void](Register-AiNovelGateVerifiedNsisFindParent `
+              -VerifiedFindParentKeys $verifiedNsisFindParentKeys `
+              -PendingNsisCmdExitFailures $pendingNsisCmdExitFailures `
+              -ParentProcessIdentityKey $parentProcessIdentityKey)
+            [void](Resolve-AiNovelGateDeferredNsisCmdExitFailure `
+              -State $deferredNsisCmdExitFailure `
+              -ProcessIdentityKey $parentProcessIdentityKey)
+            $exitClassification = 'expected-nsis-find-no-match'
+          }
+        }
+        elseif (Test-AiNovelGateExpectedNsisCmdProcessCheckExit `
+          -Step $activeStep `
+          -Event $processEvent `
+          -ProcessIdentity $processIdentity `
+          -ParentIdentity $parentIdentity `
+          -VerifiedFindParentKeys $verifiedNsisFindParentKeys) {
+          $exitClassification = 'expected-nsis-cmd-process-check'
+        }
+        elseif (Test-AiNovelGateNsisCmdProcessCheckCandidate `
+          -Step $activeStep `
+          -Event $processEvent `
+          -ProcessIdentity $processIdentity `
+          -ParentIdentity $parentIdentity) {
+          $processIdentityKey = Get-AiNovelGateProcessIdentityKey -ProcessIdentity $processIdentity
+          if (Add-AiNovelGatePendingNsisCmdExitFailure `
+            -PendingNsisCmdExitFailures $pendingNsisCmdExitFailures `
+            -ProcessIdentityKey $processIdentityKey `
+            -Failure $exitFailure) {
+            # A cmd.exe exit can reach the completion port before its find.exe
+            # child. Delay the exception decision until a matching, validated
+            # find.exe no-match event is observed.
+            $exitClassification = 'pending-nsis-cmd-process-check'
+          } else {
+            $exitClassification = 'failure'
+          }
+        }
         else {
           $exitClassification = 'failure'
         }
+      }
+      elseif ([string]$processEvent.Kind -eq 'job-empty') {
+        # Delay resolution until the whole Drain() batch is processed: a
+        # completion port can surface cmd.exe before its find.exe child.
+        $jobBecameEmpty = $true
+        $exitClassification = 'job-empty'
       }
       Write-AiNovelGateProcessEventEvidence `
         -Path $EvidencePath `
@@ -1586,7 +2094,12 @@ try {
         # write its durable result.json. The failure is finalized on the
         # explicit step-complete acknowledgement, or after a bounded drain
         # deadline if the launcher never completes.
-        if ($exitClassification -eq 'expected-nsis-powershell-probe') {
+        if ($exitClassification -in @(
+          'expected-nsis-powershell-probe',
+          'expected-nsis-cmd-process-check',
+          'expected-nsis-find-no-match',
+          'pending-nsis-cmd-process-check'
+        )) {
           continue
         }
         $exitFailure = Get-AiNovelGateProcessExitFailure -Step $activeStep -Event $processEvent
@@ -1600,6 +2113,23 @@ try {
             -ProcessStartTimeTicks $trackedProcessStartTimeTicks `
             -Reason 'process-failure-awaiting-launch-result'
         }
+      }
+    }
+
+    if ($jobBecameEmpty -and $null -eq $deferredProcessFailure) {
+      $pendingNsisCmdFailure = Get-AiNovelGatePendingNsisCmdExitFailureEntry `
+        -PendingNsisCmdExitFailures $pendingNsisCmdExitFailures
+      if (Promote-AiNovelGatePendingNsisCmdExitFailure `
+        -State $deferredNsisCmdExitFailure `
+        -PendingEntry $pendingNsisCmdFailure `
+        -NowUtc ([DateTime]::UtcNow) `
+        -CurrentDrain $drainSequence) {
+        Write-AiNovelGateProcessTreeEvidence `
+          -Path $EvidencePath `
+          -Step $activeStep `
+          -ProcessIds $trackedProcessIds `
+          -ProcessStartTimeTicks $trackedProcessStartTimeTicks `
+          -Reason 'nsis-cmd-awaiting-verified-find'
       }
     }
 
@@ -1682,7 +2212,11 @@ try {
       }
     }
 
-    if ($completionDeadline) {
+    if (
+      $completionDeadline -and
+      $null -eq $deferredProcessFailure -and
+      $null -eq $deferredNsisCmdExitFailure.failure
+    ) {
       $aliveProcessIds = @(Get-AiNovelAliveProcessIds `
         -ProcessIds $trackedProcessIds `
         -ProcessStartTimeTicks $trackedProcessStartTimeTicks)
@@ -1693,6 +2227,23 @@ try {
         -PostExitQuietDeadline $completionQuietDeadline
       $completionQuietDeadline = $completionDecision.PostExitQuietDeadline
       if ($completionDecision.State -eq 'complete') {
+        # If the Job Object did not deliver its terminal notification, keep
+        # draining through the normal post-exit quiet period and fail closed
+        # immediately before this step could otherwise be marked complete.
+        $pendingNsisCmdFailure = Get-AiNovelGatePendingNsisCmdExitFailureEntry `
+          -PendingNsisCmdExitFailures $pendingNsisCmdExitFailures
+        if (Promote-AiNovelGatePendingNsisCmdExitFailure `
+          -State $deferredNsisCmdExitFailure `
+          -PendingEntry $pendingNsisCmdFailure `
+          -NowUtc ([DateTime]::UtcNow) `
+          -CurrentDrain $drainSequence) {
+          Write-AiNovelGateProcessTreeEvidence `
+            -Path $EvidencePath `
+            -Step $activeStep `
+            -ProcessIds $trackedProcessIds `
+            -ProcessStartTimeTicks $trackedProcessStartTimeTicks `
+            -Reason 'nsis-cmd-awaiting-verified-find'
+        } else {
         # Keep the full historical PID + start-time set until error-window
         # detection has run continuously for five seconds after process exit.
         Write-AiNovelGateProcessTreeEvidence `
@@ -1704,6 +2255,7 @@ try {
         Write-AiNovelGateStatus -State 'step-completed' -Step $activeStep
         $completionDeadline = $null
         $completionQuietDeadline = $null
+        }
       }
       elseif ($completionDecision.State -eq 'process-timeout') {
         $failure = "Release gate step '$activeStep' left related processes running: $($aliveProcessIds -join ', ')"
@@ -1750,6 +2302,37 @@ try {
         -ProcessIds $trackedProcessIds `
         -ProcessStartTimeTicks $trackedProcessStartTimeTicks `
         -Reason 'deferred-process-failure'
+      $script:AiNovelGateMonitorStoppedAt = [DateTime]::UtcNow.ToString('o')
+      Write-AiNovelGateStatus -State 'failed' -Step $activeStep -Failure $failure
+      Stop-AiNovelGateAtomicJob -AtomicMonitor $atomicMonitor
+      Stop-AiNovelGateProcesses `
+        -ProcessIds $trackedProcessIds `
+        -ProcessStartTimeTicks $trackedProcessStartTimeTicks
+      exit 1
+    }
+
+    if (
+      $null -eq $deferredProcessFailure -and
+      (Test-AiNovelGateDeferredNsisCmdExitFailureReady `
+        -State $deferredNsisCmdExitFailure `
+        -NowUtc ([DateTime]::UtcNow) `
+        -CurrentDrain $drainSequence)
+    ) {
+      # The narrow NSIS exception is fail-closed: after a whole later Drain()
+      # and a bounded correlation grace, a cmd.exe no-process exit without its
+      # exact, identity-bound find.exe child remains a real installer failure.
+      $failure = [string]$deferredNsisCmdExitFailure.failure
+      Save-AiNovelSmokeFailureEvidence `
+        -Path $EvidencePath `
+        -Failure $failure `
+        -Windows $lastWindowSnapshot `
+        -ObservedProcessIds @($trackedProcessIds)
+      Write-AiNovelGateProcessTreeEvidence `
+        -Path $EvidencePath `
+        -Step $activeStep `
+        -ProcessIds $trackedProcessIds `
+        -ProcessStartTimeTicks $trackedProcessStartTimeTicks `
+        -Reason 'nsis-cmd-missing-verified-find'
       $script:AiNovelGateMonitorStoppedAt = [DateTime]::UtcNow.ToString('o')
       Write-AiNovelGateStatus -State 'failed' -Step $activeStep -Failure $failure
       Stop-AiNovelGateAtomicJob -AtomicMonitor $atomicMonitor


### PR DESCRIPTION
## 修复范围

- 精确识别 electron-builder 26.8.1 NSIS 的 PowerShell 与 cmd/find 进程检查链
- cmd exit 1 仅在同 PID、启动时间和映像路径的 find no-match 事件验证后豁免
- 支持跨 Drain 的事件顺序；无匹配 find、错键或超时继续 fail-closed
- 所有证据保持命令行脱敏

## 验证

- 142 个测试文件、795 项测试通过
- TypeScript 类型检查通过
- ESLint 通过
- PowerShell 解析与 diff 检查通过
- 独立冻结审查：Standards PASS / Spec PASS / P0-P2 = 0

本 PR 仅解决当前云端 Windows 安装器验收阻塞，不扩展功能范围。