### PR TITLE
fix(macos): package LanceDB ARM64 native binding

### DIFF
--- a/electron/__tests__/package-contract.test.ts
+++ b/electron/__tests__/package-contract.test.ts
@@ -12,8 +12,9 @@ const pkg = JSON.parse(readFileSync('package.json', 'utf8')) as {
 }
 
 describe('release dependency contract', () => {
-  it('uses one pinned package manager and exposes the Windows LanceDB binding', () => {
+  it('uses one pinned package manager and exposes every shipped LanceDB native binding', () => {
     expect(pkg.packageManager).toBe('pnpm@11.11.0')
+    expect(pkg.optionalDependencies?.['@lancedb/lancedb-darwin-arm64']).toBe('0.27.2')
     expect(pkg.optionalDependencies?.['@lancedb/lancedb-win32-x64-msvc']).toBe('0.27.2')
     expect(existsSync('package-lock.json')).toBe(false)
   })

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "vitest": "^4.1.4"
   },
   "optionalDependencies": {
+    "@lancedb/lancedb-darwin-arm64": "0.27.2",
     "@lancedb/lancedb-win32-x64-msvc": "0.27.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,6 +220,9 @@ importers:
         specifier: ^4.1.4
         version: 4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1))
     optionalDependencies:
+      '@lancedb/lancedb-darwin-arm64':
+        specifier: 0.27.2
+        version: 0.27.2
       '@lancedb/lancedb-win32-x64-msvc':
         specifier: 0.27.2
         version: 0.27.2


### PR DESCRIPTION
## What changed\n- Declare the macOS ARM64 LanceDB N-API package as a pinned optional production dependency.\n- Preserve the existing macOS ASAR unpack rule so the native binding is available inside the mounted DMG.\n- Add a release dependency contract test for both shipped native bindings.\n\n## Verification\n- pnpm run typecheck\n- pnpm exec vitest run electron/__tests__/package-contract.test.ts scripts/__tests__/macos-cloud-build-workflow.test.ts\n\nThis fixes macOS qualification run 30476117170, where the packaged app could not resolve @lancedb/lancedb-darwin-arm64.