### PR TITLE
fix(macos): clean up mounted DMG safely

### DIFF
--- a/scripts/__tests__/macos-cloud-build-workflow.test.ts
+++ b/scripts/__tests__/macos-cloud-build-workflow.test.ts
@@ -69,6 +69,8 @@ describe('macOS ARM64 cloud build workflow contract', () => {
     expect(packageMetadata.scripts?.['smoke:mac-dmg']).toContain('scripts/smoke-macos-dmg.sh')
     expect(smokeScript).toContain('hdiutil attach')
     expect(smokeScript).toContain('hdiutil detach')
+    expect(smokeScript).toContain('hdiutil detach "$mount_point" -force -quiet')
+    expect(smokeScript).toContain('rm -rf "$smoke_root" || true')
     expect(smokeScript).toContain('--ai-novel-release-smoke=')
     expect(smokeScript).toContain('--ai-novel-release-homepage-smoke=')
     expect(smokeScript).toContain('security/darwin-safe-file-system')

--- a/scripts/smoke-macos-dmg.sh
+++ b/scripts/smoke-macos-dmg.sh
@@ -20,10 +20,13 @@ smoke_home="$smoke_root/home"
 mounted=0
 
 cleanup() {
+  local exit_status=$?
   if [[ "$mounted" == "1" ]]; then
-    hdiutil detach "$mount_point" -quiet || true
+    hdiutil detach "$mount_point" -force -quiet || true
+    mounted=0
   fi
-  rm -rf "$smoke_root"
+  rm -rf "$smoke_root" || true
+  return "$exit_status"
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
Fix the mounted-DMG smoke cleanup: force-detach the read-only volume, tolerate best-effort temporary cleanup, and preserve the original smoke status. Verified by typecheck, targeted workflow/packaging contract tests, and bash syntax checking.