### PR TITLE
chore(dsh-plugin): prepare npm publication

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,14 @@
 
 除了 Windows 与 macOS 桌面版，本仓库还在 [插件目录](https://github.com/EthanYoQ/AI-Novel-Writer/tree/master/plugins/dsh-ai-novel-writer) 维护 `@ethanyoq/dsh-ai-novel-writer` `0.1.0` 开发预览。它把项目设置、人物设定、故事蓝图、章节蓝图和章节正文带入 DeepSeek Harness Web，并通过对话中的单文件审批卡片逐项保存；插件使用独立的 Harness 小说项目格式，不读取桌面版 `.vela` 项目。
 
-该插件尚未进入桌面版正式 Release，也未发布到 npm。它是独立 pnpm workspace，拥有独立锁文件、CI 和 MIT 许可；仓库根目录仍为 GPL-3.0 桌面应用。从源码安装时进入插件目录执行：
+该插件尚未进入桌面版正式 Release，但已发布为独立 npm 包，拥有独立锁文件、CI 和 MIT 许可；仓库根目录仍为 GPL-3.0 桌面应用。将它安装到 DeepSeek Harness 的 `web` profile：
+
+```sh
+dsh plugin --profile web add @ethanyoq/dsh-ai-novel-writer
+dsh --profile web
+```
+
+开发时也可以从源码安装：
 
 ```sh
 git clone https://github.com/EthanYoQ/AI-Novel-Writer.git

--- a/README_en.md
+++ b/README_en.md
@@ -45,7 +45,14 @@
 
 In addition to the Windows and macOS desktop editions, the [plugin directory](https://github.com/EthanYoQ/AI-Novel-Writer/tree/master/plugins/dsh-ai-novel-writer) contains the `@ethanyoq/dsh-ai-novel-writer` `0.1.0` developer preview. It brings project settings, characters, story blueprints, chapter blueprints, and chapter drafts into DeepSeek Harness Web, saving one asset at a time through the conversation's approval card. The plugin uses its own Harness novel-project format and does not read desktop `.vela` projects.
 
-The plugin is not part of the desktop application's formal Release and has not been published to npm. It is a separate pnpm workspace with its own lockfile, CI, and MIT license; the repository root remains the GPL-3.0 desktop application. Install it from source in the plugin directory:
+The plugin is not part of the desktop application's formal Release, but it is published as a separate npm package with its own lockfile, CI, and MIT license; the repository root remains the GPL-3.0 desktop application. Install it into the DeepSeek Harness `web` profile:
+
+```sh
+dsh plugin --profile web add @ethanyoq/dsh-ai-novel-writer
+dsh --profile web
+```
+
+For development, install it from source in the plugin directory:
 
 ```sh
 git clone https://github.com/EthanYoQ/AI-Novel-Writer.git

--- a/plugins/dsh-ai-novel-writer/README.md
+++ b/plugins/dsh-ai-novel-writer/README.md
@@ -10,6 +10,17 @@ The package ships three plugin entries:
 - `./agent`, mounted only by the bundled `ai-novel-writer` preset;
 - `./client`, which registers an “AI 小说作家” evidence card in Plugin Configuration and adds the compact “小说工作台” side drawer through the shell overlay.
 
+## Install from npm
+
+Install the published bundle into a DeepSeek Harness profile:
+
+```sh
+dsh plugin --profile web add @ethanyoq/dsh-ai-novel-writer
+dsh --profile web
+```
+
+The desktop application at the repository root is separate and is not an activatable DSH bundle.
+
 ## Configuration
 
 The Host entry accepts `presetRoot`, an absolute path to the user preset root. It defaults to `$DSH_HOME/.agent-presets` (normally `~/.dsh/.agent-presets`). The agent entry accepts `assetBytes`, `workingSetBytes`, and `queryMatches`. Defaults are 512 KiB per asset, 512 KiB per working set, and 20 query matches. Invalid paths or limits fail during plugin loading.
@@ -70,7 +81,7 @@ The preset persona and the two tool definitions are stable across turns. Project
 
 ## Known Limitations and Deferred Work
 
-The package does not import `.vela` projects, provide multi-asset transactions, run batch multi-chapter jobs, or publish itself. All five V1 assets are editable through the compact workbench, but persistence remains a native approval-gated agent action rather than a browser write.
+The package does not import `.vela` projects, provide multi-asset transactions, or run batch multi-chapter jobs. All five V1 assets are editable through the compact workbench, but persistence remains a native approval-gated agent action rather than a browser write.
 
 Build and run the focused qualification with:
 

--- a/plugins/dsh-ai-novel-writer/package.json
+++ b/plugins/dsh-ai-novel-writer/package.json
@@ -2,7 +2,18 @@
   "name": "@ethanyoq/dsh-ai-novel-writer",
   "version": "0.1.0",
   "description": "A local-first novel project plugin for DeepSeek Harness",
-  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/EthanYoQ/AI-Novel-Writer.git",
+    "directory": "plugins/dsh-ai-novel-writer"
+  },
+  "bugs": {
+    "url": "https://github.com/EthanYoQ/AI-Novel-Writer/issues"
+  },
+  "homepage": "https://github.com/EthanYoQ/AI-Novel-Writer/tree/master/plugins/dsh-ai-novel-writer#readme",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "packageManager": "pnpm@11.11.0",
   "main": "lib/index.js",

--- a/plugins/dsh-ai-novel-writer/tests/package.spec.ts
+++ b/plugins/dsh-ai-novel-writer/tests/package.spec.ts
@@ -17,11 +17,19 @@ async function yamlList(path: string): Promise<unknown[]> {
 }
 
 describe('installable AI novel bundle', () => {
-  it('keeps an independent private MIT package face', async () => {
+  it('keeps an independent public MIT package face linked to its source repository', async () => {
     const manifest = JSON.parse(await readFile(join(root, 'package.json'), 'utf8'))
-    expect(manifest.private).toBe(true)
+    expect(manifest.private).toBeUndefined()
     expect(manifest.license).toBe('MIT')
     expect(manifest.packageManager).toBe('pnpm@11.11.0')
+    expect(manifest.publishConfig).toEqual({ access: 'public' })
+    expect(manifest.repository).toEqual({
+      type: 'git',
+      url: 'git+https://github.com/EthanYoQ/AI-Novel-Writer.git',
+      directory: 'plugins/dsh-ai-novel-writer',
+    })
+    expect(manifest.bugs).toEqual({ url: 'https://github.com/EthanYoQ/AI-Novel-Writer/issues' })
+    expect(manifest.homepage).toBe('https://github.com/EthanYoQ/AI-Novel-Writer/tree/master/plugins/dsh-ai-novel-writer#readme')
     for (const packagedFile of ['LICENSE', 'THIRD_PARTY_NOTICES.md']) {
       await expect(readFile(join(root, packagedFile), 'utf8')).resolves.toContain('MIT')
     }


### PR DESCRIPTION
## Summary

- prepares `@ethanyoq/dsh-ai-novel-writer@0.1.0` for public npm distribution;
- adds npm repository metadata pointing to `EthanYoQ/AI-Novel-Writer` and its plugin subdirectory;
- documents profile installation from the registry;
- replaces the private-package assertion with a public package-source association assertion.

## Verification

- `pnpm run typecheck` — passed.
- `pnpm test` — 26 files passed, 194 tests passed, 2 skipped.
- `npm pack --dry-run --json` — passed; tarball contains 26 declared runtime/license/preset files.

## Repository qualification note

`pnpm run qualify -- --harness-root C:\SoftWare\AI Tools\Deepseek Harness` reached the repository-level Electron release-test lane and failed on four existing desktop assertions unrelated to this PR: three missing provider-price snapshots and missing v0.8.2/v0.8.3 README-history assertions. No plugin package test failed.

## Publication boundary

This PR does not publish to npm. Publish only after this source state is merged and registry authentication is available.