### PR TITLE
fix: preserve monitor script Unicode on Windows

### DIFF
--- a/electron/__tests__/package-contract.test.ts
+++ b/electron/__tests__/package-contract.test.ts
@@ -176,7 +176,7 @@ describe('release dependency contract', () => {
 
     expect(
       createHash('sha256').update(releaseMonitor).digest('hex'),
-    ).toBe('4a40bac5c020133819aee0b62dbb68f3ca410f2ddd85ff49c47d6a3f9a8f58a4')
+    ).toBe('4db5ff057dcc28b8a48fa8f746feb7a6c1f75843727854e01f1e38daf358b9d4')
   })
 
   it('blocks direct Windows artifact builds outside the release gate', () => {

--- a/scripts/__tests__/smoke-win-installer.test.ts
+++ b/scripts/__tests__/smoke-win-installer.test.ts
@@ -48,7 +48,7 @@ describe('Windows PowerShell smoke script encoding', () => {
   it('uses a UTF-8 BOM for scripts directly executed by Windows PowerShell', () => {
     const utf8Bom = Buffer.from([0xef, 0xbb, 0xbf])
 
-    for (const script of [probeScript, installerScript]) {
+    for (const script of [probeScript, installerScript, releaseMonitorScript]) {
       expect(readFileSync(script).subarray(0, utf8Bom.length)).toEqual(utf8Bom)
     }
   })

--- a/scripts/monitor-win-release-gate.ps1
+++ b/scripts/monitor-win-release-gate.ps1
@@ -1,4 +1,4 @@
-param(
+﻿param(
   [string]$ControlPath,
   [string]$StatusPath,
   [string]$EvidencePath,


### PR DESCRIPTION
## 云端失败根因

GitHub 的英文 Windows PowerShell 5.1 会把无 BOM 的 UTF-8 脚本按 ANSI 代码页读取，导致监控器中的中文安装包进程名被解码错误。严格 NSIS 识别因此在本机通过、在云端失败。

## 最小修复

- 为 monitor-win-release-gate.ps1 增加 UTF-8 BOM，逻辑正文不变
- 将监控脚本纳入 Windows PowerShell BOM 契约测试
- 同步不可变脚本哈希

## 验证

- 完整 142 个测试文件 / 795 项测试通过
- Typecheck、Lint、PowerShell 5.1 Parser、diff check 通过
- 独立限定审查 Standards PASS / Spec PASS / P0-P2 = 0