### PR TITLE
fix: make qualification lockfile hash cross-platform

### DIFF
--- a/scripts/__tests__/generate-cloud-build-manifest.test.ts
+++ b/scripts/__tests__/generate-cloud-build-manifest.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { spawnSync } from 'node:child_process'
 import { afterEach, describe, expect, it } from 'vitest'
+import { canonicalPnpmLockfileSha256 } from '../canonical-pnpm-lockfile-hash.mjs'
 
 const testDirectory = path.dirname(fileURLToPath(import.meta.url))
 const repositoryRoot = path.resolve(testDirectory, '..', '..')
@@ -87,7 +88,7 @@ describe('cloud Windows build manifest', () => {
     expect(manifest).toMatchObject({
       schemaVersion: 1,
       commit,
-      lockfileSha256: sha256(readFileSync(path.join(repositoryRoot, 'pnpm-lock.yaml'))),
+      lockfileSha256: canonicalPnpmLockfileSha256(path.join(repositoryRoot, 'pnpm-lock.yaml')),
       nodeVersion: process.versions.node,
       pnpmVersion: '11.11.0',
       runnerImage: {

--- a/scripts/__tests__/promote-windows-runtime-artifact.test.ts
+++ b/scripts/__tests__/promote-windows-runtime-artifact.test.ts
@@ -13,6 +13,7 @@ import {
   verifyRemoteReleaseAssets,
   verifyStagedPromotion,
 } from '../promote-windows-runtime-artifact.mjs'
+import { canonicalPnpmLockfileSha256 } from '../canonical-pnpm-lockfile-hash.mjs'
 
 const SHA = 'a'.repeat(40)
 const OTHER_SHA = 'b'.repeat(40)
@@ -109,14 +110,23 @@ function queuedFetcher(
   }, { assertDrained: () => expect(expected).toHaveLength(0), requests })
 }
 
-function qualificationFixture() {
+function qualificationFixture({
+  sourceLockfileText = 'lockfileVersion: 9.0\n',
+  manifestLockfileText = sourceLockfileText,
+}: {
+  sourceLockfileText?: string
+  manifestLockfileText?: string
+} = {}) {
   const root = temporaryDirectory()
   const source = path.join(root, 'source')
   const artifact = path.join(root, 'artifact', '0.4.0')
   mkdirSync(path.join(artifact, 'qualification'), { recursive: true })
   mkdirSync(source, { recursive: true })
   writeJson(path.join(source, 'package.json'), { version: '0.4.0' })
-  writeFileSync(path.join(source, 'pnpm-lock.yaml'), 'lockfileVersion: 9.0\n', 'utf8')
+  const sourceLockfile = path.join(source, 'pnpm-lock.yaml')
+  const manifestLockfile = path.join(root, 'manifest-pnpm-lock.yaml')
+  writeFileSync(sourceLockfile, sourceLockfileText, 'utf8')
+  writeFileSync(manifestLockfile, manifestLockfileText, 'utf8')
 
   const installer = 'ai-novel-writer-setup-0.4.0.exe'
   writeFileSync(path.join(artifact, installer), 'installer bytes')
@@ -170,7 +180,7 @@ function qualificationFixture() {
   writeJson(path.join(artifact, 'manifest.json'), {
     schemaVersion: 1,
     commit: SHA,
-    lockfileSha256: hash(path.join(source, 'pnpm-lock.yaml')),
+    lockfileSha256: canonicalPnpmLockfileSha256(manifestLockfile),
     gateLevel: 'RUNTIME_VERIFIED',
     releaseCreated: false,
     artifacts,
@@ -232,6 +242,31 @@ describe('downloaded qualification verification', () => {
       'latest.yml',
     ])
     expect(verifyStagedPromotion(output).expectedSha).toBe(SHA)
+  })
+
+  it('accepts Windows lockfile line endings but rejects a changed lockfile', () => {
+    const sourceLockfileText = 'lockfileVersion: 9.0\nsettings:\n  autoInstallPeers: false\n'
+    const windowsQualification = qualificationFixture({
+      sourceLockfileText,
+      manifestLockfileText: sourceLockfileText.replaceAll('\n', '\r\n'),
+    })
+    expect(() => verifyDownloadedQualification({
+      artifactRoot: windowsQualification.artifactRoot,
+      qualifiedSource: windowsQualification.source,
+      sourceCommit: SHA,
+      sourcePlan: sourcePlan(),
+    })).not.toThrow()
+
+    const changedLockfile = qualificationFixture({
+      sourceLockfileText,
+      manifestLockfileText: 'lockfileVersion: 9.0\nsettings:\n  autoInstallPeers: true\n',
+    })
+    expect(() => verifyDownloadedQualification({
+      artifactRoot: changedLockfile.artifactRoot,
+      qualifiedSource: changedLockfile.source,
+      sourceCommit: SHA,
+      sourcePlan: sourcePlan(),
+    })).toThrow('lockfile hash')
   })
 
   it('rejects a manifest without the RUNTIME_VERIFIED gate', () => {

--- a/scripts/canonical-pnpm-lockfile-hash.mjs
+++ b/scripts/canonical-pnpm-lockfile-hash.mjs
@@ -1,0 +1,37 @@
+import { Buffer } from 'node:buffer'
+import { createHash } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+
+/**
+ * Canonicalize only line endings in a pnpm lockfile before hashing it.
+ *
+ * The Windows qualification job and Linux promotion job may check out the
+ * same Git blob with different working-tree line endings. This routine keeps
+ * every non-line-ending byte intact, so it does not hide a dependency or
+ * lockfile-content change.
+ */
+export function canonicalizePnpmLockfileBytes(bytes) {
+  const normalized = Buffer.allocUnsafe(bytes.length)
+  let writeOffset = 0
+
+  for (let readOffset = 0; readOffset < bytes.length; readOffset += 1) {
+    const byte = bytes[readOffset]
+    if (byte === 0x0d) {
+      normalized[writeOffset] = 0x0a
+      writeOffset += 1
+      if (bytes[readOffset + 1] === 0x0a) readOffset += 1
+      continue
+    }
+
+    normalized[writeOffset] = byte
+    writeOffset += 1
+  }
+
+  return normalized.subarray(0, writeOffset)
+}
+
+export function canonicalPnpmLockfileSha256(file) {
+  return createHash('sha256')
+    .update(canonicalizePnpmLockfileBytes(readFileSync(file)))
+    .digest('hex')
+}

--- a/scripts/generate-cloud-build-manifest.mjs
+++ b/scripts/generate-cloud-build-manifest.mjs
@@ -3,6 +3,7 @@ import { existsSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
+import { canonicalPnpmLockfileSha256 } from './canonical-pnpm-lockfile-hash.mjs'
 
 const scriptPath = fileURLToPath(import.meta.url)
 const repositoryRoot = path.resolve(path.dirname(scriptPath), '..')
@@ -60,7 +61,7 @@ function main() {
   const manifest = {
     schemaVersion: 1,
     commit: requiredEnvironment('GITHUB_SHA'),
-    lockfileSha256: sha256(path.join(repositoryRoot, 'pnpm-lock.yaml')),
+    lockfileSha256: canonicalPnpmLockfileSha256(path.join(repositoryRoot, 'pnpm-lock.yaml')),
     nodeVersion: process.versions.node,
     pnpmVersion: requiredEnvironment('AI_NOVEL_CLOUD_BUILD_PNPM_VERSION'),
     runnerImage: {

--- a/scripts/promote-windows-runtime-artifact.mjs
+++ b/scripts/promote-windows-runtime-artifact.mjs
@@ -16,6 +16,7 @@ import path from 'node:path'
 import process from 'node:process'
 import { execFileSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
+import { canonicalPnpmLockfileSha256 } from './canonical-pnpm-lockfile-hash.mjs'
 
 const scriptPath = fileURLToPath(import.meta.url)
 const EXPECTED_WORKFLOW_NAME = 'Windows cloud package qualification'
@@ -221,7 +222,7 @@ export function verifyDownloadedQualification({ artifactRoot, qualifiedSource, s
   assert(String(sourceCommit ?? '').toLowerCase() === sourcePlan.expectedSha, 'Qualified source checkout does not match expected_sha')
   const packageMetadata = jsonFile(path.join(qualifiedSource, 'package.json'), 'qualified package.json')
   assert(packageMetadata?.version === sourcePlan.version, `Qualified source version ${packageMetadata?.version ?? '(missing)'} does not match ${sourcePlan.tag}`)
-  assert(sha256(path.join(qualifiedSource, 'pnpm-lock.yaml')) !== '', 'Qualified source lockfile could not be hashed')
+  assert(canonicalPnpmLockfileSha256(path.join(qualifiedSource, 'pnpm-lock.yaml')) !== '', 'Qualified source lockfile could not be hashed')
 
   const allArtifactFiles = listRegularFiles(artifactRoot)
   assert(!allArtifactFiles.some(file => file.toLowerCase().endsWith('.zip')), 'Portable ZIP files are forbidden in formal promotion input')
@@ -237,7 +238,7 @@ export function verifyDownloadedQualification({ artifactRoot, qualifiedSource, s
   assert(manifest.gateLevel === 'RUNTIME_VERIFIED', 'Runtime verification manifest gateLevel is not RUNTIME_VERIFIED')
   assert(manifest.releaseCreated === false, 'Qualification manifest unexpectedly claims that a Release was created')
   assert(String(manifest.commit ?? '').toLowerCase() === sourcePlan.expectedSha, 'Runtime verification manifest commit does not match expected_sha')
-  assert(manifest.lockfileSha256 === sha256(path.join(qualifiedSource, 'pnpm-lock.yaml')), 'Runtime verification manifest lockfile hash does not match qualified source')
+  assert(manifest.lockfileSha256 === canonicalPnpmLockfileSha256(path.join(qualifiedSource, 'pnpm-lock.yaml')), 'Runtime verification manifest lockfile hash does not match qualified source')
 
   const installer = `ai-novel-writer-setup-${sourcePlan.version}.exe`
   const blockmap = `${installer}.blockmap`


### PR DESCRIPTION
## Summary
- canonicalize only pnpm-lock.yaml line endings before hashing
- share the same byte-level hash routine between qualification manifest generation and Linux promotion verification
- keep installer, blockmap, update metadata, manifest, and checksum validation byte-exact

## Root cause
Promotion run 30221229502 compared a Windows checkout's CRLF lockfile bytes with the same Git content checked out as LF on Linux. The dependency graph was identical, but the raw working-tree byte hashes differed.

## Verification
- full Vitest: 798 passed, 1 explicit skip
- focused tests: 29/29 passed
- CRLF/LF equivalence passes; real lockfile content change is rejected
- typecheck, lint, Node syntax check, diff check: passed
- independent frozen review: Standards PASS; Spec PASS; P0-P2 = 0

The earlier qualification artifact is intentionally not reused. A fresh Windows qualification run is required after merge.