### PR TITLE
fix: bind NSIS probes through launch ancestry

### DIFF
--- a/electron/__tests__/package-contract.test.ts
+++ b/electron/__tests__/package-contract.test.ts
@@ -176,7 +176,7 @@ describe('release dependency contract', () => {
 
     expect(
       createHash('sha256').update(releaseMonitor).digest('hex'),
-    ).toBe('91eda5acad927a36d5053c33dc8a066c7f575424a8ff3a6d3e55c157a7f6a1a5')
+    ).toBe('c0bfaa9efe640442812bef8ab5bfb9b613aea4bd50e0c3ede3686910ef281858')
   })
 
   it('blocks direct Windows artifact builds outside the release gate', () => {

--- a/scripts/__tests__/release-win-verify.test.ts
+++ b/scripts/__tests__/release-win-verify.test.ts
@@ -13,6 +13,11 @@ function quotePowerShell(value: string): string {
   return `'${value.replaceAll("'", "''")}'`
 }
 
+function sameWindowsPath(left: unknown, right: string): boolean {
+  return typeof left === 'string'
+    && left.replaceAll('/', '\\').toLowerCase() === right.replaceAll('/', '\\').toLowerCase()
+}
+
 const windowsShortPathFixtureSource = String.raw`
 using System;
 using System.Runtime.InteropServices;
@@ -1526,6 +1531,13 @@ internal static class ExactNsisUninstallerHelper {
       context.skip('This filesystem does not expose a distinct 8.3 helper path; the 8.3-specific chain test is not applicable.')
       return
     }
+    const wrapperEncodedCommand = Buffer.from(
+      [
+        `& ${quotePowerShell(uninstallerPath)} '--host' ${quotePowerShell(helperLaunchPath)} ${quotePowerShell(systemPowerShell)} ${quotePowerShell(systemCmd)} ${quotePowerShell(probeResultPath)}`,
+        'exit $LASTEXITCODE',
+      ].join('\r\n'),
+      'utf16le',
+    ).toString('base64')
     const monitor = spawn(
       'powershell.exe',
       [
@@ -1549,8 +1561,12 @@ internal static class ExactNsisUninstallerHelper {
       await waitForGateStatus(statusPath, 'ready')
       gate = await startArmedExecutable(
         root,
-        uninstallerPath,
-        ['--host', helperLaunchPath, systemPowerShell, systemCmd, probeResultPath],
+        systemCmd,
+        [
+          '/D',
+          '/C',
+          `powershell.exe -NoProfile -ExecutionPolicy Bypass -EncodedCommand ${wrapperEncodedCommand}`,
+        ],
       )
       if (gate.child.pid == null) throw new Error('The armed uninstaller gate did not expose a PID')
       appendFileSync(
@@ -1592,12 +1608,30 @@ internal static class ExactNsisUninstallerHelper {
         const identity = event.processIdentity as Record<string, unknown> | undefined
         return event.kind === 'process-start' && identity?.processName === 'Uninstall AI小说作家'
       })
+      const wrapperCmdStart = events.find(event => {
+        const identity = event.processIdentity as Record<string, unknown> | undefined
+        return event.kind === 'process-start'
+          && sameWindowsPath(identity?.executablePath, systemCmd)
+          && identity?.parentProcessId === gate?.child.pid
+      })
+      const wrapperCmdIdentity = wrapperCmdStart?.processIdentity as Record<string, unknown> | undefined
+      const wrapperPowerShellStart = events.find(event => {
+        const identity = event.processIdentity as Record<string, unknown> | undefined
+        return event.kind === 'process-start'
+          && sameWindowsPath(identity?.executablePath, systemPowerShell)
+          && identity?.parentProcessId === wrapperCmdIdentity?.processId
+      })
+      const wrapperPowerShellIdentity = wrapperPowerShellStart?.processIdentity as Record<string, unknown> | undefined
+      const uninstallerIdentity = uninstallerStart?.processIdentity as Record<string, unknown> | undefined
 
       expect(expectedPowerShell).toMatchObject({ exitCode: 1 })
       expect(expectedCmd).toMatchObject({ exitCode: 1 })
       expect(expectedFind).toMatchObject({ exitCode: 1 })
+      expect(wrapperCmdStart).toBeDefined()
+      expect(wrapperPowerShellStart).toBeDefined()
       expect(helperStart).toBeDefined()
       expect(uninstallerStart).toBeDefined()
+      expect(uninstallerIdentity?.parentProcessId).toBe(wrapperPowerShellIdentity?.processId)
       expect(events.some(event => event.kind === 'process-exit' && event.exitClassification === 'failure')).toBe(false)
       expect(rawEvidence).not.toContain('tasklist /FI')
       expect(rawEvidence).not.toContain('Get-CimInstance')

--- a/scripts/__tests__/smoke-win-installer.test.ts
+++ b/scripts/__tests__/smoke-win-installer.test.ts
@@ -1527,22 +1527,40 @@ $unrelatedArmedRoot = [pscustomobject]@{
   executablePath = $armedRootPath
   identityCaptured = $true
 }
-$uninstallerStart = '638900000000000000'
-$uninstaller = [pscustomobject]@{
+$wrapperCmd = [pscustomobject]@{
   processId = 700
-  startTimeTicks = $uninstallerStart
-  executablePath = $uninstallerPath
+  startTimeTicks = '638900000000000000'
+  executablePath = $cmdPath
   identityCaptured = $true
   parentProcessId = $armedRoot.processId
   parentProcessStartTimeTicks = $armedRoot.startTimeTicks
   parentExecutablePath = $armedRoot.executablePath
 }
-$helper = [pscustomobject]@{
+$wrapperPowerShell = [pscustomobject]@{
   processId = 701
-  startTimeTicks = '638900000000000100'
+  startTimeTicks = '638900000000000050'
+  executablePath = $powerShellPath
+  identityCaptured = $true
+  parentProcessId = $wrapperCmd.processId
+  parentProcessStartTimeTicks = $wrapperCmd.startTimeTicks
+  parentExecutablePath = $wrapperCmd.executablePath
+}
+$uninstallerStart = '638900000000000100'
+$uninstaller = [pscustomobject]@{
+  processId = 702
+  startTimeTicks = $uninstallerStart
+  executablePath = $uninstallerPath
+  identityCaptured = $true
+  parentProcessId = $wrapperPowerShell.processId
+  parentProcessStartTimeTicks = $wrapperPowerShell.startTimeTicks
+  parentExecutablePath = $wrapperPowerShell.executablePath
+}
+$helper = [pscustomobject]@{
+  processId = 703
+  startTimeTicks = '638900000000000200'
   executablePath = $helperPath
   identityCaptured = $true
-  parentProcessId = 700
+  parentProcessId = $uninstaller.processId
   parentProcessStartTimeTicks = $uninstallerStart
   parentExecutablePath = $uninstallerPath
 }
@@ -1550,8 +1568,8 @@ $availabilityCommand = '"' + $powerShellPath + '" -C "if (Get-Command Get-CimIns
 $cmdCommand = '"' + $cmdPath + '" /C tasklist /FI "USERNAME eq %USERNAME%" /FI "IMAGENAME eq AI小说作家.exe" /FO CSV | "' + $findPath + '" "AI小说作家.exe"'
 $findCommand = '"' + $findPath + '"  "AI小说作家.exe"'
 $powerShell = [pscustomobject]@{
-  processId = 702
-  startTimeTicks = '638900000000000200'
+  processId = 704
+  startTimeTicks = '638900000000000300'
   executablePath = $powerShellPath
   commandLine = $availabilityCommand
   commandLineCaptured = $true
@@ -1561,8 +1579,8 @@ $powerShell = [pscustomobject]@{
   parentExecutablePath = $helperPath
 }
 $cmd = [pscustomobject]@{
-  processId = 703
-  startTimeTicks = '638900000000000300'
+  processId = 705
+  startTimeTicks = '638900000000000400'
   executablePath = $cmdPath
   commandLine = $cmdCommand
   commandLineCaptured = $true
@@ -1572,8 +1590,8 @@ $cmd = [pscustomobject]@{
   parentExecutablePath = $helperPath
 }
 $find = [pscustomobject]@{
-  processId = 704
-  startTimeTicks = '638900000000000400'
+  processId = 706
+  startTimeTicks = '638900000000000500'
   executablePath = $findPath
   commandLine = $findCommand
   commandLineCaptured = $true
@@ -1582,7 +1600,10 @@ $find = [pscustomobject]@{
   parentProcessStartTimeTicks = $cmd.startTimeTicks
   parentExecutablePath = $cmdPath
 }
-$event = [pscustomobject]@{ ProcessId = 702; ExitCode = 1; ExitCodeCaptured = $true; JobMessage = 7 }
+$trackedProcessIdentities = @{}
+$trackedProcessIdentities[[int]$wrapperCmd.processId] = $wrapperCmd
+$trackedProcessIdentities[[int]$wrapperPowerShell.processId] = $wrapperPowerShell
+$event = [pscustomobject]@{ ProcessId = $powerShell.processId; ExitCode = 1; ExitCodeCaptured = $true; JobMessage = 7 }
 $verifiedFindParentKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
 [void]$verifiedFindParentKeys.Add((Get-AiNovelGateProcessIdentityKey -ProcessIdentity $cmd))
 $wrongNamedUninstaller = [pscustomobject]@{
@@ -1620,36 +1641,70 @@ $reusedHelperPowerShell = [pscustomobject]@{
   parentProcessStartTimeTicks = '638899999999999998'
   parentExecutablePath = $helper.executablePath
 }
+$missingWrapperTracked = @{}
+$missingWrapperTracked[[int]$wrapperCmd.processId] = $wrapperCmd
+$reusedWrapperCmd = [pscustomobject]@{
+  processId = $wrapperCmd.processId
+  startTimeTicks = '638899999999999998'
+  executablePath = $wrapperCmd.executablePath
+  identityCaptured = $true
+  parentProcessId = $armedRoot.processId
+  parentProcessStartTimeTicks = $armedRoot.startTimeTicks
+  parentExecutablePath = $armedRoot.executablePath
+}
+$reusedWrapperTracked = @{}
+$reusedWrapperTracked[[int]$wrapperCmd.processId] = $reusedWrapperCmd
+$reusedWrapperTracked[[int]$wrapperPowerShell.processId] = $wrapperPowerShell
+$cycleCmd = [pscustomobject]@{
+  processId = $wrapperCmd.processId
+  startTimeTicks = $wrapperCmd.startTimeTicks
+  executablePath = $wrapperCmd.executablePath
+  identityCaptured = $true
+  parentProcessId = $wrapperPowerShell.processId
+  parentProcessStartTimeTicks = $wrapperPowerShell.startTimeTicks
+  parentExecutablePath = $wrapperPowerShell.executablePath
+}
+$cycleTracked = @{}
+$cycleTracked[[int]$wrapperCmd.processId] = $cycleCmd
+$cycleTracked[[int]$wrapperPowerShell.processId] = $wrapperPowerShell
 [pscustomobject]@{
   HelperImage = Test-AiNovelGateNsisUninstallerHelperImage -ImagePath $helperPath
-  UninstallerParent = Test-AiNovelGateCapturedParentIdentity -ChildIdentity $uninstaller -ParentIdentity $armedRoot
-  HelperParent = Test-AiNovelGateCapturedNsisUninstallerHelperParent -HelperIdentity $helper -UninstallerIdentity $uninstaller -ArmedRootIdentity $armedRoot
-  PowerShellChain = Test-AiNovelGateExpectedNsisPowerShellProbeExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity $powerShell -ParentIdentity $helper -GrandParentIdentity $uninstaller -ArmedRootIdentity $armedRoot
-  CmdCandidateChain = Test-AiNovelGateNsisCmdProcessCheckCandidate -Step 'smoke:win-installer' -Event $event -ProcessIdentity $cmd -ParentIdentity $helper -GrandParentIdentity $uninstaller -ArmedRootIdentity $armedRoot
-  CmdVerifiedChain = Test-AiNovelGateExpectedNsisCmdProcessCheckExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity $cmd -ParentIdentity $helper -GrandParentIdentity $uninstaller -ArmedRootIdentity $armedRoot -VerifiedFindParentKeys $verifiedFindParentKeys
-  FindFourLevelChain = Test-AiNovelGateExpectedNsisFindNoMatchExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity $find -ParentIdentity $cmd -GrandParentIdentity $helper -GreatGrandParentIdentity $uninstaller -ArmedRootIdentity $armedRoot
-  SameNamedCompleteChainWrongArmedRoot = Test-AiNovelGateExpectedNsisPowerShellProbeExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity $powerShell -ParentIdentity $helper -GrandParentIdentity $uninstaller -ArmedRootIdentity $unrelatedArmedRoot
-  OtherStep = Test-AiNovelGateExpectedNsisPowerShellProbeExit -Step 'other-step' -Event $event -ProcessIdentity $powerShell -ParentIdentity $helper -GrandParentIdentity $uninstaller -ArmedRootIdentity $armedRoot
-  OrphanHelper = Test-AiNovelGateCapturedNsisUninstallerHelperParent -HelperIdentity $helper -UninstallerIdentity $null -ArmedRootIdentity $armedRoot
+  UninstallerAncestry = Test-AiNovelGateIdentityAncestryToArmedRoot -StartIdentity $uninstaller -TrackedProcessIdentities $trackedProcessIdentities -ArmedRootIdentity $armedRoot
+  HelperParent = Test-AiNovelGateCapturedNsisUninstallerHelperParent -HelperIdentity $helper -UninstallerIdentity $uninstaller -ArmedRootIdentity $armedRoot -TrackedProcessIdentities $trackedProcessIdentities
+  PowerShellChain = Test-AiNovelGateExpectedNsisPowerShellProbeExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity $powerShell -ParentIdentity $helper -GrandParentIdentity $uninstaller -ArmedRootIdentity $armedRoot -TrackedProcessIdentities $trackedProcessIdentities
+  CmdCandidateChain = Test-AiNovelGateNsisCmdProcessCheckCandidate -Step 'smoke:win-installer' -Event $event -ProcessIdentity $cmd -ParentIdentity $helper -GrandParentIdentity $uninstaller -ArmedRootIdentity $armedRoot -TrackedProcessIdentities $trackedProcessIdentities
+  CmdVerifiedChain = Test-AiNovelGateExpectedNsisCmdProcessCheckExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity $cmd -ParentIdentity $helper -GrandParentIdentity $uninstaller -ArmedRootIdentity $armedRoot -TrackedProcessIdentities $trackedProcessIdentities -VerifiedFindParentKeys $verifiedFindParentKeys
+  FindFourLevelChain = Test-AiNovelGateExpectedNsisFindNoMatchExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity $find -ParentIdentity $cmd -GrandParentIdentity $helper -GreatGrandParentIdentity $uninstaller -ArmedRootIdentity $armedRoot -TrackedProcessIdentities $trackedProcessIdentities
+  SameNamedCompleteChainWrongArmedRoot = Test-AiNovelGateExpectedNsisPowerShellProbeExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity $powerShell -ParentIdentity $helper -GrandParentIdentity $uninstaller -ArmedRootIdentity $unrelatedArmedRoot -TrackedProcessIdentities $trackedProcessIdentities
+  MissingWrapperRecord = Test-AiNovelGateIdentityAncestryToArmedRoot -StartIdentity $uninstaller -TrackedProcessIdentities $missingWrapperTracked -ArmedRootIdentity $armedRoot
+  ReusedWrapperPid = Test-AiNovelGateIdentityAncestryToArmedRoot -StartIdentity $uninstaller -TrackedProcessIdentities $reusedWrapperTracked -ArmedRootIdentity $armedRoot
+  CycleFailsClosed = Test-AiNovelGateIdentityAncestryToArmedRoot -StartIdentity $uninstaller -TrackedProcessIdentities $cycleTracked -ArmedRootIdentity $armedRoot
+  DepthFailsClosed = Test-AiNovelGateIdentityAncestryToArmedRoot -StartIdentity $uninstaller -TrackedProcessIdentities $trackedProcessIdentities -ArmedRootIdentity $armedRoot -MaxDepth 2
+  OtherStep = Test-AiNovelGateExpectedNsisPowerShellProbeExit -Step 'other-step' -Event $event -ProcessIdentity $powerShell -ParentIdentity $helper -GrandParentIdentity $uninstaller -ArmedRootIdentity $armedRoot -TrackedProcessIdentities $trackedProcessIdentities
+  OrphanHelper = Test-AiNovelGateCapturedNsisUninstallerHelperParent -HelperIdentity $helper -UninstallerIdentity $null -ArmedRootIdentity $armedRoot -TrackedProcessIdentities $trackedProcessIdentities
   NestedHelperDirectory = Test-AiNovelGateNsisUninstallerHelperImage -ImagePath $nestedHelperPath
   WrongHelperFile = Test-AiNovelGateNsisUninstallerHelperImage -ImagePath $wrongFileHelperPath
-  WrongUninstallerName = Test-AiNovelGateCapturedNsisUninstallerHelperParent -HelperIdentity $wrongNamedHelper -UninstallerIdentity $wrongNamedUninstaller -ArmedRootIdentity $armedRoot
-  ReusedUninstallerPid = Test-AiNovelGateCapturedNsisUninstallerHelperParent -HelperIdentity $reusedUninstallerHelper -UninstallerIdentity $uninstaller -ArmedRootIdentity $armedRoot
-  ReusedHelperPid = Test-AiNovelGateExpectedNsisPowerShellProbeExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity $reusedHelperPowerShell -ParentIdentity $helper -GrandParentIdentity $uninstaller -ArmedRootIdentity $armedRoot
-  FindWrongGreatGrandParent = Test-AiNovelGateExpectedNsisFindNoMatchExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity $find -ParentIdentity $cmd -GrandParentIdentity $helper -GreatGrandParentIdentity $wrongNamedUninstaller -ArmedRootIdentity $armedRoot
+  WrongUninstallerName = Test-AiNovelGateCapturedNsisUninstallerHelperParent -HelperIdentity $wrongNamedHelper -UninstallerIdentity $wrongNamedUninstaller -ArmedRootIdentity $armedRoot -TrackedProcessIdentities $trackedProcessIdentities
+  ReusedUninstallerPid = Test-AiNovelGateCapturedNsisUninstallerHelperParent -HelperIdentity $reusedUninstallerHelper -UninstallerIdentity $uninstaller -ArmedRootIdentity $armedRoot -TrackedProcessIdentities $trackedProcessIdentities
+  ReusedHelperPid = Test-AiNovelGateExpectedNsisPowerShellProbeExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity $reusedHelperPowerShell -ParentIdentity $helper -GrandParentIdentity $uninstaller -ArmedRootIdentity $armedRoot -TrackedProcessIdentities $trackedProcessIdentities
+  FindWrongGreatGrandParent = Test-AiNovelGateExpectedNsisFindNoMatchExit -Step 'smoke:win-installer' -Event $event -ProcessIdentity $find -ParentIdentity $cmd -GrandParentIdentity $helper -GreatGrandParentIdentity $wrongNamedUninstaller -ArmedRootIdentity $armedRoot -TrackedProcessIdentities $trackedProcessIdentities
 } | ConvertTo-Json -Compress
 `)
     const result = parseLastJsonLine(output)
 
     expect(result).toEqual({
       HelperImage: true,
-      UninstallerParent: true,
+      UninstallerAncestry: true,
       HelperParent: true,
       PowerShellChain: true,
       CmdCandidateChain: true,
       CmdVerifiedChain: true,
       FindFourLevelChain: true,
       SameNamedCompleteChainWrongArmedRoot: false,
+      MissingWrapperRecord: false,
+      ReusedWrapperPid: false,
+      CycleFailsClosed: false,
+      DepthFailsClosed: false,
       OtherStep: false,
       OrphanHelper: false,
       NestedHelperDirectory: false,

--- a/scripts/monitor-win-release-gate.ps1
+++ b/scripts/monitor-win-release-gate.ps1
@@ -1552,11 +1552,70 @@ function Test-AiNovelGateCapturedInstallerParent {
   )
 }
 
+function Test-AiNovelGateIdentityAncestryToArmedRoot {
+  param(
+    [AllowNull()]$StartIdentity,
+    [AllowNull()]$TrackedProcessIdentities,
+    [AllowNull()]$ArmedRootIdentity,
+    [ValidateRange(1, 64)][int]$MaxDepth = 16
+  )
+
+  # The release launcher can add shell wrappers before it starts the NSIS
+  # uninstaller. Walk the captured parent identities rather than assuming that
+  # the named uninstaller is a direct child of the armed Node root. Every edge
+  # remains bound to PID, creation time, and absolute image path; a missing
+  # record, PID reuse, cycle, or excessive ancestry depth fails closed.
+  if (
+    $null -eq $StartIdentity -or
+    $null -eq $TrackedProcessIdentities -or
+    $null -eq $ArmedRootIdentity
+  ) {
+    return $false
+  }
+
+  try {
+    $seenIdentityKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    $currentIdentity = $StartIdentity
+    for ($depth = 0; $depth -lt $MaxDepth; $depth += 1) {
+      $currentIdentityKey = Get-AiNovelGateProcessIdentityKey -ProcessIdentity $currentIdentity
+      if ($null -eq $currentIdentityKey -or -not $seenIdentityKeys.Add($currentIdentityKey)) {
+        return $false
+      }
+
+      if (Test-AiNovelGateCapturedParentIdentity `
+        -ChildIdentity $currentIdentity `
+        -ParentIdentity $ArmedRootIdentity) {
+        return $true
+      }
+
+      if (
+        $null -eq $currentIdentity.parentProcessId -or
+        -not $TrackedProcessIdentities.ContainsKey([int]$currentIdentity.parentProcessId)
+      ) {
+        return $false
+      }
+      $parentIdentity = $TrackedProcessIdentities[[int]$currentIdentity.parentProcessId]
+      if (-not (Test-AiNovelGateCapturedParentIdentity `
+        -ChildIdentity $currentIdentity `
+        -ParentIdentity $parentIdentity)) {
+        return $false
+      }
+      $currentIdentity = $parentIdentity
+    }
+  }
+  catch {
+    return $false
+  }
+
+  return $false
+}
+
 function Test-AiNovelGateCapturedNsisUninstallerHelperParent {
   param(
     [AllowNull()]$HelperIdentity,
     [AllowNull()]$UninstallerIdentity,
-    [AllowNull()]$ArmedRootIdentity
+    [AllowNull()]$ArmedRootIdentity,
+    [AllowNull()]$TrackedProcessIdentities
   )
 
   # electron-builder's NSIS uninstaller first copies itself into the current
@@ -1569,12 +1628,13 @@ function Test-AiNovelGateCapturedNsisUninstallerHelperParent {
       -ChildIdentity $HelperIdentity `
       -ParentIdentity $UninstallerIdentity) -and
     (Test-AiNovelGateNsisUninstallerImage -ImagePath ([string]$UninstallerIdentity.executablePath)) -and
-    # The named uninstaller is a child of the armed Node release-gate root;
-    # it is not itself that root. Bind this final edge to reject an unrelated
-    # same-named NSIS chain that happens to be inside the Job Object.
-    (Test-AiNovelGateCapturedParentIdentity `
-      -ChildIdentity $UninstallerIdentity `
-      -ParentIdentity $ArmedRootIdentity)
+    # The named uninstaller is not itself the armed Node release-gate root.
+    # Its complete captured ancestry must terminate at that exact root so an
+    # unrelated same-named NSIS chain inside the Job Object cannot qualify.
+    (Test-AiNovelGateIdentityAncestryToArmedRoot `
+      -StartIdentity $UninstallerIdentity `
+      -TrackedProcessIdentities $TrackedProcessIdentities `
+      -ArmedRootIdentity $ArmedRootIdentity)
   )
 }
 
@@ -1583,7 +1643,8 @@ function Test-AiNovelGateCapturedNsisProbeParent {
     [AllowNull()]$ChildIdentity,
     [AllowNull()]$ParentIdentity,
     [AllowNull()]$GrandParentIdentity,
-    [AllowNull()]$ArmedRootIdentity
+    [AllowNull()]$ArmedRootIdentity,
+    [AllowNull()]$TrackedProcessIdentities
   )
 
   # Keep the original direct-installer check intact. The only additional
@@ -1598,7 +1659,8 @@ function Test-AiNovelGateCapturedNsisProbeParent {
     ((Test-AiNovelGateCapturedNsisUninstallerHelperParent `
         -HelperIdentity $ParentIdentity `
         -UninstallerIdentity $GrandParentIdentity `
-        -ArmedRootIdentity $ArmedRootIdentity) -and
+        -ArmedRootIdentity $ArmedRootIdentity `
+        -TrackedProcessIdentities $TrackedProcessIdentities) -and
       (Test-AiNovelGateCapturedParentIdentity `
         -ChildIdentity $ChildIdentity `
         -ParentIdentity $ParentIdentity))
@@ -1642,7 +1704,8 @@ function Test-AiNovelGateExpectedNsisPowerShellProbeExit {
     [AllowNull()]$ProcessIdentity,
     [AllowNull()]$ParentIdentity,
     [AllowNull()]$GrandParentIdentity,
-    [AllowNull()]$ArmedRootIdentity
+    [AllowNull()]$ArmedRootIdentity,
+    [AllowNull()]$TrackedProcessIdentities
   )
 
   # electron-builder's NSIS template deliberately treats exit 1 from these
@@ -1672,7 +1735,8 @@ function Test-AiNovelGateExpectedNsisPowerShellProbeExit {
     -ChildIdentity $ProcessIdentity `
     -ParentIdentity $ParentIdentity `
     -GrandParentIdentity $GrandParentIdentity `
-    -ArmedRootIdentity $ArmedRootIdentity
+    -ArmedRootIdentity $ArmedRootIdentity `
+    -TrackedProcessIdentities $TrackedProcessIdentities
 }
 
 function Test-AiNovelGateNsisCmdProcessCheckCandidate {
@@ -1682,7 +1746,8 @@ function Test-AiNovelGateNsisCmdProcessCheckCandidate {
     [AllowNull()]$ProcessIdentity,
     [AllowNull()]$ParentIdentity,
     [AllowNull()]$GrandParentIdentity,
-    [AllowNull()]$ArmedRootIdentity
+    [AllowNull()]$ArmedRootIdentity,
+    [AllowNull()]$TrackedProcessIdentities
   )
 
   if (-not (Test-AiNovelGateExpectedExitOne -Step $Step -Event $Event)) {
@@ -1705,7 +1770,8 @@ function Test-AiNovelGateNsisCmdProcessCheckCandidate {
     -ChildIdentity $ProcessIdentity `
     -ParentIdentity $ParentIdentity `
     -GrandParentIdentity $GrandParentIdentity `
-    -ArmedRootIdentity $ArmedRootIdentity
+    -ArmedRootIdentity $ArmedRootIdentity `
+    -TrackedProcessIdentities $TrackedProcessIdentities
 }
 
 function Test-AiNovelGateExpectedNsisCmdProcessCheckExit {
@@ -1716,6 +1782,7 @@ function Test-AiNovelGateExpectedNsisCmdProcessCheckExit {
     [AllowNull()]$ParentIdentity,
     [AllowNull()]$GrandParentIdentity,
     [AllowNull()]$ArmedRootIdentity,
+    [AllowNull()]$TrackedProcessIdentities,
     [AllowNull()]$VerifiedFindParentKeys
   )
 
@@ -1725,7 +1792,8 @@ function Test-AiNovelGateExpectedNsisCmdProcessCheckExit {
     -ProcessIdentity $ProcessIdentity `
     -ParentIdentity $ParentIdentity `
     -GrandParentIdentity $GrandParentIdentity `
-    -ArmedRootIdentity $ArmedRootIdentity)) {
+    -ArmedRootIdentity $ArmedRootIdentity `
+    -TrackedProcessIdentities $TrackedProcessIdentities)) {
     return $false
   }
   $processIdentityKey = Get-AiNovelGateProcessIdentityKey -ProcessIdentity $ProcessIdentity
@@ -1915,7 +1983,8 @@ function Test-AiNovelGateExpectedNsisFindNoMatchExit {
     [AllowNull()]$ParentIdentity,
     [AllowNull()]$GrandParentIdentity,
     [AllowNull()]$GreatGrandParentIdentity,
-    [AllowNull()]$ArmedRootIdentity
+    [AllowNull()]$ArmedRootIdentity,
+    [AllowNull()]$TrackedProcessIdentities
   )
 
   if (-not (Test-AiNovelGateExpectedExitOne -Step $Step -Event $Event)) {
@@ -1949,7 +2018,8 @@ function Test-AiNovelGateExpectedNsisFindNoMatchExit {
     -ChildIdentity $ParentIdentity `
     -ParentIdentity $GrandParentIdentity `
     -GrandParentIdentity $GreatGrandParentIdentity `
-    -ArmedRootIdentity $ArmedRootIdentity
+    -ArmedRootIdentity $ArmedRootIdentity `
+    -TrackedProcessIdentities $TrackedProcessIdentities
 }
 
 function ConvertTo-AiNovelGateProcessEvidenceIdentity {
@@ -2331,7 +2401,8 @@ try {
           -ProcessIdentity $processIdentity `
           -ParentIdentity $parentIdentity `
           -GrandParentIdentity $grandParentIdentity `
-          -ArmedRootIdentity $armedRootIdentity) {
+          -ArmedRootIdentity $armedRootIdentity `
+          -TrackedProcessIdentities $trackedProcessIdentities) {
           $exitClassification = 'expected-nsis-powershell-probe'
         }
         elseif (Test-AiNovelGateExpectedNsisFindNoMatchExit `
@@ -2341,7 +2412,8 @@ try {
           -ParentIdentity $parentIdentity `
           -GrandParentIdentity $grandParentIdentity `
           -GreatGrandParentIdentity $greatGrandParentIdentity `
-          -ArmedRootIdentity $armedRootIdentity) {
+          -ArmedRootIdentity $armedRootIdentity `
+          -TrackedProcessIdentities $trackedProcessIdentities) {
           $parentProcessIdentityKey = Get-AiNovelGateProcessIdentityKey -ProcessIdentity $parentIdentity
           if ($null -eq $parentProcessIdentityKey) {
             $exitClassification = 'failure'
@@ -2363,6 +2435,7 @@ try {
           -ParentIdentity $parentIdentity `
           -GrandParentIdentity $grandParentIdentity `
           -ArmedRootIdentity $armedRootIdentity `
+          -TrackedProcessIdentities $trackedProcessIdentities `
           -VerifiedFindParentKeys $verifiedNsisFindParentKeys) {
           $exitClassification = 'expected-nsis-cmd-process-check'
         }
@@ -2372,7 +2445,8 @@ try {
           -ProcessIdentity $processIdentity `
           -ParentIdentity $parentIdentity `
           -GrandParentIdentity $grandParentIdentity `
-          -ArmedRootIdentity $armedRootIdentity) {
+          -ArmedRootIdentity $armedRootIdentity `
+          -TrackedProcessIdentities $trackedProcessIdentities) {
           $processIdentityKey = Get-AiNovelGateProcessIdentityKey -ProcessIdentity $processIdentity
           if (Add-AiNovelGatePendingNsisCmdExitFailure `
             -PendingNsisCmdExitFailures $pendingNsisCmdExitFailures `


### PR DESCRIPTION
Fixes the remaining false positive from Windows qualification run 30217322046. The cloud launch root has normal cmd and PowerShell wrappers before the product uninstaller, so the release gate now proves the complete bounded PID/start/path ancestry back to the armed root instead of assuming a direct parent. Missing identities, PID reuse, cycles, excess depth, and a different root remain fail-closed.

Verification: focused 71/71, full 142 files / 798 tests, typecheck, lint, PowerShell parser, diff check, real multi-layer Windows chain, and frozen Sol/Max Standards/Spec review all pass.