### PR TITLE
fix(macos): 无 GUI 执行已打包向量资格验证

### DIFF
--- a/electron/release-vector-smoke-runner.ts
+++ b/electron/release-vector-smoke-runner.ts
@@ -1,0 +1,28 @@
+import {
+  parseReleaseVectorSmokeInvocation,
+  runReleaseVectorSmoke,
+} from './services/release-vector-smoke'
+
+async function main(): Promise<void> {
+  const invocation = parseReleaseVectorSmokeInvocation(process.argv, process.env)
+  if (!invocation) throw new Error('Invalid packaged vector smoke invocation')
+
+  const timeout = setTimeout(() => {
+    process.stderr.write('[AI Novel release vector smoke] Packaged vector smoke timed out after 90 seconds\n')
+    process.exit(1)
+  }, 90_000)
+  try {
+    const evidence = await runReleaseVectorSmoke(invocation.token)
+    process.stdout.write(`${JSON.stringify(evidence)}\n`)
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+void main().then(
+  () => process.exit(0),
+  () => {
+    process.stderr.write('[AI Novel release vector smoke] failed\n')
+    process.exit(1)
+  },
+)

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build:win:artifacts": "node scripts/require-release-gate.mjs && pnpm run rebuild:electron && tsc && vite build && electron-builder --win --x64 --publish never",
     "release:win:verify": "node scripts/release-win-verify.mjs",
     "build:win-dir": "pnpm run clean:build && pnpm run typecheck && pnpm run rebuild:electron && vite build && electron-builder --win dir --x64 && pnpm run verify:win-package",
-    "build:mac:artifacts": "pnpm run clean:build && pnpm run typecheck && pnpm run rebuild:electron && clang -fobjc-arc -framework Foundation electron/security/darwin-safe-file-system.m -o electron/security/darwin-safe-file-system && chmod +x electron/security/darwin-safe-file-system && vite build && electron-builder --mac --arm64 --publish never",
+    "build:mac:artifacts": "pnpm run clean:build && pnpm run typecheck && pnpm run rebuild:electron && clang -fobjc-arc -framework Foundation electron/security/darwin-safe-file-system.m -o electron/security/darwin-safe-file-system && chmod +x electron/security/darwin-safe-file-system && vite build && node scripts/build-release-vector-smoke-runner.mjs && electron-builder --mac --arm64 --publish never",
     "verify:win-package": "node scripts/verify-win-package.mjs",
     "verify:win-update-artifacts": "node scripts/verify-win-update-artifacts.mjs",
     "verify:github-update-release": "node scripts/verify-github-update-release.mjs",

--- a/scripts/__tests__/macos-cloud-build-workflow.test.ts
+++ b/scripts/__tests__/macos-cloud-build-workflow.test.ts
@@ -7,6 +7,8 @@ const workflowPath = path.join(repositoryRoot, '.github', 'workflows', 'macos-ar
 const packageMetadataPath = path.join(repositoryRoot, 'package.json')
 const macSmokeScriptPath = path.join(repositoryRoot, 'scripts', 'smoke-macos-dmg.sh')
 const manifestScriptPath = path.join(repositoryRoot, 'scripts', 'generate-macos-cloud-build-manifest.mjs')
+const vectorRunnerBuildScriptPath = path.join(repositoryRoot, 'scripts', 'build-release-vector-smoke-runner.mjs')
+const vectorRunnerSourcePath = path.join(repositoryRoot, 'electron', 'release-vector-smoke-runner.ts')
 
 function readRequired(file: string) {
   expect(existsSync(file), `Missing macOS cloud qualification contract file: ${file}`).toBe(true)
@@ -27,6 +29,8 @@ describe('macOS ARM64 cloud build workflow contract', () => {
     const packageMetadata = JSON.parse(readRequired(packageMetadataPath)) as { scripts?: Record<string, string> }
     const smokeScript = readRequired(macSmokeScriptPath)
     const manifestScript = readRequired(manifestScriptPath)
+    const vectorRunnerBuildScript = readRequired(vectorRunnerBuildScriptPath)
+    const vectorRunnerSource = readRequired(vectorRunnerSourcePath)
 
     const triggerBlock = workflow.match(/^on:\r?\n(?<triggers>(?: {2}.*(?:\r?\n|$))*)/m)?.groups?.triggers
     expect(triggerBlock?.trim()).toBe('workflow_dispatch:')
@@ -60,6 +64,7 @@ describe('macOS ARM64 cloud build workflow contract', () => {
     expect(artifactStep).toContain('qualification/packaged-official-homepage-smoke.json')
     expect(artifactStep).toContain('qualification/macos-dmg-smoke.json')
 
+    expect(packageMetadata.scripts?.['build:mac:artifacts']).toContain('node scripts/build-release-vector-smoke-runner.mjs')
     expect(packageMetadata.scripts?.['build:mac:artifacts']).toContain('electron-builder --mac --arm64 --publish never')
     expect(packageMetadata.scripts?.['smoke:mac-dmg']).toContain('scripts/smoke-macos-dmg.sh')
     expect(smokeScript).toContain('hdiutil attach')
@@ -71,6 +76,12 @@ describe('macOS ARM64 cloud build workflow contract', () => {
     expect(smokeScript).toContain('secureFileSystemSmoke: true')
     expect(smokeScript).toContain('run_with_timeout')
     expect(smokeScript).toContain('Package smoke process exceeded timeout')
+    expect(smokeScript).toContain('ELECTRON_RUN_AS_NODE=1')
+    expect(smokeScript).toContain('release-vector-smoke-runner.cjs')
+    expect(vectorRunnerBuildScript).toContain('release-vector-smoke-runner.ts')
+    expect(vectorRunnerBuildScript).toContain("platform: 'node'")
+    expect(vectorRunnerSource).toContain('runReleaseVectorSmoke')
+    expect(vectorRunnerSource).toContain('Packaged vector smoke timed out after 90 seconds')
     expect(manifestScript).toContain("platform: 'darwin'")
     expect(manifestScript).toContain("arch: 'arm64'")
     expect(manifestScript).toContain("gateLevel: 'RUNTIME_VERIFIED'")

--- a/scripts/build-release-vector-smoke-runner.mjs
+++ b/scripts/build-release-vector-smoke-runner.mjs
@@ -1,0 +1,15 @@
+import { build } from 'esbuild'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+
+await build({
+  entryPoints: [path.join(repositoryRoot, 'electron', 'release-vector-smoke-runner.ts')],
+  bundle: true,
+  external: ['better-sqlite3', '@lancedb/lancedb'],
+  format: 'cjs',
+  outfile: path.join(repositoryRoot, 'dist-electron', 'release-vector-smoke-runner.cjs'),
+  platform: 'node',
+  target: ['node22'],
+})

--- a/scripts/smoke-macos-dmg.sh
+++ b/scripts/smoke-macos-dmg.sh
@@ -46,6 +46,11 @@ if [[ ! -x "$secure_helper" ]]; then
   echo "Missing executable Darwin secure file-system helper: $secure_helper" >&2
   exit 1
 fi
+vector_runner="$app/Contents/Resources/app.asar/dist-electron/release-vector-smoke-runner.cjs"
+if [[ ! -f "$app/Contents/Resources/app.asar" ]]; then
+  echo 'Mounted application does not contain app.asar.' >&2
+  exit 1
+fi
 
 run_with_timeout() {
   local label="$1"
@@ -112,9 +117,9 @@ token="$(node -e "process.stdout.write(require('node:crypto').randomBytes(32).to
 vector_evidence="$qualification_directory/packaged-vector-smoke.json"
 homepage_evidence="$qualification_directory/packaged-official-homepage-smoke.json"
 
-run_with_timeout 'packaged vector smoke' 300 env \
-  HOME="$smoke_home" AI_NOVEL_RELEASE_SMOKE=1 AI_NOVEL_RELEASE_SMOKE_TOKEN="$token" \
-  "$executable" "--ai-novel-release-smoke=$token" > "$vector_evidence"
+run_with_timeout 'packaged vector smoke' 120 env \
+  ELECTRON_RUN_AS_NODE=1 HOME="$smoke_home" AI_NOVEL_RELEASE_SMOKE=1 AI_NOVEL_RELEASE_SMOKE_TOKEN="$token" \
+  "$executable" "$vector_runner" "--ai-novel-release-smoke=$token" > "$vector_evidence"
 run_with_timeout 'packaged official homepage smoke' 300 env \
   HOME="$smoke_home" AI_NOVEL_RELEASE_HOMEPAGE_SMOKE=1 AI_NOVEL_RELEASE_HOMEPAGE_SMOKE_TOKEN="$token" \
   "$executable" "--ai-novel-release-homepage-smoke=$token" > "$homepage_evidence"


### PR DESCRIPTION
## 修复内容 / Fix\n\nmacOS DMG 挂载后，向量资格验证改由 app bundle 内的 Electron 二进制在 ELECTRON_RUN_AS_NODE=1 模式执行专用 runner；仍加载包内真实向量链和 native 依赖，但不依赖 GitHub macOS runner 的 GUI ready 生命周期。官网桥接冒烟仍从正式 app 主入口运行。\n\nThe macOS vector qualification now uses the app-bundled Electron binary in ELECTRON_RUN_AS_NODE=1 mode to execute a dedicated runner. It still loads the packaged vector/native dependency chain without relying on a GUI-ready lifecycle. The official-homepage smoke remains on the normal app entry point.\n\n## 验证 / Validation\n\n- macOS 工作流契约与主进程契约：7 passed。\n- TypeScript 与 Bash 语法检查通过。\n- 本机实际运行已打包 runner：768→1536 维度迁移、FTS、语义查询全部通过，并输出 packaged-vector-smoke 证据。\n- Mac CI 失败证据：30475133974 仅有 macOS Cocoa 警告、无任一 JavaScript 阶段标记，外层 300 秒超时；因此本修复只移除无窗口向量探针对 GUI 生命周期的依赖。\n\n合并后重跑 macOS 资格构建；通过后再重跑 Windows 同提交并进行统一发版。