### PR TITLE
fix(macos): 修复安全文件系统的 Foundation 编译

### DIFF
--- a/electron/security/darwin-safe-file-system.m
+++ b/electron/security/darwin-safe-file-system.m
@@ -339,7 +339,9 @@ static NSDictionary *ListDirectory(NSString *rootPath, NSArray<NSString *> *segm
   struct dirent *entry = NULL;
   while ((entry = readdir(stream)) != NULL) {
     if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) continue;
-    NSString *name = [[NSString alloc] initWithFileSystemRepresentation:entry->d_name length:strlen(entry->d_name)];
+    NSString *name = [[NSFileManager defaultManager]
+      stringWithFileSystemRepresentation:entry->d_name
+      length:strlen(entry->d_name)];
     if (!name || !IsSafeSegment(name)) {
       closedir(stream);
       close(directory);


### PR DESCRIPTION
## 修复内容 / Fix

修复 macOS 云端资格构建发现的 Foundation 编译问题：目录枚举改用 Apple 支持的 `NSFileManager stringWithFileSystemRepresentation:length:` 转换 POSIX 文件系统字节。

Fixes the Foundation compile error found by the macOS cloud qualification build by using Apple's supported `NSFileManager stringWithFileSystemRepresentation:length:` conversion.

## 验证 / Validation

- 本地全量 Vitest：143 files passed，775 passed，6 skipped。
- Windows 云端资格构建 `30469904616`：通过。
- 合并后将重新运行 macOS ARM64 云端资格构建；通过前不创建正式 Release。
