### PR TITLE
fix: recognize trusted WOW64 NSIS aliases

### DIFF
--- a/electron/__tests__/package-contract.test.ts
+++ b/electron/__tests__/package-contract.test.ts
@@ -176,7 +176,7 @@ describe('release dependency contract', () => {
 
     expect(
       createHash('sha256').update(releaseMonitor).digest('hex'),
-    ).toBe('4db5ff057dcc28b8a48fa8f746feb7a6c1f75843727854e01f1e38daf358b9d4')
+    ).toBe('3d7ef8e911c8fb21efa31c64477e7d0d77d9e37c5e6a017bf9e7b3a44f6d29fa')
   })
 
   it('blocks direct Windows artifact builds outside the release gate', () => {

--- a/scripts/__tests__/smoke-win-installer.test.ts
+++ b/scripts/__tests__/smoke-win-installer.test.ts
@@ -1114,6 +1114,93 @@ $abnormal = [pscustomobject]@{ ProcessId = 701; ExitCode = 1; ExitCodeCaptured =
     expect(result.MissingParentMetadata).toBe(false)
   })
 
+  windowsIt('accepts only the NSIS System32 to SysWOW64 command-image redirect aliases', () => {
+    const output = runReleaseMonitorLibrary(`
+$system32PowerShell = Join-Path $env:SystemRoot 'System32\\WindowsPowerShell\\v1.0\\powershell.exe'
+$sysWow64PowerShell = Join-Path $env:SystemRoot 'SysWOW64\\WindowsPowerShell\\v1.0\\powershell.exe'
+$system32Cmd = Join-Path $env:SystemRoot 'System32\\cmd.exe'
+$sysWow64Cmd = Join-Path $env:SystemRoot 'SysWOW64\\cmd.exe'
+$system32Find = Join-Path $env:SystemRoot 'System32\\find.exe'
+$sysWow64Find = Join-Path $env:SystemRoot 'SysWOW64\\find.exe'
+$system32Where = Join-Path $env:SystemRoot 'System32\\where.exe'
+$sysWow64Where = Join-Path $env:SystemRoot 'SysWOW64\\where.exe'
+$installerPath = 'C:\\temp\\ai-novel-writer-setup-0.4.0.exe'
+$installer = [pscustomobject]@{
+  processId = 700
+  startTimeTicks = '638900000000000000'
+  executablePath = $installerPath
+  identityCaptured = $true
+}
+$event = [pscustomobject]@{ ProcessId = 701; ExitCode = 1; ExitCodeCaptured = $true; JobMessage = 7 }
+$availabilityCommand = '"' + $system32PowerShell + '" -C "if (Get-Command Get-CimInstance -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }"'
+$cmdCommand = '"' + $system32Cmd + '" /C tasklist /FI "USERNAME eq %USERNAME%" /FI "IMAGENAME eq AI小说作家.exe" /FO CSV | "' + $system32Find + '" "AI小说作家.exe"'
+$findCommand = '"' + $system32Find + '"  "AI小说作家.exe"'
+$powerShell = [pscustomobject]@{
+  processId = 701
+  startTimeTicks = '638900000000000100'
+  executablePath = $sysWow64PowerShell
+  commandLine = $availabilityCommand
+  commandLineCaptured = $true
+  identityCaptured = $true
+  parentProcessId = 700
+  parentProcessStartTimeTicks = $installer.startTimeTicks
+  parentExecutablePath = $installerPath
+}
+$cmd = [pscustomobject]@{
+  processId = 702
+  startTimeTicks = '638900000000000200'
+  executablePath = $sysWow64Cmd
+  commandLine = $cmdCommand
+  commandLineCaptured = $true
+  identityCaptured = $true
+  parentProcessId = 700
+  parentProcessStartTimeTicks = $installer.startTimeTicks
+  parentExecutablePath = $installerPath
+}
+$find = [pscustomobject]@{
+  processId = 703
+  startTimeTicks = '638900000000000300'
+  executablePath = $sysWow64Find
+  commandLine = $findCommand
+  commandLineCaptured = $true
+  identityCaptured = $true
+  parentProcessId = $cmd.processId
+  parentProcessStartTimeTicks = $cmd.startTimeTicks
+  parentExecutablePath = $sysWow64Cmd
+}
+$verifiedFindParentKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+[void]$verifiedFindParentKeys.Add((Get-AiNovelGateProcessIdentityKey -ProcessIdentity $cmd))
+$wrongFileCommand = $availabilityCommand.Replace($system32PowerShell, $system32Cmd)
+$wrongDirectoryCommand = $availabilityCommand.Replace($system32PowerShell, (Join-Path $env:SystemRoot 'SystemOther\\WindowsPowerShell\\v1.0\\powershell.exe'))
+$sameBasenameElsewhereCommand = $availabilityCommand.Replace($system32PowerShell, 'C:\\temp\\powershell.exe')
+$relativeArgvZeroCommand = 'System32\\WindowsPowerShell\\v1.0\\powershell.exe -C "if (Get-Command Get-CimInstance -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }"'
+[pscustomobject]@{
+  System32PowerShellArgvZeroSysWow64Actual = Test-AiNovelGateExpectedNsisPowerShellProbeExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity $powerShell -ParentIdentity $installer
+  System32CmdArgvZeroSysWow64Actual = Test-AiNovelGateExpectedNsisCmdProcessCheckExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity $cmd -ParentIdentity $installer -VerifiedFindParentKeys $verifiedFindParentKeys
+  System32FindArgvZeroSysWow64Actual = Test-AiNovelGateExpectedNsisFindNoMatchExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity $find -ParentIdentity $cmd -GrandParentIdentity $installer
+  WrongFileIsNotAlias = Test-AiNovelGateExpectedNsisPowerShellProbeExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity ([pscustomobject]@{ processId = 701; startTimeTicks = '638900000000000100'; executablePath = $sysWow64PowerShell; commandLine = $wrongFileCommand; commandLineCaptured = $true; identityCaptured = $true; parentProcessId = 700; parentProcessStartTimeTicks = $installer.startTimeTicks; parentExecutablePath = $installerPath }) -ParentIdentity $installer
+  WrongDirectoryIsNotAlias = Test-AiNovelGateExpectedNsisPowerShellProbeExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity ([pscustomobject]@{ processId = 701; startTimeTicks = '638900000000000100'; executablePath = $sysWow64PowerShell; commandLine = $wrongDirectoryCommand; commandLineCaptured = $true; identityCaptured = $true; parentProcessId = 700; parentProcessStartTimeTicks = $installer.startTimeTicks; parentExecutablePath = $installerPath }) -ParentIdentity $installer
+  SameBasenameElsewhereIsNotAlias = Test-AiNovelGateExpectedNsisPowerShellProbeExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity ([pscustomobject]@{ processId = 701; startTimeTicks = '638900000000000100'; executablePath = $sysWow64PowerShell; commandLine = $sameBasenameElsewhereCommand; commandLineCaptured = $true; identityCaptured = $true; parentProcessId = 700; parentProcessStartTimeTicks = $installer.startTimeTicks; parentExecutablePath = $installerPath }) -ParentIdentity $installer
+  RelativeArgvZeroIsNotAlias = Test-AiNovelGateExpectedNsisPowerShellProbeExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity ([pscustomobject]@{ processId = 701; startTimeTicks = '638900000000000100'; executablePath = $sysWow64PowerShell; commandLine = $relativeArgvZeroCommand; commandLineCaptured = $true; identityCaptured = $true; parentProcessId = 700; parentProcessStartTimeTicks = $installer.startTimeTicks; parentExecutablePath = $installerPath }) -ParentIdentity $installer
+  UnlistedSystemExecutableIsNotAlias = Test-AiNovelGateSameBoundSystemExecutablePath -Left $system32Where -Right $sysWow64Where
+  ExactNonSystemPathStillBinds = (Get-AiNovelGateBoundCommandArguments -CommandLine '"C:\\temp\\custom.exe" --check' -ImagePath 'C:\\temp\\custom.exe') -eq ' --check'
+} | ConvertTo-Json -Compress
+`)
+    const result = parseLastJsonLine(output)
+
+    expect(result).toEqual({
+      System32PowerShellArgvZeroSysWow64Actual: true,
+      System32CmdArgvZeroSysWow64Actual: true,
+      System32FindArgvZeroSysWow64Actual: true,
+      WrongFileIsNotAlias: false,
+      WrongDirectoryIsNotAlias: false,
+      SameBasenameElsewhereIsNotAlias: false,
+      RelativeArgvZeroIsNotAlias: false,
+      UnlistedSystemExecutableIsNotAlias: false,
+      ExactNonSystemPathStillBinds: true,
+    })
+  })
+
   windowsIt('exempts only the exact NSIS cmd and find no-process fallback chain', () => {
     const output = runReleaseMonitorLibrary(`
 $cmdPath = Join-Path $env:SystemRoot 'System32\\cmd.exe'

--- a/scripts/monitor-win-release-gate.ps1
+++ b/scripts/monitor-win-release-gate.ps1
@@ -1150,6 +1150,62 @@ function Test-AiNovelGateSameAbsolutePath {
   }
 }
 
+function Test-AiNovelGateSameBoundSystemExecutablePath {
+  param(
+    [AllowEmptyString()][string]$Left,
+    [AllowEmptyString()][string]$Right
+  )
+
+  # The command line must normally bind argv[0] to the exact image path
+  # captured from the process. A 32-bit NSIS stub is the narrow exception:
+  # $SYSDIR can be recorded as System32 while QueryFullProcessImageName sees
+  # the redirected SysWOW64 image. Do not turn this into a basename match.
+  if (Test-AiNovelGateSameAbsolutePath -Left $Left -Right $Right) {
+    return $true
+  }
+  if (
+    [string]::IsNullOrWhiteSpace($Left) -or
+    [string]::IsNullOrWhiteSpace($Right) -or
+    $Left -notmatch '^[A-Za-z]:\\' -or
+    $Right -notmatch '^[A-Za-z]:\\'
+  ) {
+    return $false
+  }
+  try {
+    $systemRoot = [System.Environment]::GetEnvironmentVariable('SystemRoot')
+    if ([string]::IsNullOrWhiteSpace($systemRoot) -or $systemRoot -notmatch '^[A-Za-z]:\\') {
+      return $false
+    }
+    $windowsRoot = [System.IO.Path]::GetFullPath($systemRoot)
+    $leftFullPath = [System.IO.Path]::GetFullPath($Left)
+    $rightFullPath = [System.IO.Path]::GetFullPath($Right)
+    $allowedRelativeExecutablePaths = @(
+      'cmd.exe',
+      'find.exe',
+      'WindowsPowerShell\v1.0\powershell.exe'
+    )
+    foreach ($relativeExecutablePath in $allowedRelativeExecutablePaths) {
+      $system32Path = [System.IO.Path]::GetFullPath((Join-Path $windowsRoot (Join-Path 'System32' $relativeExecutablePath)))
+      $sysWow64Path = [System.IO.Path]::GetFullPath((Join-Path $windowsRoot (Join-Path 'SysWOW64' $relativeExecutablePath)))
+      $isSystem32ToSysWow64 = (
+        [string]::Equals($leftFullPath, $system32Path, [System.StringComparison]::OrdinalIgnoreCase) -and
+        [string]::Equals($rightFullPath, $sysWow64Path, [System.StringComparison]::OrdinalIgnoreCase)
+      )
+      $isSysWow64ToSystem32 = (
+        [string]::Equals($leftFullPath, $sysWow64Path, [System.StringComparison]::OrdinalIgnoreCase) -and
+        [string]::Equals($rightFullPath, $system32Path, [System.StringComparison]::OrdinalIgnoreCase)
+      )
+      if ($isSystem32ToSysWow64 -or $isSysWow64ToSystem32) {
+        return $true
+      }
+    }
+    return $false
+  }
+  catch {
+    return $false
+  }
+}
+
 function Get-AiNovelGateBoundCommandArguments {
   param(
     [AllowEmptyString()][string]$CommandLine,
@@ -1180,7 +1236,7 @@ function Get-AiNovelGateBoundCommandArguments {
     $argvZero = $CommandLine.Substring(0, $firstWhitespace.Index)
     $arguments = $CommandLine.Substring($firstWhitespace.Index)
   }
-  if (-not (Test-AiNovelGateSameAbsolutePath -Left $argvZero -Right $ImagePath)) {
+  if (-not (Test-AiNovelGateSameBoundSystemExecutablePath -Left $argvZero -Right $ImagePath)) {
     return $null
   }
   return [string]$arguments
@@ -1240,7 +1296,7 @@ function Test-AiNovelGateKnownNsisCmdProcessCheckCommand {
       return $false
     }
     $findPath = $arguments.Substring($prefix.Length, $findPathLength)
-    return Test-AiNovelGateSameAbsolutePath -Left $findPath -Right $expectedFindPath
+    return Test-AiNovelGateSameBoundSystemExecutablePath -Left $findPath -Right $expectedFindPath
   }
   catch {
     return $false


### PR DESCRIPTION
## 云端失败根因

32 位 NSIS 的命令行记录 System32 路径，而 QueryFullProcessImageName 在 GitHub Windows Runner 返回重定向后的 SysWOW64 映像。严格路径绑定因此把同一个 Windows 系统程序误判为不同映像。

## 限定修复

- 仅允许 System32 与 SysWOW64 间三项官方重定向别名：cmd.exe、find.exe、WindowsPowerShell\v1.0\powershell.exe
- argv0 与 cmd 内嵌 find 路径继续绑定捕获映像
- 其他目录、文件、相对路径、任意同 basename、未列入 allowlist 的 where.exe 全部拒绝

## 验证

- 定向 43/43
- 完整 142 文件 / 796 测试
- Typecheck、Lint、PowerShell parser、diff check
- 最终限定审查 Standards PASS / Spec PASS / P0-P2 = 0

证据：Windows cloud run 30213502750 的 PID 7564、2868、2992 分别为同一安装器链中的 SysWOW64 PowerShell、cmd、find。