### PR TITLE
fix: keep native ABI verification in-process

### DIFF
--- a/scripts/__tests__/release-win-verify.test.ts
+++ b/scripts/__tests__/release-win-verify.test.ts
@@ -408,6 +408,14 @@ describe('Windows release verification orchestration', () => {
     expect(script).toContain(
       'await restoreAndVerifyNodeNativeAbi({ monitored: false })',
     )
+
+    const nativeVerifyCall = script.lastIndexOf("await runner('verify:native-node', [")
+    const nativeVerifyCallEnd = script.indexOf('  ])', nativeVerifyCall)
+    const nativeVerifyArguments = script.slice(nativeVerifyCall, nativeVerifyCallEnd)
+    expect(nativeVerifyCall).toBeGreaterThan(0)
+    expect(nativeVerifyCallEnd).toBeGreaterThan(nativeVerifyCall)
+    expect(nativeVerifyArguments).toContain("'--pool=threads'")
+    expect(script.match(/'--pool=threads'/g) ?? []).toHaveLength(1)
   })
 
   windowsIt('stops a marker-only release monitor before status and control initialization', async () => {

--- a/scripts/release-win-verify.mjs
+++ b/scripts/release-win-verify.mjs
@@ -447,6 +447,7 @@ async function restoreAndVerifyNodeNativeAbi({ monitored }) {
   await runner('verify:native-node', [
     resolve('node_modules/vitest/vitest.mjs'),
     'run',
+    '--pool=threads',
     'electron/repositories/__tests__/character-repository.test.ts',
   ])
   console.log('Restored and verified better-sqlite3 for the ordinary Node test runtime.')


### PR DESCRIPTION
Fixes the final release-gate false positive from run 30218717755. The six-test verify:native-node Vitest invocation now uses the threads pool, so a normal internal fork-worker exit is no longer mistaken for a product process failure. Test failures still propagate through the monitored Vitest root process; no Node exit-code exception was added.

Verification: focused 22/22, full 142 files / 798 tests, direct threads run 6/6, typecheck, lint, diff check, and frozen Sol/Max Standards/Spec review pass.