### PR TITLE
fix: recognize trusted NSIS uninstaller probes

### DIFF
--- a/electron/__tests__/package-contract.test.ts
+++ b/electron/__tests__/package-contract.test.ts
@@ -176,7 +176,7 @@ describe('release dependency contract', () => {
 
     expect(
       createHash('sha256').update(releaseMonitor).digest('hex'),
-    ).toBe('3d7ef8e911c8fb21efa31c64477e7d0d77d9e37c5e6a017bf9e7b3a44f6d29fa')
+    ).toBe('91eda5acad927a36d5053c33dc8a066c7f575424a8ff3a6d3e55c157a7f6a1a5')
   })
 
   it('blocks direct Windows artifact builds outside the release gate', () => {

--- a/scripts/__tests__/release-win-verify.test.ts
+++ b/scripts/__tests__/release-win-verify.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync, spawn, spawnSync } from 'node:child_process'
-import { appendFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { appendFileSync, copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
@@ -11,6 +11,50 @@ const windowsIt = process.platform === 'win32' ? it : it.skip
 
 function quotePowerShell(value: string): string {
   return `'${value.replaceAll("'", "''")}'`
+}
+
+const windowsShortPathFixtureSource = String.raw`
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+public static class AiNovelTestShortPath {
+  [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+  private static extern uint GetShortPathName(
+    string longPath,
+    StringBuilder shortPath,
+    uint cchBuffer
+  );
+
+  public static string Get(string path) {
+    if (String.IsNullOrWhiteSpace(path)) return null;
+    uint required = GetShortPathName(path, null, 0);
+    if (required == 0) return null;
+    StringBuilder buffer = new StringBuilder(unchecked((int)required + 1));
+    uint written = GetShortPathName(path, buffer, unchecked((uint)buffer.Capacity));
+    if (written == 0 || written >= buffer.Capacity) return null;
+    return buffer.ToString();
+  }
+}
+`
+
+function windowsShortPath(path: string): string | undefined {
+  try {
+    const output = execFileSync(
+      'powershell.exe',
+      [
+        '-NoProfile',
+        '-ExecutionPolicy',
+        'Bypass',
+        '-Command',
+        `Add-Type -TypeDefinition ${quotePowerShell(windowsShortPathFixtureSource)}; [AiNovelTestShortPath]::Get(${quotePowerShell(path)})`,
+      ],
+      { encoding: 'utf8', windowsHide: true },
+    ).trim()
+    return output || undefined
+  } catch {
+    return undefined
+  }
 }
 
 function windowsProcessStartTimeTicks(processId: number): string {
@@ -1305,6 +1349,271 @@ internal static class ExactNsisProbeParent {
         await settleWithin(gate.child).catch(() => undefined)
       }
       await stopGateMonitor(controlPath, monitor)
+      rmSync(root, { recursive: true, force: true })
+    }
+  }, 60_000)
+
+  windowsIt('accepts the real 8.3-path NSIS uninstaller helper process-check chain only after its identity-bound TEMP host is observed', async (context) => {
+    const root = mkdtempSync(join(tmpdir(), 'ai-novel-release-gate-nsis-uninstaller-'))
+    const controlPath = join(root, 'control.jsonl')
+    const statusPath = join(root, 'status.json')
+    const evidencePath = join(root, 'evidence')
+    const helperDirectory = join(tmpdir(), `~nsu${Date.now().toString(36)}${process.pid.toString(36)}.tmp`)
+    const helperPath = join(helperDirectory, 'Un_A9.exe')
+    const installRoot = join(root, 'installed-app')
+    const uninstallerPath = join(installRoot, 'Uninstall AI小说作家.exe')
+    const sourcePath = join(root, 'ExactNsisUninstallerHelper.cs')
+    const probeResultPath = join(root, 'probe-results.txt')
+    const systemPowerShell = join(
+      process.env.SystemRoot ?? 'C:\\Windows',
+      'System32',
+      'WindowsPowerShell',
+      'v1.0',
+      'powershell.exe',
+    )
+    const systemCmd = join(process.env.SystemRoot ?? 'C:\\Windows', 'System32', 'cmd.exe')
+    mkdirSync(helperDirectory, { recursive: true })
+    mkdirSync(installRoot, { recursive: true })
+    writeFileSync(sourcePath, String.raw`
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+
+internal static class ExactNsisUninstallerHelper {
+  [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+  private struct StartupInfo {
+    public int cb;
+    public string lpReserved;
+    public string lpDesktop;
+    public string lpTitle;
+    public int dwX;
+    public int dwY;
+    public int dwXSize;
+    public int dwYSize;
+    public int dwXCountChars;
+    public int dwYCountChars;
+    public int dwFillAttribute;
+    public int dwFlags;
+    public short wShowWindow;
+    public short cbReserved2;
+    public IntPtr lpReserved2;
+    public IntPtr hStdInput;
+    public IntPtr hStdOutput;
+    public IntPtr hStdError;
+  }
+
+  [StructLayout(LayoutKind.Sequential)]
+  private struct ProcessInformation {
+    public IntPtr hProcess;
+    public IntPtr hThread;
+    public uint dwProcessId;
+    public uint dwThreadId;
+  }
+
+  [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+  private static extern bool CreateProcess(
+    string applicationName,
+    StringBuilder commandLine,
+    IntPtr processAttributes,
+    IntPtr threadAttributes,
+    bool inheritHandles,
+    uint creationFlags,
+    IntPtr environment,
+    string currentDirectory,
+    ref StartupInfo startupInfo,
+    out ProcessInformation processInformation
+  );
+
+  [DllImport("kernel32.dll", SetLastError = true)]
+  private static extern uint WaitForSingleObject(IntPtr handle, uint milliseconds);
+
+  [DllImport("kernel32.dll", SetLastError = true)]
+  private static extern bool GetExitCodeProcess(IntPtr process, out uint exitCode);
+
+  [DllImport("kernel32.dll", SetLastError = true)]
+  private static extern bool CloseHandle(IntPtr handle);
+
+  private static int RunCommand(string executablePath, string commandLineValue) {
+    StartupInfo startupInfo = new StartupInfo();
+    startupInfo.cb = Marshal.SizeOf(startupInfo);
+    ProcessInformation processInformation;
+    StringBuilder commandLine = new StringBuilder(commandLineValue);
+    if (!CreateProcess(
+      executablePath,
+      commandLine,
+      IntPtr.Zero,
+      IntPtr.Zero,
+      false,
+      0x08000000,
+      IntPtr.Zero,
+      null,
+      ref startupInfo,
+      out processInformation
+    )) return -Marshal.GetLastWin32Error();
+    try {
+      if (WaitForSingleObject(processInformation.hProcess, 30000) != 0) return -9001;
+      uint exitCode;
+      if (!GetExitCodeProcess(processInformation.hProcess, out exitCode)) return -Marshal.GetLastWin32Error();
+      return unchecked((int)exitCode);
+    }
+    finally {
+      CloseHandle(processInformation.hThread);
+      CloseHandle(processInformation.hProcess);
+    }
+  }
+
+  private static string QuoteArgument(string value) {
+    return "\"" + value + "\"";
+  }
+
+  private static int RunHost(string helperPath, string powerShellPath, string cmdPath, string outputPath) {
+    ProcessStartInfo startInfo = new ProcessStartInfo();
+    startInfo.FileName = helperPath;
+    startInfo.Arguments = QuoteArgument(powerShellPath) + " " + QuoteArgument(cmdPath) + " " + QuoteArgument(outputPath);
+    startInfo.UseShellExecute = false;
+    startInfo.CreateNoWindow = true;
+    using (Process helper = Process.Start(startInfo)) {
+      helper.WaitForExit();
+      return helper.ExitCode;
+    }
+  }
+
+  private static int RunHelper(string powerShellPath, string cmdPath, string outputPath) {
+    string probePayload = "if ((Get-CimInstance -ClassName Win32_Process | ? {$_.Path -and $_.Path.StartsWith('C:\\ai-novel-release-probe-empty', 'CurrentCultureIgnoreCase')}).Count -gt 0) { exit 0 } else { exit 1 }";
+    string powerShellCommand = "\"" + powerShellPath + "\" -C \"" + probePayload + "\"";
+    string findPath = Path.Combine(Path.GetDirectoryName(cmdPath), "find.exe");
+    string cmdCommand =
+      "\"" + cmdPath + "\" /C tasklist /FI \"USERNAME eq %USERNAME%\" /FI \"IMAGENAME eq AI小说作家.exe\" /FO CSV | \"" +
+      findPath +
+      "\" \"AI小说作家.exe\"";
+    int powerShellExit = RunCommand(powerShellPath, powerShellCommand);
+    int cmdExit = RunCommand(cmdPath, cmdCommand);
+    File.WriteAllText(outputPath, powerShellExit + "," + cmdExit);
+    return 0;
+  }
+
+  public static int Main(string[] args) {
+    if (args.Length == 5 && String.Equals(args[0], "--host", StringComparison.Ordinal)) {
+      return RunHost(args[1], args[2], args[3], args[4]);
+    }
+    if (args.Length == 3) return RunHelper(args[0], args[1], args[2]);
+    return 64;
+  }
+}
+`, 'utf8')
+    execFileSync(
+      'powershell.exe',
+      [
+        '-NoProfile',
+        '-ExecutionPolicy',
+        'Bypass',
+        '-Command',
+        `Add-Type -Path ${quotePowerShell(sourcePath)} -OutputAssembly ${quotePowerShell(helperPath)} -OutputType ConsoleApplication`,
+      ],
+      { windowsHide: true, stdio: 'ignore' },
+    )
+    copyFileSync(helperPath, uninstallerPath)
+    const helperLaunchPath = windowsShortPath(helperPath)
+    if (
+      !helperLaunchPath
+      || helperLaunchPath.toLowerCase() === helperPath.toLowerCase()
+      || !helperLaunchPath.includes('~')
+    ) {
+      rmSync(helperDirectory, { recursive: true, force: true })
+      rmSync(root, { recursive: true, force: true })
+      context.skip('This filesystem does not expose a distinct 8.3 helper path; the 8.3-specific chain test is not applicable.')
+      return
+    }
+    const monitor = spawn(
+      'powershell.exe',
+      [
+        '-NoProfile',
+        '-ExecutionPolicy',
+        'Bypass',
+        '-File',
+        releaseMonitorScript,
+        '-ControlPath',
+        controlPath,
+        '-StatusPath',
+        statusPath,
+        '-EvidencePath',
+        evidencePath,
+      ],
+      { windowsHide: true, stdio: 'ignore' },
+    )
+    let gate: Awaited<ReturnType<typeof startArmedExecutable>> | undefined
+
+    try {
+      await waitForGateStatus(statusPath, 'ready')
+      gate = await startArmedExecutable(
+        root,
+        uninstallerPath,
+        ['--host', helperLaunchPath, systemPowerShell, systemCmd, probeResultPath],
+      )
+      if (gate.child.pid == null) throw new Error('The armed uninstaller gate did not expose a PID')
+      appendFileSync(
+        controlPath,
+        `${JSON.stringify({
+          sequence: 1,
+          state: 'running',
+          step: 'smoke:win-installer',
+          rootProcessId: gate.child.pid,
+          rootProcessStartTimeTicks: windowsProcessStartTimeTicks(gate.child.pid),
+          relatedTargetNames: ['Uninstall AI小说作家', 'Un_A9', 'powershell'],
+        })}\n`,
+        'utf8',
+      )
+      await waitForGateStatus(statusPath, 'monitoring')
+      writeFileSync(gate.releasePath, 'release', 'utf8')
+      expect(await settleWithin(gate.child, 30_000)).toEqual({ code: 0, signal: null })
+      expect(readFileSync(probeResultPath, 'utf8').split(',').map(Number)).toEqual([1, 1])
+
+      appendFileSync(
+        controlPath,
+        `${JSON.stringify({ sequence: 2, state: 'step-complete', step: 'smoke:win-installer' })}\n`,
+        'utf8',
+      )
+      await waitForGateStatus(statusPath, 'step-completed', 30_000)
+      const rawEvidence = readFileSync(join(evidencePath, 'process-events.jsonl'), 'utf8')
+      const events = rawEvidence.trim().split(/\r?\n/).filter(Boolean).map(line => JSON.parse(line) as Record<string, unknown>)
+      const expectedPowerShell = events.find(event => event.kind === 'process-exit'
+        && event.exitClassification === 'expected-nsis-powershell-probe')
+      const expectedCmd = events.find(event => event.kind === 'process-exit'
+        && event.exitClassification === 'expected-nsis-cmd-process-check')
+      const expectedFind = events.find(event => event.kind === 'process-exit'
+        && event.exitClassification === 'expected-nsis-find-no-match')
+      const helperStart = events.find(event => {
+        const identity = event.processIdentity as Record<string, unknown> | undefined
+        return event.kind === 'process-start' && identity?.processName === 'Un_A9'
+      })
+      const uninstallerStart = events.find(event => {
+        const identity = event.processIdentity as Record<string, unknown> | undefined
+        return event.kind === 'process-start' && identity?.processName === 'Uninstall AI小说作家'
+      })
+
+      expect(expectedPowerShell).toMatchObject({ exitCode: 1 })
+      expect(expectedCmd).toMatchObject({ exitCode: 1 })
+      expect(expectedFind).toMatchObject({ exitCode: 1 })
+      expect(helperStart).toBeDefined()
+      expect(uninstallerStart).toBeDefined()
+      expect(events.some(event => event.kind === 'process-exit' && event.exitClassification === 'failure')).toBe(false)
+      expect(rawEvidence).not.toContain('tasklist /FI')
+      expect(rawEvidence).not.toContain('Get-CimInstance')
+    } catch (error) {
+      const eventPath = join(evidencePath, 'process-events.jsonl')
+      const diagnostics = existsSync(eventPath)
+        ? readFileSync(eventPath, 'utf8').trim().split(/\r?\n/).slice(-30).join('\n')
+        : 'process-events.jsonl was not created'
+      throw new Error(`${String(error)}\nRecent redacted process events:\n${diagnostics}`)
+    } finally {
+      if (gate) {
+        gate.child.kill()
+        await settleWithin(gate.child).catch(() => undefined)
+      }
+      await stopGateMonitor(controlPath, monitor)
+      rmSync(helperDirectory, { recursive: true, force: true })
       rmSync(root, { recursive: true, force: true })
     }
   }, 60_000)

--- a/scripts/__tests__/smoke-win-installer.test.ts
+++ b/scripts/__tests__/smoke-win-installer.test.ts
@@ -1504,6 +1504,163 @@ $noFindFailsClosedAfterGrace = Test-AiNovelGateDeferredNsisCmdExitFailureReady -
     })
   })
 
+  windowsIt('accepts only the complete NSIS uninstaller helper chain for expected process-check exits', () => {
+    const output = runReleaseMonitorLibrary(`
+$powerShellPath = Join-Path $env:SystemRoot 'System32\\WindowsPowerShell\\v1.0\\powershell.exe'
+$cmdPath = Join-Path $env:SystemRoot 'System32\\cmd.exe'
+$findPath = Join-Path $env:SystemRoot 'System32\\find.exe'
+$tempRoot = [System.IO.Path]::GetTempPath()
+$helperPath = Join-Path (Join-Path $tempRoot '~nsuA9.tmp') 'Un_A9.exe'
+$nestedHelperPath = Join-Path (Join-Path (Join-Path $tempRoot '~nsuA9.tmp') 'nested') 'Un_A9.exe'
+$wrongFileHelperPath = Join-Path (Join-Path $tempRoot '~nsuA9.tmp') 'Un_A9-.exe'
+$uninstallerPath = 'C:\\temp\\installed-app\\Uninstall AI小说作家.exe'
+$armedRootPath = 'C:\\tools\\node.exe'
+$armedRoot = [pscustomobject]@{
+  processId = 699
+  startTimeTicks = '638899999999999900'
+  executablePath = $armedRootPath
+  identityCaptured = $true
+}
+$unrelatedArmedRoot = [pscustomobject]@{
+  processId = 698
+  startTimeTicks = '638899999999999800'
+  executablePath = $armedRootPath
+  identityCaptured = $true
+}
+$uninstallerStart = '638900000000000000'
+$uninstaller = [pscustomobject]@{
+  processId = 700
+  startTimeTicks = $uninstallerStart
+  executablePath = $uninstallerPath
+  identityCaptured = $true
+  parentProcessId = $armedRoot.processId
+  parentProcessStartTimeTicks = $armedRoot.startTimeTicks
+  parentExecutablePath = $armedRoot.executablePath
+}
+$helper = [pscustomobject]@{
+  processId = 701
+  startTimeTicks = '638900000000000100'
+  executablePath = $helperPath
+  identityCaptured = $true
+  parentProcessId = 700
+  parentProcessStartTimeTicks = $uninstallerStart
+  parentExecutablePath = $uninstallerPath
+}
+$availabilityCommand = '"' + $powerShellPath + '" -C "if (Get-Command Get-CimInstance -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }"'
+$cmdCommand = '"' + $cmdPath + '" /C tasklist /FI "USERNAME eq %USERNAME%" /FI "IMAGENAME eq AI小说作家.exe" /FO CSV | "' + $findPath + '" "AI小说作家.exe"'
+$findCommand = '"' + $findPath + '"  "AI小说作家.exe"'
+$powerShell = [pscustomobject]@{
+  processId = 702
+  startTimeTicks = '638900000000000200'
+  executablePath = $powerShellPath
+  commandLine = $availabilityCommand
+  commandLineCaptured = $true
+  identityCaptured = $true
+  parentProcessId = $helper.processId
+  parentProcessStartTimeTicks = $helper.startTimeTicks
+  parentExecutablePath = $helperPath
+}
+$cmd = [pscustomobject]@{
+  processId = 703
+  startTimeTicks = '638900000000000300'
+  executablePath = $cmdPath
+  commandLine = $cmdCommand
+  commandLineCaptured = $true
+  identityCaptured = $true
+  parentProcessId = $helper.processId
+  parentProcessStartTimeTicks = $helper.startTimeTicks
+  parentExecutablePath = $helperPath
+}
+$find = [pscustomobject]@{
+  processId = 704
+  startTimeTicks = '638900000000000400'
+  executablePath = $findPath
+  commandLine = $findCommand
+  commandLineCaptured = $true
+  identityCaptured = $true
+  parentProcessId = $cmd.processId
+  parentProcessStartTimeTicks = $cmd.startTimeTicks
+  parentExecutablePath = $cmdPath
+}
+$event = [pscustomobject]@{ ProcessId = 702; ExitCode = 1; ExitCodeCaptured = $true; JobMessage = 7 }
+$verifiedFindParentKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+[void]$verifiedFindParentKeys.Add((Get-AiNovelGateProcessIdentityKey -ProcessIdentity $cmd))
+$wrongNamedUninstaller = [pscustomobject]@{
+  processId = $uninstaller.processId
+  startTimeTicks = $uninstaller.startTimeTicks
+  executablePath = 'C:\\temp\\installed-app\\Uninstall other.exe'
+  identityCaptured = $true
+}
+$wrongNamedHelper = [pscustomobject]@{
+  processId = $helper.processId
+  startTimeTicks = $helper.startTimeTicks
+  executablePath = $helperPath
+  identityCaptured = $true
+  parentProcessId = $uninstaller.processId
+  parentProcessStartTimeTicks = $uninstaller.startTimeTicks
+  parentExecutablePath = $wrongNamedUninstaller.executablePath
+}
+$reusedUninstallerHelper = [pscustomobject]@{
+  processId = $helper.processId
+  startTimeTicks = $helper.startTimeTicks
+  executablePath = $helperPath
+  identityCaptured = $true
+  parentProcessId = $uninstaller.processId
+  parentProcessStartTimeTicks = '638899999999999999'
+  parentExecutablePath = $uninstaller.executablePath
+}
+$reusedHelperPowerShell = [pscustomobject]@{
+  processId = $powerShell.processId
+  startTimeTicks = $powerShell.startTimeTicks
+  executablePath = $powerShell.executablePath
+  commandLine = $powerShell.commandLine
+  commandLineCaptured = $true
+  identityCaptured = $true
+  parentProcessId = $helper.processId
+  parentProcessStartTimeTicks = '638899999999999998'
+  parentExecutablePath = $helper.executablePath
+}
+[pscustomobject]@{
+  HelperImage = Test-AiNovelGateNsisUninstallerHelperImage -ImagePath $helperPath
+  UninstallerParent = Test-AiNovelGateCapturedParentIdentity -ChildIdentity $uninstaller -ParentIdentity $armedRoot
+  HelperParent = Test-AiNovelGateCapturedNsisUninstallerHelperParent -HelperIdentity $helper -UninstallerIdentity $uninstaller -ArmedRootIdentity $armedRoot
+  PowerShellChain = Test-AiNovelGateExpectedNsisPowerShellProbeExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity $powerShell -ParentIdentity $helper -GrandParentIdentity $uninstaller -ArmedRootIdentity $armedRoot
+  CmdCandidateChain = Test-AiNovelGateNsisCmdProcessCheckCandidate -Step 'smoke:win-installer' -Event $event -ProcessIdentity $cmd -ParentIdentity $helper -GrandParentIdentity $uninstaller -ArmedRootIdentity $armedRoot
+  CmdVerifiedChain = Test-AiNovelGateExpectedNsisCmdProcessCheckExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity $cmd -ParentIdentity $helper -GrandParentIdentity $uninstaller -ArmedRootIdentity $armedRoot -VerifiedFindParentKeys $verifiedFindParentKeys
+  FindFourLevelChain = Test-AiNovelGateExpectedNsisFindNoMatchExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity $find -ParentIdentity $cmd -GrandParentIdentity $helper -GreatGrandParentIdentity $uninstaller -ArmedRootIdentity $armedRoot
+  SameNamedCompleteChainWrongArmedRoot = Test-AiNovelGateExpectedNsisPowerShellProbeExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity $powerShell -ParentIdentity $helper -GrandParentIdentity $uninstaller -ArmedRootIdentity $unrelatedArmedRoot
+  OtherStep = Test-AiNovelGateExpectedNsisPowerShellProbeExit -Step 'other-step' -Event $event -ProcessIdentity $powerShell -ParentIdentity $helper -GrandParentIdentity $uninstaller -ArmedRootIdentity $armedRoot
+  OrphanHelper = Test-AiNovelGateCapturedNsisUninstallerHelperParent -HelperIdentity $helper -UninstallerIdentity $null -ArmedRootIdentity $armedRoot
+  NestedHelperDirectory = Test-AiNovelGateNsisUninstallerHelperImage -ImagePath $nestedHelperPath
+  WrongHelperFile = Test-AiNovelGateNsisUninstallerHelperImage -ImagePath $wrongFileHelperPath
+  WrongUninstallerName = Test-AiNovelGateCapturedNsisUninstallerHelperParent -HelperIdentity $wrongNamedHelper -UninstallerIdentity $wrongNamedUninstaller -ArmedRootIdentity $armedRoot
+  ReusedUninstallerPid = Test-AiNovelGateCapturedNsisUninstallerHelperParent -HelperIdentity $reusedUninstallerHelper -UninstallerIdentity $uninstaller -ArmedRootIdentity $armedRoot
+  ReusedHelperPid = Test-AiNovelGateExpectedNsisPowerShellProbeExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity $reusedHelperPowerShell -ParentIdentity $helper -GrandParentIdentity $uninstaller -ArmedRootIdentity $armedRoot
+  FindWrongGreatGrandParent = Test-AiNovelGateExpectedNsisFindNoMatchExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity $find -ParentIdentity $cmd -GrandParentIdentity $helper -GreatGrandParentIdentity $wrongNamedUninstaller -ArmedRootIdentity $armedRoot
+} | ConvertTo-Json -Compress
+`)
+    const result = parseLastJsonLine(output)
+
+    expect(result).toEqual({
+      HelperImage: true,
+      UninstallerParent: true,
+      HelperParent: true,
+      PowerShellChain: true,
+      CmdCandidateChain: true,
+      CmdVerifiedChain: true,
+      FindFourLevelChain: true,
+      SameNamedCompleteChainWrongArmedRoot: false,
+      OtherStep: false,
+      OrphanHelper: false,
+      NestedHelperDirectory: false,
+      WrongHelperFile: false,
+      WrongUninstallerName: false,
+      ReusedUninstallerPid: false,
+      ReusedHelperPid: false,
+      FindWrongGreatGrandParent: false,
+    })
+  })
+
   windowsIt('keeps command-line secrets in memory and redacts them from process evidence', () => {
     const root = mkdtempSync(join(tmpdir(), 'ai-novel-release-evidence-redaction-'))
     const secret = 'super-secret-cli-token'

--- a/scripts/monitor-win-release-gate.ps1
+++ b/scripts/monitor-win-release-gate.ps1
@@ -79,6 +79,30 @@ namespace AiNovelReleaseGate {
     }
   }
 
+  // QueryFullProcessImageName can preserve an 8.3 alias such as
+  // C:\\Users\\RUNNER~1 even though the monitor's TEMP root uses the long
+  // profile name. Keep that translation narrowly available to the PowerShell
+  // classifier; a failed lookup deliberately leaves the classifier fail-closed.
+  public static class WindowsPath {
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern uint GetLongPathName(
+      string shortPath,
+      StringBuilder longPath,
+      uint cchBuffer
+    );
+
+    public static string TryGetLongPathName(string path) {
+      if (String.IsNullOrWhiteSpace(path)) return null;
+      uint required = GetLongPathName(path, null, 0);
+      if (required == 0) return null;
+      StringBuilder buffer = new StringBuilder(unchecked((int)required + 1));
+      uint written = GetLongPathName(path, buffer, unchecked((uint)buffer.Capacity));
+      if (written == 0 || written >= buffer.Capacity) return null;
+      return buffer.ToString();
+    }
+
+  }
+
   public sealed class JobProcessMonitor : IDisposable {
     private const int JobObjectAssociateCompletionPortInformation = 7;
     private const uint JobObjectMsgActiveProcessZero = 4;
@@ -865,6 +889,59 @@ function Initialize-AiNovelGateRootIdentity {
     -ExpectedStartTimeTicks $RootProcessStartTimeTicks
 }
 
+function Get-AiNovelGateArmedRootIdentity {
+  param(
+    [Parameter(Mandatory = $true)][int]$RootProcessId,
+    [Parameter(Mandatory = $true)][long]$RootProcessStartTimeTicks
+  )
+
+  # Capture the gate root once, while it is deliberately held before release.
+  # Child lifecycle records can later be consumed after that root has exited,
+  # so the uninstaller exception must retain this immutable PID/start/path
+  # identity instead of accepting a same-named helper chain from elsewhere in
+  # the Job Object.
+  if ($RootProcessStartTimeTicks -le 0) {
+    return $null
+  }
+  $process = $null
+  try {
+    $process = [System.Diagnostics.Process]::GetProcessById($RootProcessId)
+    $process.Refresh()
+    if ($process.HasExited) {
+      return $null
+    }
+    $actualStartTimeTicks = $process.StartTime.ToUniversalTime().Ticks
+    if ($actualStartTimeTicks -ne $RootProcessStartTimeTicks) {
+      return $null
+    }
+    $imagePath = [System.IO.Path]::GetFullPath([string]$process.MainModule.FileName)
+    if ([string]::IsNullOrWhiteSpace($imagePath) -or $imagePath -notmatch '^[A-Za-z]:\\') {
+      return $null
+    }
+    return [pscustomobject][ordered]@{
+      processId = $RootProcessId
+      startTimeTicks = [string]$actualStartTimeTicks
+      processName = [string]$process.ProcessName
+      executablePath = $imagePath
+      commandLine = $null
+      parentProcessId = $null
+      parentProcessStartTimeTicks = $null
+      parentExecutablePath = $null
+      identityCaptured = $true
+      commandLineCaptured = $false
+      identityCaptureError = $null
+    }
+  }
+  catch {
+    return $null
+  }
+  finally {
+    if ($null -ne $process) {
+      $process.Dispose()
+    }
+  }
+}
+
 function New-AiNovelGateQuietDeadline {
   param(
     [Parameter(Mandatory = $true)][DateTime]$NowUtc,
@@ -1150,6 +1227,105 @@ function Test-AiNovelGateSameAbsolutePath {
   }
 }
 
+function Resolve-AiNovelGateCanonicalExistingPath {
+  param([AllowEmptyString()][string]$Path)
+
+  if ([string]::IsNullOrWhiteSpace($Path) -or $Path -notmatch '^[A-Za-z]:\\') {
+    return $null
+  }
+  try {
+    $fullPath = [System.IO.Path]::GetFullPath($Path)
+    # Do not accept a path merely because its textual 8.3 spelling happens to
+    # resemble TEMP. When the file still exists (as the NSIS helper does while
+    # its probes run), expand the alias through kernel32. If expansion fails,
+    # retain the absolute spelling and let the strict TEMP containment test
+    # reject any unproven alias.
+    $longPath = [AiNovelReleaseGate.WindowsPath]::TryGetLongPathName($fullPath)
+    if (-not [string]::IsNullOrWhiteSpace($longPath)) {
+      return [System.IO.Path]::GetFullPath($longPath)
+    }
+    return $fullPath
+  }
+  catch {
+    return $null
+  }
+}
+
+function Test-AiNovelGateDirectChildDirectory {
+  param(
+    [AllowEmptyString()][string]$DirectoryPath,
+    [AllowEmptyString()][string]$RootPath
+  )
+
+  $directoryFullPath = Resolve-AiNovelGateCanonicalExistingPath -Path $DirectoryPath
+  $rootFullPath = Resolve-AiNovelGateCanonicalExistingPath -Path $RootPath
+  if (
+    [string]::IsNullOrWhiteSpace($directoryFullPath) -or
+    [string]::IsNullOrWhiteSpace($rootFullPath)
+  ) {
+    return $false
+  }
+  try {
+    $rootWithSeparator = $rootFullPath.TrimEnd([char]92) + [char]92
+    if (-not $directoryFullPath.StartsWith($rootWithSeparator, [System.StringComparison]::OrdinalIgnoreCase)) {
+      return $false
+    }
+    $relativeDirectory = $directoryFullPath.Substring($rootWithSeparator.Length)
+    return (
+      -not [string]::IsNullOrWhiteSpace($relativeDirectory) -and
+      $relativeDirectory.IndexOf([char]92) -lt 0
+    )
+  }
+  catch {
+    return $false
+  }
+}
+
+function Test-AiNovelGateNsisUninstallerImage {
+  param([AllowEmptyString()][string]$ImagePath)
+
+  if ([string]::IsNullOrWhiteSpace($ImagePath) -or $ImagePath -notmatch '^[A-Za-z]:\\') {
+    return $false
+  }
+  try {
+    return [string]::Equals(
+      [System.IO.Path]::GetFileName([System.IO.Path]::GetFullPath($ImagePath)),
+      'Uninstall AI小说作家.exe',
+      [System.StringComparison]::OrdinalIgnoreCase
+    )
+  }
+  catch {
+    return $false
+  }
+}
+
+function Test-AiNovelGateNsisUninstallerHelperImage {
+  param([AllowEmptyString()][string]$ImagePath)
+
+  if ([string]::IsNullOrWhiteSpace($ImagePath) -or $ImagePath -notmatch '^[A-Za-z]:\\') {
+    return $false
+  }
+  try {
+    $helperFullPath = Resolve-AiNovelGateCanonicalExistingPath -Path $ImagePath
+    if ([string]::IsNullOrWhiteSpace($helperFullPath)) {
+      return $false
+    }
+    $helperDirectory = [System.IO.Path]::GetDirectoryName($helperFullPath)
+    $helperFileName = [System.IO.Path]::GetFileName($helperFullPath)
+    $helperDirectoryName = [System.IO.Path]::GetFileName($helperDirectory)
+    return (
+      (Test-AiNovelGateDirectChildDirectory `
+        -DirectoryPath $helperDirectory `
+        -RootPath ([System.IO.Path]::GetTempPath())) -and
+      $helperDirectoryName -match '^(?i:~nsu[A-Za-z0-9]+\.tmp)$' -and
+      $helperFileName -match '^(?i:Un_[A-Za-z0-9]+\.exe)$'
+    )
+  }
+  catch {
+    return $false
+  }
+}
+
 function Test-AiNovelGateSameBoundSystemExecutablePath {
   param(
     [AllowEmptyString()][string]$Left,
@@ -1376,6 +1552,59 @@ function Test-AiNovelGateCapturedInstallerParent {
   )
 }
 
+function Test-AiNovelGateCapturedNsisUninstallerHelperParent {
+  param(
+    [AllowNull()]$HelperIdentity,
+    [AllowNull()]$UninstallerIdentity,
+    [AllowNull()]$ArmedRootIdentity
+  )
+
+  # electron-builder's NSIS uninstaller first copies itself into the current
+  # TEMP root (~nsu*.tmp\Un_*.exe), then runs its process-exit checks from that
+  # helper. This is intentionally a fixed product chain, not a basename-based
+  # exemption for arbitrary temporary executables.
+  return (
+    (Test-AiNovelGateNsisUninstallerHelperImage -ImagePath ([string]$HelperIdentity.executablePath)) -and
+    (Test-AiNovelGateCapturedParentIdentity `
+      -ChildIdentity $HelperIdentity `
+      -ParentIdentity $UninstallerIdentity) -and
+    (Test-AiNovelGateNsisUninstallerImage -ImagePath ([string]$UninstallerIdentity.executablePath)) -and
+    # The named uninstaller is a child of the armed Node release-gate root;
+    # it is not itself that root. Bind this final edge to reject an unrelated
+    # same-named NSIS chain that happens to be inside the Job Object.
+    (Test-AiNovelGateCapturedParentIdentity `
+      -ChildIdentity $UninstallerIdentity `
+      -ParentIdentity $ArmedRootIdentity)
+  )
+}
+
+function Test-AiNovelGateCapturedNsisProbeParent {
+  param(
+    [AllowNull()]$ChildIdentity,
+    [AllowNull()]$ParentIdentity,
+    [AllowNull()]$GrandParentIdentity,
+    [AllowNull()]$ArmedRootIdentity
+  )
+
+  # Keep the original direct-installer check intact. The only additional
+  # branch is the complete helper -> named uninstaller -> armed gate-root
+  # chain, with every edge bound by PID, creation time, and absolute image
+  # path. The direct installer branch deliberately retains its original
+  # classification semantics.
+  return (
+    (Test-AiNovelGateCapturedInstallerParent `
+      -ChildIdentity $ChildIdentity `
+      -ParentIdentity $ParentIdentity) -or
+    ((Test-AiNovelGateCapturedNsisUninstallerHelperParent `
+        -HelperIdentity $ParentIdentity `
+        -UninstallerIdentity $GrandParentIdentity `
+        -ArmedRootIdentity $ArmedRootIdentity) -and
+      (Test-AiNovelGateCapturedParentIdentity `
+        -ChildIdentity $ChildIdentity `
+        -ParentIdentity $ParentIdentity))
+  )
+}
+
 function Get-AiNovelGateProcessIdentityKey {
   param([AllowNull()]$ProcessIdentity)
 
@@ -1411,7 +1640,9 @@ function Test-AiNovelGateExpectedNsisPowerShellProbeExit {
     [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Step,
     [Parameter(Mandatory = $true)]$Event,
     [AllowNull()]$ProcessIdentity,
-    [AllowNull()]$ParentIdentity
+    [AllowNull()]$ParentIdentity,
+    [AllowNull()]$GrandParentIdentity,
+    [AllowNull()]$ArmedRootIdentity
   )
 
   # electron-builder's NSIS template deliberately treats exit 1 from these
@@ -1437,9 +1668,11 @@ function Test-AiNovelGateExpectedNsisPowerShellProbeExit {
     -PowerShellImagePath ([string]$ProcessIdentity.executablePath))) {
     return $false
   }
-  return Test-AiNovelGateCapturedInstallerParent `
+  return Test-AiNovelGateCapturedNsisProbeParent `
     -ChildIdentity $ProcessIdentity `
-    -ParentIdentity $ParentIdentity
+    -ParentIdentity $ParentIdentity `
+    -GrandParentIdentity $GrandParentIdentity `
+    -ArmedRootIdentity $ArmedRootIdentity
 }
 
 function Test-AiNovelGateNsisCmdProcessCheckCandidate {
@@ -1447,7 +1680,9 @@ function Test-AiNovelGateNsisCmdProcessCheckCandidate {
     [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Step,
     [Parameter(Mandatory = $true)]$Event,
     [AllowNull()]$ProcessIdentity,
-    [AllowNull()]$ParentIdentity
+    [AllowNull()]$ParentIdentity,
+    [AllowNull()]$GrandParentIdentity,
+    [AllowNull()]$ArmedRootIdentity
   )
 
   if (-not (Test-AiNovelGateExpectedExitOne -Step $Step -Event $Event)) {
@@ -1466,9 +1701,11 @@ function Test-AiNovelGateNsisCmdProcessCheckCandidate {
   ) {
     return $false
   }
-  return Test-AiNovelGateCapturedInstallerParent `
+  return Test-AiNovelGateCapturedNsisProbeParent `
     -ChildIdentity $ProcessIdentity `
-    -ParentIdentity $ParentIdentity
+    -ParentIdentity $ParentIdentity `
+    -GrandParentIdentity $GrandParentIdentity `
+    -ArmedRootIdentity $ArmedRootIdentity
 }
 
 function Test-AiNovelGateExpectedNsisCmdProcessCheckExit {
@@ -1477,6 +1714,8 @@ function Test-AiNovelGateExpectedNsisCmdProcessCheckExit {
     [Parameter(Mandatory = $true)]$Event,
     [AllowNull()]$ProcessIdentity,
     [AllowNull()]$ParentIdentity,
+    [AllowNull()]$GrandParentIdentity,
+    [AllowNull()]$ArmedRootIdentity,
     [AllowNull()]$VerifiedFindParentKeys
   )
 
@@ -1484,7 +1723,9 @@ function Test-AiNovelGateExpectedNsisCmdProcessCheckExit {
     -Step $Step `
     -Event $Event `
     -ProcessIdentity $ProcessIdentity `
-    -ParentIdentity $ParentIdentity)) {
+    -ParentIdentity $ParentIdentity `
+    -GrandParentIdentity $GrandParentIdentity `
+    -ArmedRootIdentity $ArmedRootIdentity)) {
     return $false
   }
   $processIdentityKey = Get-AiNovelGateProcessIdentityKey -ProcessIdentity $ProcessIdentity
@@ -1672,7 +1913,9 @@ function Test-AiNovelGateExpectedNsisFindNoMatchExit {
     [Parameter(Mandatory = $true)]$Event,
     [AllowNull()]$ProcessIdentity,
     [AllowNull()]$ParentIdentity,
-    [AllowNull()]$GrandParentIdentity
+    [AllowNull()]$GrandParentIdentity,
+    [AllowNull()]$GreatGrandParentIdentity,
+    [AllowNull()]$ArmedRootIdentity
   )
 
   if (-not (Test-AiNovelGateExpectedExitOne -Step $Step -Event $Event)) {
@@ -1702,9 +1945,11 @@ function Test-AiNovelGateExpectedNsisFindNoMatchExit {
   ) {
     return $false
   }
-  return Test-AiNovelGateCapturedInstallerParent `
+  return Test-AiNovelGateCapturedNsisProbeParent `
     -ChildIdentity $ParentIdentity `
-    -ParentIdentity $GrandParentIdentity
+    -ParentIdentity $GrandParentIdentity `
+    -GrandParentIdentity $GreatGrandParentIdentity `
+    -ArmedRootIdentity $ArmedRootIdentity
 }
 
 function ConvertTo-AiNovelGateProcessEvidenceIdentity {
@@ -1852,6 +2097,7 @@ $atomicMonitor = $null
 $deferredProcessFailure = $null
 $deferredProcessFailureDeadline = $null
 $deferredNsisCmdExitFailure = New-AiNovelGateDeferredNsisCmdExitFailureState
+$armedRootIdentity = $null
 $verifiedNsisFindParentKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
 $pendingNsisCmdExitFailures = @{}
 $drainSequence = 0
@@ -1928,6 +2174,7 @@ try {
         $deferredProcessFailure = $null
         $deferredProcessFailureDeadline = $null
         Clear-AiNovelGateDeferredNsisCmdExitFailureState -State $deferredNsisCmdExitFailure
+        $armedRootIdentity = $null
         $verifiedNsisFindParentKeys.Clear()
         $pendingNsisCmdExitFailures.Clear()
         $rootIdentityAccepted = Initialize-AiNovelGateRootIdentity `
@@ -1937,6 +2184,12 @@ try {
           -ProcessStartTimeTicks $trackedProcessStartTimeTicks
         if (-not $rootIdentityAccepted) {
           throw "Release gate rejected missing, exited, or reused root process identity for step '$activeStep'."
+        }
+        $armedRootIdentity = Get-AiNovelGateArmedRootIdentity `
+          -RootProcessId ([int]$control.rootProcessId) `
+          -RootProcessStartTimeTicks ([long]$control.rootProcessStartTimeTicks)
+        if ($null -eq $armedRootIdentity) {
+          throw "Release gate could not capture the immutable PID/start/path identity for root process $($control.rootProcessId) in step '$activeStep'."
         }
         try {
           # The launcher is deliberately held at its gate. Assigning it to the
@@ -1975,6 +2228,7 @@ try {
         $deferredProcessFailure = $null
         $deferredProcessFailureDeadline = $null
         Clear-AiNovelGateDeferredNsisCmdExitFailureState -State $deferredNsisCmdExitFailure
+        $armedRootIdentity = $null
         $verifiedNsisFindParentKeys.Clear()
         $pendingNsisCmdExitFailures.Clear()
         $completionDeadline = $null
@@ -2042,6 +2296,7 @@ try {
         }
         $parentIdentity = $null
         $grandParentIdentity = $null
+        $greatGrandParentIdentity = $null
         try {
           if (
             $null -ne $processIdentity -and
@@ -2054,6 +2309,12 @@ try {
               $trackedProcessIdentities.ContainsKey([int]$parentIdentity.parentProcessId)
             ) {
               $grandParentIdentity = $trackedProcessIdentities[[int]$parentIdentity.parentProcessId]
+              if (
+                $null -ne $grandParentIdentity.parentProcessId -and
+                $trackedProcessIdentities.ContainsKey([int]$grandParentIdentity.parentProcessId)
+              ) {
+                $greatGrandParentIdentity = $trackedProcessIdentities[[int]$grandParentIdentity.parentProcessId]
+              }
             }
           }
         }
@@ -2068,7 +2329,9 @@ try {
           -Step $activeStep `
           -Event $processEvent `
           -ProcessIdentity $processIdentity `
-          -ParentIdentity $parentIdentity) {
+          -ParentIdentity $parentIdentity `
+          -GrandParentIdentity $grandParentIdentity `
+          -ArmedRootIdentity $armedRootIdentity) {
           $exitClassification = 'expected-nsis-powershell-probe'
         }
         elseif (Test-AiNovelGateExpectedNsisFindNoMatchExit `
@@ -2076,7 +2339,9 @@ try {
           -Event $processEvent `
           -ProcessIdentity $processIdentity `
           -ParentIdentity $parentIdentity `
-          -GrandParentIdentity $grandParentIdentity) {
+          -GrandParentIdentity $grandParentIdentity `
+          -GreatGrandParentIdentity $greatGrandParentIdentity `
+          -ArmedRootIdentity $armedRootIdentity) {
           $parentProcessIdentityKey = Get-AiNovelGateProcessIdentityKey -ProcessIdentity $parentIdentity
           if ($null -eq $parentProcessIdentityKey) {
             $exitClassification = 'failure'
@@ -2096,6 +2361,8 @@ try {
           -Event $processEvent `
           -ProcessIdentity $processIdentity `
           -ParentIdentity $parentIdentity `
+          -GrandParentIdentity $grandParentIdentity `
+          -ArmedRootIdentity $armedRootIdentity `
           -VerifiedFindParentKeys $verifiedNsisFindParentKeys) {
           $exitClassification = 'expected-nsis-cmd-process-check'
         }
@@ -2103,7 +2370,9 @@ try {
           -Step $activeStep `
           -Event $processEvent `
           -ProcessIdentity $processIdentity `
-          -ParentIdentity $parentIdentity) {
+          -ParentIdentity $parentIdentity `
+          -GrandParentIdentity $grandParentIdentity `
+          -ArmedRootIdentity $armedRootIdentity) {
           $processIdentityKey = Get-AiNovelGateProcessIdentityKey -ProcessIdentity $processIdentity
           if (Add-AiNovelGatePendingNsisCmdExitFailure `
             -PendingNsisCmdExitFailures $pendingNsisCmdExitFailures `


### PR DESCRIPTION
Closes the final cloud acceptance false positive seen in run 30214793538. The release gate now accepts only the complete identity-bound chain from the armed launch root through the product uninstaller and its restricted TEMP helper to the exact NSIS PowerShell/cmd/find probes. Same-named chains from another root remain fail-closed. Direct installer semantics are unchanged.

Verification: 142 test files / 798 tests, focused 71/71, typecheck, lint, PowerShell parser, diff check, and independent frozen Standards/Spec review all pass.