### PR TITLE
fix: defer draft recovery to write-capable publish job

### DIFF
--- a/scripts/__tests__/promote-windows-runtime-artifact.test.ts
+++ b/scripts/__tests__/promote-windows-runtime-artifact.test.ts
@@ -87,7 +87,7 @@ function metadata(overrides: Record<string, unknown> = {}) {
         workflow_run: { id: 123, head_sha: SHA },
       }],
     },
-    remotePromotion: { tagCommitSha: null, release: null },
+    remoteTagCommitSha: null,
     now: new Date('2029-01-01T00:00:00Z'),
     ...overrides,
   }
@@ -233,15 +233,15 @@ describe('runtime artifact promotion source validation', () => {
     })
   })
 
-  it('records an exact existing draft and tag as a recovery candidate', () => {
+  it('records a visible expected tag as a draft-recovery intent', () => {
     expect(validateQualificationSource(metadata({
-      remotePromotion: { tagCommitSha: SHA, release: recoveryDraft() },
+      remoteTagCommitSha: SHA,
     }))).toMatchObject({
-      promotionRecovery: { mode: 'RESUME_DRAFT', releaseId: 360126743 },
+      promotionRecovery: { mode: 'RESUME_DRAFT' },
     })
   })
 
-  it('reads an exact existing draft and tag into a resumable source plan', async () => {
+  it('plans from the visible tag without querying a draft hidden from the read-only token', async () => {
     const input = metadata()
     const fetcher = queuedFetcher([
       { method: 'GET', path: '/repos/EthanYoQ/AI-Novel-Writer', status: 200, data: input.repository },
@@ -250,11 +250,10 @@ describe('runtime artifact promotion source validation', () => {
       { method: 'GET', path: `/compare/${SHA}...master`, status: 200, data: input.comparison },
       { method: 'GET', path: '/actions/runs/123/artifacts?per_page=100', status: 200, data: input.artifactsResponse },
       { method: 'GET', path: '/git/ref/tags/v0.4.0', status: 200, data: { ref: 'refs/tags/v0.4.0', object: { type: 'commit', sha: SHA } } },
-      { method: 'GET', path: '/releases/tags/v0.4.0', status: 200, data: recoveryDraft() },
     ])
     await expect(createSourcePlan({ token: 'token', inputs: input.inputs, fetcher })).resolves.toMatchObject({
       state: 'SOURCE_VERIFIED',
-      promotionRecovery: { mode: 'RESUME_DRAFT', releaseId: 360126743 },
+      promotionRecovery: { mode: 'RESUME_DRAFT' },
     })
     fetcher.assertDrained()
   })
@@ -264,12 +263,8 @@ describe('runtime artifact promotion source validation', () => {
     ['wrong workflow', () => metadata({ workflow: { ...metadata().workflow, name: 'Other workflow' } }), 'workflow name'],
     ['wrong SHA', () => metadata({ run: { ...metadata().run, head_sha: 'b'.repeat(40) } }), 'head SHA'],
     ['invalid tag', () => metadata({ inputs: { ...metadata().inputs, tag: 'v0.4.0-beta.1' } }), 'final v-prefixed'],
-    ['tag without Release', () => metadata({ remotePromotion: { tagCommitSha: SHA, release: null } }), 'partially occupied'],
-    ['Release without tag', () => metadata({ remotePromotion: { tagCommitSha: null, release: recoveryDraft() } }), 'partially occupied'],
-    ['wrong existing tag target', () => metadata({ remotePromotion: { tagCommitSha: OTHER_SHA, release: recoveryDraft() } }), 'does not resolve to expected_sha'],
-    ['wrong existing draft target', () => metadata({ remotePromotion: { tagCommitSha: SHA, release: recoveryDraft({ target_commitish: OTHER_SHA }) } }), 'target_commitish'],
-    ['published existing Release', () => metadata({ remotePromotion: { tagCommitSha: SHA, release: recoveryDraft({ draft: false }) } }), 'not an unpublished'],
-    ['wrong existing draft provenance', () => metadata({ remotePromotion: { tagCommitSha: SHA, release: recoveryDraft({ body: 'untrusted provenance' }) } }), 'provenance'],
+    ['wrong existing tag target', () => metadata({ remoteTagCommitSha: OTHER_SHA }), 'does not resolve to expected_sha'],
+    ['invalid existing tag target', () => metadata({ remoteTagCommitSha: 'not-a-sha' }), 'SHA is invalid'],
   ])('rejects %s', (_label, makeInput, message) => {
     expect(() => validateQualificationSource(makeInput())).toThrow(message)
   })
@@ -406,7 +401,7 @@ describe('remote Release asset verification', () => {
 describe('idempotent draft recovery', () => {
   function recoverySourcePlan() {
     return validateQualificationSource(metadata({
-      remotePromotion: { tagCommitSha: SHA, release: recoveryDraft() },
+      remoteTagCommitSha: SHA,
     }))
   }
 
@@ -457,6 +452,83 @@ describe('idempotent draft recovery', () => {
       expectedTag: 'v0.4.0',
       fetcher,
     })).rejects.toThrow('Remote Release has 0 assets')
+    expect(requests.map(request => request.method)).toEqual(['GET', 'GET'])
+    fetcher.assertDrained()
+  })
+
+  it('fails closed when a visible retained tag has no matching draft for the write-capable job', async () => {
+    const fixture = stagedPromotionFixture(recoverySourcePlan())
+    const requests: MockRequest[] = []
+    const fetcher = queuedFetcher([
+      { method: 'GET', path: '/git/ref/tags/v0.4.0', status: 200, data: { ref: 'refs/tags/v0.4.0', object: { type: 'commit', sha: SHA } } },
+      { method: 'GET', path: '/releases/tags/v0.4.0', status: 404 },
+      { method: 'GET', path: '/releases?per_page=100&page=1', status: 200, data: [] },
+    ], requests)
+
+    await expect(publishPromotion({
+      token: 'token',
+      readyRoot: fixture.readyRoot,
+      expectedRepository: 'EthanYoQ/AI-Novel-Writer',
+      expectedTag: 'v0.4.0',
+      fetcher,
+    })).rejects.toThrow('partially occupied')
+    expect(requests.map(request => request.method)).toEqual(['GET', 'GET', 'GET'])
+    fetcher.assertDrained()
+  })
+
+  it('fails closed when a visible draft has no matching tag for the write-capable job', async () => {
+    const fixture = stagedPromotionFixture()
+    const requests: MockRequest[] = []
+    const fetcher = queuedFetcher([
+      { method: 'GET', path: '/git/ref/tags/v0.4.0', status: 404 },
+      { method: 'GET', path: '/releases/tags/v0.4.0', status: 200, data: recoveryDraft({ assets: uploadedAssets(fixture.plan) }) },
+    ], requests)
+
+    await expect(publishPromotion({
+      token: 'token',
+      readyRoot: fixture.readyRoot,
+      expectedRepository: 'EthanYoQ/AI-Novel-Writer',
+      expectedTag: 'v0.4.0',
+      fetcher,
+    })).rejects.toThrow('partially occupied')
+    expect(requests.map(request => request.method)).toEqual(['GET', 'GET'])
+    fetcher.assertDrained()
+  })
+
+  it('fails closed when the write-capable job sees a non-draft Release', async () => {
+    const fixture = stagedPromotionFixture(recoverySourcePlan())
+    const requests: MockRequest[] = []
+    const fetcher = queuedFetcher([
+      { method: 'GET', path: '/git/ref/tags/v0.4.0', status: 200, data: { ref: 'refs/tags/v0.4.0', object: { type: 'commit', sha: SHA } } },
+      { method: 'GET', path: '/releases/tags/v0.4.0', status: 200, data: recoveryDraft({ draft: false, assets: uploadedAssets(fixture.plan) }) },
+    ], requests)
+
+    await expect(publishPromotion({
+      token: 'token',
+      readyRoot: fixture.readyRoot,
+      expectedRepository: 'EthanYoQ/AI-Novel-Writer',
+      expectedTag: 'v0.4.0',
+      fetcher,
+    })).rejects.toThrow('not an unpublished')
+    expect(requests.map(request => request.method)).toEqual(['GET', 'GET'])
+    fetcher.assertDrained()
+  })
+
+  it('fails closed when the write-capable job sees a draft for another commit', async () => {
+    const fixture = stagedPromotionFixture(recoverySourcePlan())
+    const requests: MockRequest[] = []
+    const fetcher = queuedFetcher([
+      { method: 'GET', path: '/git/ref/tags/v0.4.0', status: 200, data: { ref: 'refs/tags/v0.4.0', object: { type: 'commit', sha: SHA } } },
+      { method: 'GET', path: '/releases/tags/v0.4.0', status: 200, data: recoveryDraft({ target_commitish: OTHER_SHA, assets: uploadedAssets(fixture.plan) }) },
+    ], requests)
+
+    await expect(publishPromotion({
+      token: 'token',
+      readyRoot: fixture.readyRoot,
+      expectedRepository: 'EthanYoQ/AI-Novel-Writer',
+      expectedTag: 'v0.4.0',
+      fetcher,
+    })).rejects.toThrow('target_commitish')
     expect(requests.map(request => request.method)).toEqual(['GET', 'GET'])
     fetcher.assertDrained()
   })

--- a/scripts/promote-windows-runtime-artifact.mjs
+++ b/scripts/promote-windows-runtime-artifact.mjs
@@ -80,6 +80,13 @@ function promotionReleaseBody(qualificationRunId) {
   return `Windows runtime-verified release promoted from qualification run ${qualificationRunId}.`
 }
 
+function promotionRecoveryIntent(remoteTagCommitSha, { tag, expectedSha }) {
+  if (remoteTagCommitSha === null) return { mode: 'CREATE' }
+  assert(typeof remoteTagCommitSha === 'string' && /^[a-f0-9]{40}$/i.test(remoteTagCommitSha), 'Existing Git tag SHA is invalid')
+  assert(remoteTagCommitSha.toLowerCase() === expectedSha, `Existing Git tag ${tag} does not resolve to expected_sha`)
+  return { mode: 'RESUME_DRAFT' }
+}
+
 function promotionRecoveryCandidate(remotePromotion, { tag, expectedSha, qualificationRunId }) {
   assert(remotePromotion && typeof remotePromotion === 'object', 'Remote promotion state could not be determined')
   const tagCommitSha = remotePromotion.tagCommitSha
@@ -103,9 +110,6 @@ function promotionRecoveryCandidate(remotePromotion, { tag, expectedSha, qualifi
 
 function assertPromotionRecoveryPlan(recovery) {
   assert(recovery?.mode === 'CREATE' || recovery?.mode === 'RESUME_DRAFT', 'Promotion recovery plan is invalid')
-  if (recovery.mode === 'RESUME_DRAFT') {
-    assert(Number.isInteger(recovery.releaseId) && recovery.releaseId > 0, 'Promotion recovery draft Release ID is invalid')
-  }
 }
 
 export function validateQualificationSource({
@@ -115,7 +119,7 @@ export function validateQualificationSource({
   run,
   comparison,
   artifactsResponse,
-  remotePromotion,
+  remoteTagCommitSha,
   now = new Date(),
 }) {
   assert(inputs?.confirmation === PROMOTION_CONFIRMATION, `confirmation must exactly equal ${PROMOTION_CONFIRMATION}`)
@@ -159,10 +163,9 @@ export function validateQualificationSource({
     assert(String(artifact.workflow_run.head_sha ?? '').toLowerCase() === expectedSha, 'Qualification artifact head SHA is inconsistent')
   }
 
-  const promotionRecovery = promotionRecoveryCandidate(remotePromotion, {
+  const promotionRecovery = promotionRecoveryIntent(remoteTagCommitSha, {
     tag: inputs.tag,
     expectedSha,
-    qualificationRunId: Number(inputs.qualificationRunId),
   })
 
   return {
@@ -452,8 +455,11 @@ export async function createSourcePlan({ token, inputs, fetcher = globalThis.fet
   const expectedSha = encodeURIComponent(inputs.expectedSha)
   const { data: comparison } = await apiRequest({ token, url: `${base}/compare/${expectedSha}...${defaultBranch}`, fetcher })
   const { data: artifactsResponse } = await apiRequest({ token, url: `${base}/actions/runs/${inputs.qualificationRunId}/artifacts?per_page=100`, fetcher })
-  const remotePromotion = await inspectRemotePromotionState({ token, repository: inputs.repository, tag: inputs.tag, fetcher })
-  return validateQualificationSource({ inputs, repository, workflow, run, comparison, artifactsResponse, remotePromotion })
+  // This job intentionally has contents: read. Draft Releases can be hidden from
+  // that token, so only the visible tag state is planned here; the write-capable
+  // publish job re-reads and validates the full draft and its assets.
+  const remoteTagCommitSha = await resolveTagCommitShaIfPresent({ token, repository: inputs.repository, tag: inputs.tag, fetcher })
+  return validateQualificationSource({ inputs, repository, workflow, run, comparison, artifactsResponse, remoteTagCommitSha })
 }
 
 async function resolveTagCommitShaIfPresent({ token, repository, tag, fetcher = globalThis.fetch }) {
@@ -689,7 +695,6 @@ export async function publishPromotion({ token, readyRoot, expectedRepository, e
 
   const base = apiBase(plan.repository)
   if (currentRecovery.mode === 'RESUME_DRAFT') {
-    assert(currentRecovery.releaseId === plan.promotionRecovery.releaseId, 'Existing draft Release changed after qualification planning')
     verifyRemoteReleaseAssets(remotePromotion.release, plan.releaseAssets)
     return finalizePromotionDraft({ token, base, draft: remotePromotion.release, plan, fetcher })
   }


### PR DESCRIPTION
## Summary
- keep the qualification/planning job read-only and inspect only the visible tag
- treat a correct existing tag as a recovery intent without interpreting hidden draft Release responses
- make the write-capable publish job the sole authority for real-time CREATE/RESUME_DRAFT validation
- preserve strict draft provenance, commit, state, and exact asset digest checks before any write

## Root cause
Run 30222724297 showed that a contents:read GITHUB_TOKEN can see the tag but cannot discover the draft Release created by the prior promotion run. Treating that permission-limited view as proof of absence produced a false partial-occupancy failure.

## Verification
- focused tests: 41/41 passed
- full Vitest: 809 passed, 1 explicit skip
- typecheck, ESLint, Node syntax, diff check: passed
- independent frozen review: Standards PASS; Spec PASS; P0-P2 = 0

Workflow permissions remain unchanged: verification has contents:read; publication alone has contents:write.