### PR TITLE
fix(release): accept verified artifact wrapper directory

### DIFF
--- a/scripts/__tests__/promote-cross-platform-runtime-artifacts.test.ts
+++ b/scripts/__tests__/promote-cross-platform-runtime-artifacts.test.ts
@@ -1,7 +1,11 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
   PROMOTION_CONFIRMATION,
   planPromotion,
+  resolvePromotionArtifactRoot,
   verifyRemoteReleaseAssets,
 } from '../promote-cross-platform-runtime-artifacts.mjs'
 
@@ -29,6 +33,23 @@ function jsonResponse(payload: unknown) {
 }
 
 describe('cross-platform artifact promotion planner', () => {
+  it('accepts GitHub artifact-name wrappers but rejects files outside the verified bundle', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'ai-novel-promotion-artifact-'))
+    const bundleRoot = path.join(root, 'windows-cloud-build-runtime-verified', '0.5.0')
+    try {
+      mkdirSync(bundleRoot, { recursive: true })
+      writeFileSync(path.join(bundleRoot, 'manifest.json'), '{}\n', 'utf8')
+
+      expect(resolvePromotionArtifactRoot(root, 'Windows qualification')).toBe(bundleRoot)
+
+      writeFileSync(path.join(root, 'unexpected.txt'), 'unexpected\n', 'utf8')
+      expect(() => resolvePromotionArtifactRoot(root, 'Windows qualification'))
+        .toThrow('Windows qualification artifact contains files outside its verified bundle')
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
   it('selects exactly one immutable Windows and macOS artifact from matching default-branch runs', async () => {
     const responses = new Map<string, unknown>([
       ['', { full_name: repository, default_branch: 'master' }],

--- a/scripts/promote-cross-platform-runtime-artifacts.mjs
+++ b/scripts/promote-cross-platform-runtime-artifacts.mjs
@@ -90,11 +90,17 @@ function exactFileSet(actual, expected, label) {
   assert(JSON.stringify([...actual].sort()) === JSON.stringify([...expected].sort()), `${label} file set is not exact; got ${[...actual].join(', ')}`)
 }
 
-function artifactRoot(root, label) {
-  const manifests = listRegularFiles(root).filter(file => path.posix.basename(file) === 'manifest.json')
+export function resolvePromotionArtifactRoot(root, label) {
+  const files = listRegularFiles(root)
+  const manifests = files.filter(file => path.posix.basename(file) === 'manifest.json')
   assert(manifests.length === 1, `Expected exactly one manifest.json in ${label}, found ${manifests.length}`)
-  const bundleRoot = path.join(root, path.dirname(manifests[0]))
-  exactFileSet(listRegularFiles(root), listRegularFiles(bundleRoot), `${label} artifact`)
+  const bundleRelativePath = path.posix.dirname(manifests[0])
+  const bundleRoot = path.join(root, bundleRelativePath)
+  const bundlePrefix = bundleRelativePath === '.' ? '' : `${bundleRelativePath}/`
+  const filesOutsideBundle = files.filter(file => bundlePrefix !== '' && !file.startsWith(bundlePrefix))
+  assert(filesOutsideBundle.length === 0, `${label} artifact contains files outside its verified bundle: ${filesOutsideBundle.join(', ')}`)
+  const bundleFilesFromRoot = files.map(file => bundlePrefix === '' ? file : file.slice(bundlePrefix.length))
+  exactFileSet(bundleFilesFromRoot, listRegularFiles(bundleRoot), `${label} artifact`)
   return bundleRoot
 }
 
@@ -140,7 +146,7 @@ function validateManifestArtifact(manifest, bundleRoot, expectedFiles, expectedC
 }
 
 function validateWindowsArtifact(root, { expectedSha, lockfileSha256, version }) {
-  const bundleRoot = artifactRoot(root, 'Windows qualification')
+  const bundleRoot = resolvePromotionArtifactRoot(root, 'Windows qualification')
   const installer = `ai-novel-writer-setup-${version}.exe`
   const blockmap = `${installer}.blockmap`
   const evidence = ['qualification/packaged-vector-smoke.json', 'qualification/packaged-official-homepage-smoke.json']
@@ -157,7 +163,7 @@ function validateWindowsArtifact(root, { expectedSha, lockfileSha256, version })
 }
 
 function validateMacosArtifact(root, { expectedSha, lockfileSha256, version }) {
-  const bundleRoot = artifactRoot(root, 'macOS qualification')
+  const bundleRoot = resolvePromotionArtifactRoot(root, 'macOS qualification')
   const dmg = `AI小说作家-Mac-${version}-Installer.dmg`
   const dmgChecksum = `${dmg}.sha256`
   const evidence = [


### PR DESCRIPTION
Fix the cross-platform promotion verifier for the directory wrapper added by actions/download-artifact when immutable artifact IDs are selected. The verifier still requires exactly one manifest and rejects any file outside the verified bundle. Verified with targeted promotion and macOS workflow tests plus typecheck.