### PR TITLE
fix: qualify v0.9.2 after release review

### DIFF
--- a/scripts/__tests__/smoke-win-installer.test.ts
+++ b/scripts/__tests__/smoke-win-installer.test.ts
@@ -345,6 +345,22 @@ function validateUpgradeFixtureWithNode(projectRoot: string, settingsPath?: stri
   )
 }
 
+function applyExpectedDraftUnitMigration(projectRoot: string) {
+  execFileSync(
+    process.execPath,
+    [
+      '-e',
+      "const {DatabaseSync}=require('node:sqlite');const db=new DatabaseSync(process.env.AI_NOVEL_FIXTURE_DB);db.exec('UPDATE drafts SET word_count = CASE id WHEN 71 THEN 32 WHEN 72 THEN 31 ELSE word_count END; UPDATE revisions SET word_count = CASE id WHEN 91 THEN 22 ELSE word_count END');db.close()",
+    ],
+    {
+      env: {
+        ...process.env,
+        AI_NOVEL_FIXTURE_DB: join(projectRoot, '.vela', 'vela.db'),
+      },
+    },
+  )
+}
+
 function writeUpgradeFixtureSettings(settingsPath: string) {
   writeFileSync(settingsPath, JSON.stringify({
     theme: 'light',
@@ -553,6 +569,8 @@ describe('Windows installer smoke contract', () => {
       ])
       closeConnection(projectRoot)
 
+      applyExpectedDraftUnitMigration(projectRoot)
+
       const after = runUpgradeFixtureWithNode('validate', projectRoot, settingsPath)
       expect(after).toMatchObject({
         assetInventoryPath: '.vela/upgrade-data-inventory.json',
@@ -626,6 +644,7 @@ describe('Windows installer smoke contract', () => {
       try {
         writeUpgradeFixtureSettings(settingsPath)
         runUpgradeFixtureWithNode('seed', projectRoot, settingsPath)
+        applyExpectedDraftUnitMigration(projectRoot)
         testCase.mutate(projectRoot, settingsPath)
 
         const rejected = validateUpgradeFixtureWithNode(projectRoot, settingsPath)
@@ -645,6 +664,7 @@ describe('Windows installer smoke contract', () => {
     try {
       writeUpgradeFixtureSettings(settingsPath)
       runUpgradeFixtureWithNode('seed', projectRoot, settingsPath)
+      applyExpectedDraftUnitMigration(projectRoot)
       execFileSync(
         process.execPath,
         [
@@ -3140,6 +3160,7 @@ try {
     const fixtureRoot = mkdtempSync(join(tmpdir(), 'ai-novel-v025-sqlite-fixture-'))
     try {
       const seeded = runUpgradeFixtureWithNode('seed', fixtureRoot)
+      applyExpectedDraftUnitMigration(fixtureRoot)
       const validated = runUpgradeFixture('validate', fixtureRoot)
 
       expect(seeded.databasePath).toBe(join(fixtureRoot, '.vela', 'vela.db'))
@@ -3227,11 +3248,66 @@ try {
     }
   }, 15_000)
 
+  windowsIt('accepts migrated Unicode draft counts without relaxing preserved draft fields', () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), 'ai-novel-v025-draft-count-fixture-'))
+    try {
+      runUpgradeFixtureWithNode('seed', fixtureRoot)
+      const beforeMigration = validateUpgradeFixtureWithNode(fixtureRoot)
+      expect(beforeMigration.status).not.toBe(0)
+      expect(beforeMigration.stderr).toContain('draft word counts were not migrated to the current Unicode algorithm')
+
+      applyExpectedDraftUnitMigration(fixtureRoot)
+
+      expect(runUpgradeFixtureWithNode('validate', fixtureRoot)).toMatchObject({
+        draftCount: 2,
+        finalizedDraftCount: 1,
+      })
+
+      execFileSync(
+        process.execPath,
+        [
+          '-e',
+          "const {DatabaseSync}=require('node:sqlite');const db=new DatabaseSync(process.env.AI_NOVEL_FIXTURE_DB);db.prepare('UPDATE drafts SET word_count=33 WHERE id=71').run();db.close()",
+        ],
+        {
+          env: {
+            ...process.env,
+            AI_NOVEL_FIXTURE_DB: join(fixtureRoot, '.vela', 'vela.db'),
+          },
+        },
+      )
+      const countRejected = validateUpgradeFixtureWithNode(fixtureRoot)
+      expect(countRejected.status).not.toBe(0)
+      expect(countRejected.stderr).toContain('draft word counts were not migrated to the current Unicode algorithm')
+
+      applyExpectedDraftUnitMigration(fixtureRoot)
+
+      execFileSync(
+        process.execPath,
+        [
+          '-e',
+          "const {DatabaseSync}=require('node:sqlite');const db=new DatabaseSync(process.env.AI_NOVEL_FIXTURE_DB);db.prepare(\"UPDATE drafts SET source='rewrite' WHERE id=71\").run();db.close()",
+        ],
+        {
+          env: {
+            ...process.env,
+            AI_NOVEL_FIXTURE_DB: join(fixtureRoot, '.vela', 'vela.db'),
+          },
+        },
+      )
+      const rejected = validateUpgradeFixtureWithNode(fixtureRoot)
+      expect(rejected.status).not.toBe(0)
+      expect(rejected.stderr).toContain('draft identity or content reference changed during upgrade')
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true })
+    }
+  }, 15_000)
+
   windowsIt('rejects corruption in every extended v0.2.5 upgrade table', () => {
     const cases = [
       {
         sql: "UPDATE revisions SET user_prompt='changed' WHERE id=91",
-        message: 'revision records changed during upgrade',
+        message: 'revision identity or content reference changed during upgrade',
       },
       {
         sql: 'UPDATE reviews SET review_index=2 WHERE id=81',
@@ -3259,6 +3335,7 @@ try {
       const fixtureRoot = mkdtempSync(join(tmpdir(), 'ai-novel-v025-table-check-'))
       try {
         runUpgradeFixtureWithNode('seed', fixtureRoot)
+        applyExpectedDraftUnitMigration(fixtureRoot)
         execFileSync(
           process.execPath,
           [
@@ -3287,60 +3364,74 @@ try {
   }, 30_000)
 
   windowsPowerShellIt('runs the SQLite seeder and validator through the project Electron runtime', () => {
-    const output = runInstallerLibrary(`
-$fixtureRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('ai-novel-v025-wrapper-test-' + [guid]::NewGuid().ToString('N'))
+    const fixtureRoot = mkdtempSync(join(tmpdir(), 'ai-novel-v025-wrapper-test-'))
+    const settingsPath = join(fixtureRoot, 'isolated-settings.json')
+    const fixtureRootPowerShell = fixtureRoot.replace(/'/g, "''")
+    const settingsPathPowerShell = settingsPath.replace(/'/g, "''")
+    writeUpgradeFixtureSettings(settingsPath)
+    try {
+      const seededOutput = runInstallerLibrary(`
+$fixtureRoot = '${fixtureRootPowerShell}'
+$settingsPath = '${settingsPathPowerShell}'
 $before = $env:ELECTRON_RUN_AS_NODE
-try {
-  New-Item -ItemType Directory -Path $fixtureRoot -Force | Out-Null
-  $settingsPath = Join-Path $fixtureRoot 'isolated-settings.json'
-  @{ theme = 'light'; locale = 'zh-CN'; proxy = @{ enabled = $false; type = 'http'; host = ''; port = 7890 } } |
-    ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $settingsPath -Encoding utf8
-  $seeded = Invoke-AiNovelUpgradeDataFixture -Mode seed -ProjectRoot $fixtureRoot -SettingsPath $settingsPath
-  $validated = Invoke-AiNovelUpgradeDataFixture -Mode validate -ProjectRoot $fixtureRoot -SettingsPath $settingsPath
-  [pscustomobject]@{
-    SeededCharacters = $seeded.characterCount
-      ValidatedCharacters = $validated.characterCount
-      CurrentStates = $validated.currentStateCount
-      LegacyTables = $validated.legacyTableCount
-      Revisions = $validated.revisionCount
-      Reviews = $validated.reviewCount
-      PostProcessSteps = $validated.postProcessStepCount
-       LlmCalls = $validated.llmCallCount
-       SummarySnapshots = $validated.summarySnapshotCount
-       AssetCount = $validated.assetCount
-       PreservedAssets = $validated.preservedAssetCount
-       EmbeddingDimension = $validated.embeddingSpace.vectorDimension
-       EmbeddingQueryCount = $validated.embeddingSpace.queryResultCount
-       SettingsAssetCount = @($validated.assetInventory | Where-Object { $_.location -eq 'settings' }).Count
-       EnvironmentRestored = $env:ELECTRON_RUN_AS_NODE -eq $before
-    DatabaseExists = Test-Path -LiteralPath (Join-Path $fixtureRoot '.vela\\vela.db') -PathType Leaf
-  } | ConvertTo-Json -Compress
-} finally {
-  Remove-Item -LiteralPath $fixtureRoot -Recurse -Force -ErrorAction SilentlyContinue
-}
+$seeded = Invoke-AiNovelUpgradeDataFixture -Mode seed -ProjectRoot $fixtureRoot -SettingsPath $settingsPath
+[pscustomobject]@{
+  SeededCharacters = $seeded.characterCount
+  EnvironmentRestored = $env:ELECTRON_RUN_AS_NODE -eq $before
+} | ConvertTo-Json -Compress
 `)
-    const result = parseLastJsonLine(output)
+      applyExpectedDraftUnitMigration(fixtureRoot)
+      const validatedOutput = runInstallerLibrary(`
+$fixtureRoot = '${fixtureRootPowerShell}'
+$settingsPath = '${settingsPathPowerShell}'
+$before = $env:ELECTRON_RUN_AS_NODE
+$validated = Invoke-AiNovelUpgradeDataFixture -Mode validate -ProjectRoot $fixtureRoot -SettingsPath $settingsPath
+[pscustomobject]@{
+  ValidatedCharacters = $validated.characterCount
+  CurrentStates = $validated.currentStateCount
+  LegacyTables = $validated.legacyTableCount
+  Revisions = $validated.revisionCount
+  Reviews = $validated.reviewCount
+  PostProcessSteps = $validated.postProcessStepCount
+  LlmCalls = $validated.llmCallCount
+  SummarySnapshots = $validated.summarySnapshotCount
+  AssetCount = $validated.assetCount
+  PreservedAssets = $validated.preservedAssetCount
+  EmbeddingDimension = $validated.embeddingSpace.vectorDimension
+  EmbeddingQueryCount = $validated.embeddingSpace.queryResultCount
+  SettingsAssetCount = @($validated.assetInventory | Where-Object { $_.location -eq 'settings' }).Count
+  EnvironmentRestored = $env:ELECTRON_RUN_AS_NODE -eq $before
+  DatabaseExists = Test-Path -LiteralPath (Join-Path $fixtureRoot '.vela\\vela.db') -PathType Leaf
+} | ConvertTo-Json -Compress
+`)
+      const result = {
+        ...parseLastJsonLine(seededOutput),
+        ...parseLastJsonLine(validatedOutput),
+      }
 
-    expect(result).toEqual({
-      SeededCharacters: 2,
-      ValidatedCharacters: 2,
-      CurrentStates: 2,
-      LegacyTables: 11,
-      Revisions: 1,
-      Reviews: 1,
-      PostProcessSteps: 2,
-      LlmCalls: 2,
-      SummarySnapshots: 2,
-      AssetCount: expect.any(Number),
-      PreservedAssets: expect.any(Number),
-      EmbeddingDimension: 768,
-      EmbeddingQueryCount: 1,
-      SettingsAssetCount: 1,
-      EnvironmentRestored: true,
-      DatabaseExists: true,
-    })
-    expect(result.AssetCount).toBe(result.PreservedAssets)
-    expect(Number(result.AssetCount)).toBeGreaterThanOrEqual(7)
+      expect(result).toEqual({
+        SeededCharacters: 2,
+        ValidatedCharacters: 2,
+        CurrentStates: 2,
+        LegacyTables: 11,
+        Revisions: 1,
+        Reviews: 1,
+        PostProcessSteps: 2,
+        LlmCalls: 2,
+        SummarySnapshots: 2,
+        AssetCount: expect.any(Number),
+        PreservedAssets: expect.any(Number),
+        EmbeddingDimension: 768,
+        EmbeddingQueryCount: 1,
+        SettingsAssetCount: 1,
+        EnvironmentRestored: true,
+        DatabaseExists: true,
+      })
+      expect(result.AssetCount).toBe(result.PreservedAssets)
+      expect(Number(result.AssetCount)).toBeGreaterThanOrEqual(7)
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true })
+    }
   }, 15_000)
 
   windowsPowerShellIt('persists structured failure evidence and removes diagnostics only after success', () => {

--- a/scripts/__tests__/smoke-win-installer.test.ts
+++ b/scripts/__tests__/smoke-win-installer.test.ts
@@ -312,7 +312,9 @@ try {
   return parseLastJsonLine(output)
 }
 
-function runUpgradeFixture(mode: 'seed' | 'validate', projectRoot: string): Record<string, unknown> {
+type UpgradeFixtureMode = 'seed' | 'validate-legacy' | 'validate'
+
+function runUpgradeFixture(mode: UpgradeFixtureMode, projectRoot: string): Record<string, unknown> {
   const output = execFileSync(
     electronNodeRunner,
     [upgradeFixtureScript, mode, projectRoot],
@@ -325,7 +327,7 @@ function runUpgradeFixture(mode: 'seed' | 'validate', projectRoot: string): Reco
 }
 
 function runUpgradeFixtureWithNode(
-  mode: 'seed' | 'validate',
+  mode: UpgradeFixtureMode,
   projectRoot: string,
   settingsPath?: string,
 ): Record<string, unknown> {
@@ -389,6 +391,7 @@ describe('Windows installer smoke contract', () => {
     expect(script).toContain('Take one final desktop snapshot')
     expect(script).toContain('Invoke-AiNovelUpgradeDataFixture')
     expect(script).toContain('upgrade-data-fixture.mjs')
+    expect(script).toContain("[ValidateSet('seed', 'validate-legacy', 'validate')]")
     expect(script).toContain('ELECTRON_RUN_AS_NODE')
     expect(script).toContain('[string]$SettingsPath')
     expect(script).toContain('-SettingsPath $globalConfig')
@@ -419,6 +422,15 @@ describe('Windows installer smoke contract', () => {
     expect(script).toContain('smoke-win-app.ps1')
     expect(script).toContain('VelaHome = $velaHome')
     expect(script).toContain('$appSmokeParameters.ProjectPathToOpen = $upgradeFixtureRoot')
+    const legacyValidation = 'Invoke-AiNovelUpgradeDataFixture -Mode validate-legacy -ProjectRoot $upgradeFixtureRoot'
+    const migratedValidation = '$upgradeValidationEvidence = Invoke-AiNovelUpgradeDataFixture -Mode validate -ProjectRoot $upgradeFixtureRoot'
+    expect(script).toContain(legacyValidation)
+    expect(script).toContain(migratedValidation)
+    expect(script).not.toContain('UPDATE drafts SET word_count')
+    expect(script.indexOf(legacyValidation)).toBeLessThan(script.indexOf('Install-Silently $resolvedInstaller'))
+    expect(script.indexOf(migratedValidation)).toBeGreaterThan(
+      script.indexOf("& (Join-Path $PSScriptRoot 'smoke-win-app.ps1') @appSmokeParameters"),
+    )
     expect(script).toContain('PostExitQuietSeconds = $PostExitQuietSeconds')
     expect(script).toContain('Installer smoke changed existing global configuration')
 
@@ -486,6 +498,11 @@ describe('Windows installer smoke contract', () => {
     expect(fixture).toContain("const ASSET_INVENTORY_RELATIVE_PATH = '.vela/upgrade-data-inventory.json'")
     expect(fixture).toContain("const EMBEDDING_DIMENSION = 768")
     expect(fixture).toContain("const PROMPT_TEMPLATE_RELATIVE_PATH = '.vela/prompts/chapter-style.md'")
+    expect(fixture).toContain('const V1_DRAFT_WORD_COUNTS = Object.freeze({ 71: 37, 72: 38 })')
+    expect(fixture).toContain('const V2_DRAFT_WORD_COUNTS = Object.freeze({ 71: 32, 72: 31 })')
+    expect(fixture).toContain('const V1_REVISION_WORD_COUNTS = Object.freeze({ 91: 30 })')
+    expect(fixture).toContain('const V2_REVISION_WORD_COUNTS = Object.freeze({ 91: 22 })')
+    expect(fixture).not.toContain('Script=Han')
     expect(fixture).toContain('CREATE TABLE project_core')
     expect(fixture).toContain('CREATE TABLE characters')
     expect(fixture).toContain('CREATE TABLE blueprints')
@@ -3252,6 +3269,10 @@ try {
     const fixtureRoot = mkdtempSync(join(tmpdir(), 'ai-novel-v025-draft-count-fixture-'))
     try {
       runUpgradeFixtureWithNode('seed', fixtureRoot)
+      expect(runUpgradeFixtureWithNode('validate-legacy', fixtureRoot)).toMatchObject({
+        draftCount: 2,
+        revisionCount: 1,
+      })
       const beforeMigration = validateUpgradeFixtureWithNode(fixtureRoot)
       expect(beforeMigration.status).not.toBe(0)
       expect(beforeMigration.stderr).toContain('draft word counts were not migrated to the current Unicode algorithm')
@@ -3375,8 +3396,10 @@ $fixtureRoot = '${fixtureRootPowerShell}'
 $settingsPath = '${settingsPathPowerShell}'
 $before = $env:ELECTRON_RUN_AS_NODE
 $seeded = Invoke-AiNovelUpgradeDataFixture -Mode seed -ProjectRoot $fixtureRoot -SettingsPath $settingsPath
+$legacyValidated = Invoke-AiNovelUpgradeDataFixture -Mode validate-legacy -ProjectRoot $fixtureRoot -SettingsPath $settingsPath
 [pscustomobject]@{
   SeededCharacters = $seeded.characterCount
+  LegacyValidatedCharacters = $legacyValidated.characterCount
   EnvironmentRestored = $env:ELECTRON_RUN_AS_NODE -eq $before
 } | ConvertTo-Json -Compress
 `)
@@ -3411,6 +3434,7 @@ $validated = Invoke-AiNovelUpgradeDataFixture -Mode validate -ProjectRoot $fixtu
 
       expect(result).toEqual({
         SeededCharacters: 2,
+        LegacyValidatedCharacters: 2,
         ValidatedCharacters: 2,
         CurrentStates: 2,
         LegacyTables: 11,

--- a/scripts/__tests__/windows-in-app-update-e2e.test.ts
+++ b/scripts/__tests__/windows-in-app-update-e2e.test.ts
@@ -175,7 +175,7 @@ describe('Windows heavy integration timeout contract', () => {
       smokeInstallerTests.match(/runInstallerLibrary\(/g)?.length,
       smokeInstallerTests.match(/runReleaseMonitorLibrary\(/g)?.length,
       smokeInstallerTests.match(/runWinFormsGracefulCloseProbe\(/g)?.length,
-    ]).toEqual([19, 7, 20, 3])
+    ]).toEqual([19, 8, 20, 3])
 
     expect(updateE2eTests).toContain('WINDOWS_POWERSHELL_INTEGRATION_TIMEOUT_MS = 30_000')
     expect(updateE2eTests.match(/^ {2}windowsPowerShellIt\(/gm)).toHaveLength(5)

--- a/scripts/smoke-win-installer.ps1
+++ b/scripts/smoke-win-installer.ps1
@@ -114,7 +114,7 @@ function Get-AiNovelUtf8NonEmptyLines {
 
 function Invoke-AiNovelUpgradeDataFixture {
   param(
-    [Parameter(Mandatory = $true)][ValidateSet('seed', 'validate')][string]$Mode,
+    [Parameter(Mandatory = $true)][ValidateSet('seed', 'validate-legacy', 'validate')][string]$Mode,
     [Parameter(Mandatory = $true)][string]$ProjectRoot,
     [string]$SettingsPath
   )
@@ -790,7 +790,7 @@ try {
     # {project}\.vela\vela.db with all 11 v0.2.5 tables and representative
     # core, draft, revision, review, post-process, LLM, and summary records.
     Invoke-AiNovelUpgradeDataFixture -Mode seed -ProjectRoot $upgradeFixtureRoot -SettingsPath $globalConfig | Out-Null
-    Invoke-AiNovelUpgradeDataFixture -Mode validate -ProjectRoot $upgradeFixtureRoot -SettingsPath $globalConfig | Out-Null
+    Invoke-AiNovelUpgradeDataFixture -Mode validate-legacy -ProjectRoot $upgradeFixtureRoot -SettingsPath $globalConfig | Out-Null
     $upgradeFixtureSeeded = $true
     @(
       @{

--- a/scripts/upgrade-data-fixture.mjs
+++ b/scripts/upgrade-data-fixture.mjs
@@ -172,6 +172,8 @@ const CONTENT_ROWS = [
   },
 ]
 
+const V1_DRAFT_WORD_COUNTS = Object.freeze({ 71: 37, 72: 38 })
+
 const DRAFT_ROWS = [
   {
     id: 71,
@@ -180,7 +182,7 @@ const DRAFT_ROWS = [
     status: 'draft',
     source: 'write',
     content_id: 701,
-    word_count: 37,
+    word_count: V1_DRAFT_WORD_COUNTS[71],
     created_at: '2026-01-02 03:04:05',
     updated_at: '2026-01-02 03:04:05',
   },
@@ -191,33 +193,25 @@ const DRAFT_ROWS = [
     status: 'finalized',
     source: 'rewrite',
     content_id: 702,
-    word_count: 38,
+    word_count: V1_DRAFT_WORD_COUNTS[72],
     created_at: '2026-01-02 03:05:05',
     updated_at: '2026-01-02 03:08:05',
   },
 ]
 
-function countUnicodeDraftUnits(text) {
-  const normalized = text.normalize('NFC')
-  const hanCharacters = normalized.match(/\p{Script=Han}/gu)?.length ?? 0
-  const withoutHan = normalized.replace(/\p{Script=Han}/gu, ' ')
-  const words = withoutHan.match(/\p{L}[\p{L}\p{M}]*(?:['’]\p{L}[\p{L}\p{M}]*)*/gu)?.length ?? 0
-  const otherVisibleCodePoints = [...withoutHan
-    .replace(/\p{L}[\p{L}\p{M}]*(?:['’]\p{L}[\p{L}\p{M}]*)*/gu, '')
-    .replace(/[\s\p{P}\p{S}]/gu, '')]
-    .length
-  return hanCharacters + words + otherVisibleCodePoints
-}
-
-function migratedContentBackedRows(rows) {
+function rowsWithExpectedWordCounts(rows, expectedById) {
   return rows.map((row) => {
-    const content = CONTENT_ROWS.find(candidate => candidate.id === row.content_id)
-    assert(content, `fixture content ${row.content_id} is missing`)
-    return { ...row, word_count: countUnicodeDraftUnits(content.body) }
+    const wordCount = expectedById[row.id]
+    assert(Number.isInteger(wordCount), `fixture word-count expectation for row ${row.id} is missing`)
+    return { ...row, word_count: wordCount }
   })
 }
 
-const MIGRATED_DRAFT_ROWS = migratedContentBackedRows(DRAFT_ROWS)
+// Independent fixture oracle for persisted draft-unit algorithm v2. Keep these
+// reviewed values explicit so a production counter regression cannot make its
+// own upgrade acceptance fixture pass by repeating the same implementation.
+const V2_DRAFT_WORD_COUNTS = Object.freeze({ 71: 32, 72: 31 })
+const MIGRATED_DRAFT_ROWS = rowsWithExpectedWordCounts(DRAFT_ROWS, V2_DRAFT_WORD_COUNTS)
 
 const REVIEW_ROWS = [
   {
@@ -228,6 +222,8 @@ const REVIEW_ROWS = [
     created_at: '2026-01-02 03:07:05',
   },
 ]
+
+const V1_REVISION_WORD_COUNTS = Object.freeze({ 91: 30 })
 
 const REVISION_ROWS = [
   {
@@ -240,13 +236,14 @@ const REVISION_ROWS = [
     user_prompt: '保持克制文风，补足证据链的先后关系',
     review_source_id: 81,
     content_id: 703,
-    word_count: 30,
+    word_count: V1_REVISION_WORD_COUNTS[91],
     created_at: '2026-01-02 03:06:05',
     updated_at: '2026-01-02 03:08:05',
   },
 ]
 
-const MIGRATED_REVISION_ROWS = migratedContentBackedRows(REVISION_ROWS)
+const V2_REVISION_WORD_COUNTS = Object.freeze({ 91: 22 })
+const MIGRATED_REVISION_ROWS = rowsWithExpectedWordCounts(REVISION_ROWS, V2_REVISION_WORD_COUNTS)
 
 const POST_PROCESS_RUN_ROWS = [
   {
@@ -1174,13 +1171,13 @@ async function validate(projectRoot, settingsPath, migratedDraftUnitCounts = tru
 
 async function main() {
   const [mode, projectRoot, settingsPath] = process.argv.slice(2)
-  if (!projectRoot || (mode !== 'seed' && mode !== 'validate')) {
-    throw new Error('Usage: electron upgrade-data-fixture.mjs <seed|validate> <project-root> [settings-path]')
+  if (!projectRoot || !['seed', 'validate-legacy', 'validate'].includes(mode)) {
+    throw new Error('Usage: electron upgrade-data-fixture.mjs <seed|validate-legacy|validate> <project-root> [settings-path]')
   }
 
   const result = mode === 'seed'
     ? await seed(projectRoot, settingsPath)
-    : await validate(projectRoot, settingsPath)
+    : await validate(projectRoot, settingsPath, mode === 'validate')
   process.stdout.write(`${JSON.stringify({ mode, ...result })}\n`)
 }
 

--- a/scripts/upgrade-data-fixture.mjs
+++ b/scripts/upgrade-data-fixture.mjs
@@ -197,6 +197,28 @@ const DRAFT_ROWS = [
   },
 ]
 
+function countUnicodeDraftUnits(text) {
+  const normalized = text.normalize('NFC')
+  const hanCharacters = normalized.match(/\p{Script=Han}/gu)?.length ?? 0
+  const withoutHan = normalized.replace(/\p{Script=Han}/gu, ' ')
+  const words = withoutHan.match(/\p{L}[\p{L}\p{M}]*(?:['’]\p{L}[\p{L}\p{M}]*)*/gu)?.length ?? 0
+  const otherVisibleCodePoints = [...withoutHan
+    .replace(/\p{L}[\p{L}\p{M}]*(?:['’]\p{L}[\p{L}\p{M}]*)*/gu, '')
+    .replace(/[\s\p{P}\p{S}]/gu, '')]
+    .length
+  return hanCharacters + words + otherVisibleCodePoints
+}
+
+function migratedContentBackedRows(rows) {
+  return rows.map((row) => {
+    const content = CONTENT_ROWS.find(candidate => candidate.id === row.content_id)
+    assert(content, `fixture content ${row.content_id} is missing`)
+    return { ...row, word_count: countUnicodeDraftUnits(content.body) }
+  })
+}
+
+const MIGRATED_DRAFT_ROWS = migratedContentBackedRows(DRAFT_ROWS)
+
 const REVIEW_ROWS = [
   {
     id: 81,
@@ -223,6 +245,8 @@ const REVISION_ROWS = [
     updated_at: '2026-01-02 03:08:05',
   },
 ]
+
+const MIGRATED_REVISION_ROWS = migratedContentBackedRows(REVISION_ROWS)
 
 const POST_PROCESS_RUN_ROWS = [
   {
@@ -312,8 +336,10 @@ const CHARACTER_COLUMNS = Object.keys(CHARACTER_ROWS[0])
 const BLUEPRINT_COLUMNS = Object.keys(BLUEPRINT_ROWS[0])
 const CONTENT_COLUMNS = Object.keys(CONTENT_ROWS[0])
 const DRAFT_COLUMNS = Object.keys(DRAFT_ROWS[0])
+const DRAFT_PRESERVED_COLUMNS = DRAFT_COLUMNS.filter(column => column !== 'word_count')
 const REVIEW_COLUMNS = Object.keys(REVIEW_ROWS[0])
 const REVISION_COLUMNS = Object.keys(REVISION_ROWS[0])
+const REVISION_PRESERVED_COLUMNS = REVISION_COLUMNS.filter(column => column !== 'word_count')
 const POST_PROCESS_RUN_COLUMNS = Object.keys(POST_PROCESS_RUN_ROWS[0])
 const POST_PROCESS_STEP_COLUMNS = Object.keys(POST_PROCESS_STEP_ROWS[0])
 const LLM_CALL_COLUMNS = Object.keys(LLM_CALL_ROWS[0])
@@ -991,10 +1017,10 @@ async function seed(projectRoot, settingsPath) {
   seedPhysicalProjectAssets(projectRoot)
   await seedEmbeddingAssets(projectRoot)
   writeAssetInventory(projectRoot, createAssetInventory(projectRoot, settingsPath))
-  return validate(projectRoot, settingsPath)
+  return validate(projectRoot, settingsPath, false)
 }
 
-function validateDatabase(projectRoot) {
+function validateDatabase(projectRoot, migratedDraftUnitCounts) {
   const dbPath = databasePath(projectRoot)
   if (!existsSync(dbPath)) {
     throw new Error(`Upgrade fixture database is missing: ${dbPath}`)
@@ -1036,13 +1062,37 @@ function validateDatabase(projectRoot) {
     assert.deepEqual(contents, CONTENT_ROWS, 'content bodies changed during upgrade')
 
     const drafts = readRows(db, 'drafts', DRAFT_COLUMNS, 'id')
-    assert.deepEqual(drafts, DRAFT_ROWS, 'draft or finalized records changed during upgrade')
+    const expectedDrafts = migratedDraftUnitCounts ? MIGRATED_DRAFT_ROWS : DRAFT_ROWS
+    assert.deepEqual(
+      drafts.map(draft => normalizeRow(draft, DRAFT_PRESERVED_COLUMNS)),
+      DRAFT_ROWS.map(draft => normalizeRow(draft, DRAFT_PRESERVED_COLUMNS)),
+      'draft identity or content reference changed during upgrade',
+    )
+    assert.deepEqual(
+      drafts.map(({ id, word_count }) => ({ id, word_count })),
+      expectedDrafts.map(({ id, word_count }) => ({ id, word_count })),
+      migratedDraftUnitCounts
+        ? 'draft word counts were not migrated to the current Unicode algorithm'
+        : 'legacy draft word counts changed before upgrade',
+    )
 
     const reviews = readRows(db, 'reviews', REVIEW_COLUMNS, 'id')
     assert.deepEqual(reviews, REVIEW_ROWS, 'review records changed during upgrade')
 
     const revisions = readRows(db, 'revisions', REVISION_COLUMNS, 'id')
-    assert.deepEqual(revisions, REVISION_ROWS, 'revision records changed during upgrade')
+    const expectedRevisions = migratedDraftUnitCounts ? MIGRATED_REVISION_ROWS : REVISION_ROWS
+    assert.deepEqual(
+      revisions.map(revision => normalizeRow(revision, REVISION_PRESERVED_COLUMNS)),
+      REVISION_ROWS.map(revision => normalizeRow(revision, REVISION_PRESERVED_COLUMNS)),
+      'revision identity or content reference changed during upgrade',
+    )
+    assert.deepEqual(
+      revisions.map(({ id, word_count }) => ({ id, word_count })),
+      expectedRevisions.map(({ id, word_count }) => ({ id, word_count })),
+      migratedDraftUnitCounts
+        ? 'revision word counts were not migrated to the current Unicode algorithm'
+        : 'legacy revision word counts changed before upgrade',
+    )
 
     const postProcessRuns = readRows(
       db,
@@ -1106,8 +1156,8 @@ function validateDatabase(projectRoot) {
   }
 }
 
-async function validate(projectRoot, settingsPath) {
-  const databaseEvidence = validateDatabase(projectRoot)
+async function validate(projectRoot, settingsPath, migratedDraftUnitCounts = true) {
+  const databaseEvidence = validateDatabase(projectRoot, migratedDraftUnitCounts)
   const embeddingSpace = await validateEmbeddingAssets(projectRoot)
   const inventoryEvidence = validateAssetInventory(
     projectRoot,

--- a/src/components/dialogs/ImportNovelDialog.tsx
+++ b/src/components/dialogs/ImportNovelDialog.tsx
@@ -13,7 +13,11 @@ import type {
 } from '../../shared/import-run'
 import { AUTHOR_IMPORT_PREVIEW_STALE } from '../../shared/import-run'
 import type { AuthorManuscriptImportPreview } from '../../shared/author-manuscript-import'
-import { createImportWorkflow, estimateImportCost } from '../../services/workflows/import-workflow'
+import {
+  createImportWorkflow,
+  estimateImportCost,
+  loadAuthorImportChapterNumbers,
+} from '../../services/workflows/import-workflow'
 import {
   Dialog, DialogContent, DialogHeader, DialogFooter, DialogTitle, DialogDescription,
 } from '../ui/Dialog'
@@ -248,17 +252,22 @@ export default function ImportNovelDialog({ open, onClose }: ImportNovelDialogPr
     if (selected) setSavePath(selected)
   }, [])
 
-  const launchRun = useCallback((run: ImportRunSnapshot) => {
+  const launchRun = useCallback(async (run: ImportRunSnapshot) => {
     const project = useProjectStore.getState().currentProject
     const projectSession = captureProjectSession(project)
     if (!project || !projectSession) {
       throw new Error(text('当前项目会话已失效，无法启动导入', 'The project session expired, so the import cannot start.'))
     }
+    const authorChapterNumbers = run.purpose === 'author-manuscript'
+      ? await loadAuthorImportChapterNumbers(run, projectSession, project.path)
+      : undefined
+    if (!isProjectSessionCurrent(projectSession)) return
     const workflow = createImportWorkflow({
       run,
       projectPath: project.path,
       projectSession,
       executionOwner: randomUUID(),
+      authorChapterNumbers,
     })
     void startWorkflow(workflow, false).catch(error => {
       console.error('[ImportNovel] 导入工作流失败:', error)
@@ -266,7 +275,7 @@ export default function ImportNovelDialog({ open, onClose }: ImportNovelDialogPr
     if (isProjectSessionCurrent(projectSession)) onClose()
   }, [onClose, startWorkflow, text])
 
-  const applyPreparation = useCallback((
+  const applyPreparation = useCallback(async (
     preparation: ImportRunPreparationResult,
     projectSession: ProjectSessionContext,
     consumedRunId?: string,
@@ -309,7 +318,7 @@ export default function ImportNovelDialog({ open, onClose }: ImportNovelDialogPr
       return
     }
     if (!preparation.run) throw new Error(text('导入运行缺少持久化记录', 'The import run has no persisted record.'))
-    launchRun(preparation.run)
+    await launchRun(preparation.run)
   }, [launchRun, text])
 
   /** 执行导入 */
@@ -341,7 +350,7 @@ export default function ImportNovelDialog({ open, onClose }: ImportNovelDialogPr
         const preparation = selectionPreparation!
         setSelectionPreparation(null)
         setSelectionProjectLeaseId('')
-        applyPreparation(preparation, projectSession)
+        await applyPreparation(preparation, projectSession)
         return
       }
 
@@ -401,7 +410,7 @@ export default function ImportNovelDialog({ open, onClose }: ImportNovelDialogPr
         return
       }
       if (!preparation.run) throw new Error(text('导入运行缺少持久化记录', 'The import run has no persisted record.'))
-      launchRun(preparation.run)
+      await launchRun(preparation.run)
     } catch (e) {
       console.error('[ImportNovel] 导入失败:', e)
       if (purpose === 'author-manuscript') {
@@ -445,7 +454,7 @@ export default function ImportNovelDialog({ open, onClose }: ImportNovelDialogPr
           '无法完成已解析的导入，请重试。',
           'Could not finalize the parsed import. Please try again.',
         ))
-        applyPreparation(result.preparation, projectSession, resumableRun.id)
+        await applyPreparation(result.preparation, projectSession, resumableRun.id)
       } catch (error) {
         if (!isProjectSessionCurrent(projectSession)) return
         setSplitError(error instanceof Error ? error.message : String(error))
@@ -454,7 +463,7 @@ export default function ImportNovelDialog({ open, onClose }: ImportNovelDialogPr
       }
       return
     }
-    launchRun(resumableRun)
+    await launchRun(resumableRun)
   }
 
   const handleRestart = async () => {
@@ -492,7 +501,7 @@ export default function ImportNovelDialog({ open, onClose }: ImportNovelDialogPr
         if (!isProjectSessionCurrent(session)) return
         return
       }
-      launchRun(result.run)
+      await launchRun(result.run)
     } catch (error) {
       if (!isProjectSessionCurrent(session)) return
       setSplitError(error instanceof Error ? error.message : String(error))

--- a/src/components/dialogs/__tests__/import-novel-resume.browser.tsx
+++ b/src/components/dialogs/__tests__/import-novel-resume.browser.tsx
@@ -24,6 +24,23 @@ let preparation: ImportRunPreparationResult
 let authorPreview: AuthorManuscriptImportPreview
 let prepareError = ''
 let prepareErrorCode = ''
+let durableAuthorChapters: Record<string, number[]>
+
+function durableAuthorChapterPage(args: unknown[]) {
+  const runId = String(args[0])
+  const afterChapterNumber = Number(args[1])
+  const limit = Number(args[2])
+  return (durableAuthorChapters[runId] ?? [])
+    .filter(number => number > afterChapterNumber)
+    .slice(0, limit)
+    .map(number => ({
+      number,
+      title: `Chapter ${number}`,
+      contentFingerprint: String(number).padStart(64, '0'),
+      contentSize: 1,
+      content: 'x',
+    }))
+}
 
 function deferred<T>() {
   let resolve!: (value: T) => void
@@ -88,6 +105,7 @@ beforeEach(async () => {
   }
   prepareError = ''
   prepareErrorCode = ''
+  durableAuthorChapters = { 'persisted-import': [1] }
   authorPreview = {
     classification: 'ready', authorityFingerprint: 'c'.repeat(64), manifestFingerprint: 'd'.repeat(64),
     chapterCount: 1, targetStatus: 'finalized', nextChapterNumber: 2,
@@ -114,6 +132,7 @@ beforeEach(async () => {
       ? { success: false, error: prepareError || undefined, errorCode: prepareErrorCode || undefined }
       : { success: true, preparation }
     if (channel === 'db:import-run-author-preview') return authorPreview
+    if (channel === 'db:import-run-list-chapters') return durableAuthorChapterPage(args)
     if (channel === 'db:project-core-get') return null
     if (channel === 'db:blueprint-get-all') return []
     if (channel === 'db:draft-list') return []
@@ -501,6 +520,7 @@ describe('current-project reference import', () => {
       totalChapters: 1,
       manifestChapterCount: 3,
     })
+    durableAuthorChapters[incrementalRun.id] = [3]
     invoke.mockImplementation(async (channel: string, ...args: unknown[]) => {
       if (channel === 'db:import-run-list-resumable') return []
       if (channel === 'dialog:select-novel-files') return {
@@ -513,6 +533,7 @@ describe('current-project reference import', () => {
         },
       }
       if (channel === 'db:import-run-author-preview') return fullPreview
+      if (channel === 'db:import-run-list-chapters') return durableAuthorChapterPage(args)
       if (channel === 'db:import-run-prepare-inspection') {
         expect(args[0]).toMatchObject({
           authorityFingerprint: fullPreview.authorityFingerprint,
@@ -586,6 +607,7 @@ describe('current-project reference import', () => {
       totalChapters: 1,
       manifestChapterCount: 3,
     })
+    durableAuthorChapters[freshRun.id] = [3]
     invoke.mockImplementation(async (channel: string, ...args: unknown[]) => {
       if (channel === 'db:import-run-list-resumable') return [oldRun]
       if (channel === 'dialog:select-novel-files') return {
@@ -602,6 +624,7 @@ describe('current-project reference import', () => {
         },
       }
       if (channel === 'db:import-run-author-preview') return freshPreview
+      if (channel === 'db:import-run-list-chapters') return durableAuthorChapterPage(args)
       if (channel === 'db:import-run-prepare-inspection') {
         expect(args[0]).toMatchObject({
           runId: expect.not.stringMatching(/^stale-precommit-author-run$/),
@@ -743,8 +766,10 @@ describe('current-project reference import', () => {
       lastError: 'continuity unavailable',
       completedBatches: { 'author-commit': ['done'], 'author-publish': ['chapter:1'] },
     })
-    invoke.mockImplementation(async (channel: string) => {
+    durableAuthorChapters[resumable.id] = [1]
+    invoke.mockImplementation(async (channel: string, ...args: unknown[]) => {
       if (channel === 'db:import-run-list-resumable') return [resumable]
+      if (channel === 'db:import-run-list-chapters') return durableAuthorChapterPage(args)
       if (channel === 'db:project-core-get') return null
       if (channel === 'db:blueprint-get-all') return []
       return { success: true }

--- a/src/services/workflows/__tests__/architecture-workflow-project-context.test.ts
+++ b/src/services/workflows/__tests__/architecture-workflow-project-context.test.ts
@@ -168,7 +168,7 @@ describe('architecture workflow project context', () => {
       projectSession: { projectId: 'project-A', leaseId: 'lease-A', projectPath: 'C:/projects/A' },
       selectedSteps: ['premise', 'characters'],
     })
-    expect(workflow.resourceKeys).toEqual(['architecture'])
+    expect(workflow.resourceKeys).toEqual(['architecture', 'character-roster'])
     expect(workflow.readResourceKeys).toEqual(['novel-config'])
     useProjectStore.setState({
       currentProject: {

--- a/src/services/workflows/__tests__/batch-chapter-workflow.test.ts
+++ b/src/services/workflows/__tests__/batch-chapter-workflow.test.ts
@@ -139,6 +139,11 @@ describe('batch chapter workflow limits', () => {
     })
 
     expect(workflow.type).toBe('batch_generate')
+    expect(workflow.resourceKeys).toEqual(expect.arrayContaining([
+      'character-roster',
+      'continuity',
+      'chapter-summary',
+    ]))
     expect(workflow.steps).toHaveLength(MAX_BATCH_CHAPTERS)
     expect(workflow.steps[0]).toMatchObject({ name: '第4章：自动定稿与后处理' })
     expect(workflow.steps[MAX_BATCH_CHAPTERS - 1]).toMatchObject({ name: '第13章：自动定稿与后处理' })

--- a/src/services/workflows/__tests__/directory-workflow.test.ts
+++ b/src/services/workflows/__tests__/directory-workflow.test.ts
@@ -351,7 +351,7 @@ describe('directory workflow project context', () => {
       leaseId: projectA.sessionLease!,
       projectPath: projectA.path,
     })
-    expect(workflow.resourceKeys).toEqual(['blueprints'])
+    expect(workflow.resourceKeys).toEqual(['blueprints', 'character-roster'])
     expect(workflow.readResourceKeys).toEqual(['novel-config', 'architecture'])
     const context: WorkflowContext = {
       runId: 'test-run',

--- a/src/services/workflows/__tests__/import-workflow.test.ts
+++ b/src/services/workflows/__tests__/import-workflow.test.ts
@@ -77,10 +77,14 @@ describe('createImportWorkflow', () => {
       manifestChapterCount: 2,
       authorityFingerprint: 'c'.repeat(64),
     })
-    ipcMocks.invoke.mockResolvedValue([
-      { number: 2, title: 'Second', contentFingerprint: 'a'.repeat(64), contentSize: 1, content: 'a' },
-      { number: 7, title: 'Seventh', contentFingerprint: 'b'.repeat(64), contentSize: 1, content: 'b' },
-    ])
+    ipcMocks.invoke.mockImplementation(async (_session, _channel, _runId, after) => (
+      after === 0
+        ? [
+            { number: 2, title: 'Second', contentFingerprint: 'a'.repeat(64), contentSize: 1, content: 'a' },
+            { number: 7, title: 'Seventh', contentFingerprint: 'b'.repeat(64), contentSize: 1, content: 'b' },
+          ]
+        : []
+    ))
 
     await expect(loadAuthorImportChapterNumbers(snapshot, session, session.projectPath))
       .resolves.toEqual([2, 7])
@@ -92,6 +96,38 @@ describe('createImportWorkflow', () => {
       100,
       session.projectPath,
     )
+    expect(ipcMocks.invoke).toHaveBeenCalledWith(
+      session,
+      'db:import-run-list-chapters',
+      snapshot.id,
+      7,
+      100,
+      session.projectPath,
+    )
+  })
+
+  it('rejects an author manifest with durable rows beyond the declared chapter count', async () => {
+    const snapshot = run({
+      purpose: 'author-manuscript',
+      effectNamespace: 'import:author-manuscript:import-run-1',
+      stage: 'author-publish',
+      totalChapters: 2,
+      manifestChapterCount: 2,
+      authorityFingerprint: 'c'.repeat(64),
+    })
+    ipcMocks.invoke.mockImplementation(async (_session, _channel, _runId, after) => {
+      if (after === 0) return [
+        { number: 2, title: 'Second', contentFingerprint: 'a'.repeat(64), contentSize: 1, content: 'a' },
+        { number: 7, title: 'Seventh', contentFingerprint: 'b'.repeat(64), contentSize: 1, content: 'b' },
+      ]
+      if (after === 7) return [
+        { number: 9, title: 'Ninth', contentFingerprint: 'd'.repeat(64), contentSize: 1, content: 'd' },
+      ]
+      return []
+    })
+
+    await expect(loadAuthorImportChapterNumbers(snapshot, session, session.projectPath))
+      .rejects.toThrow('持久化章节清单不完整')
   })
 
   it('freezes the persisted run id, locale, session, and reference-only staged copy', () => {

--- a/src/services/workflows/__tests__/import-workflow.test.ts
+++ b/src/services/workflows/__tests__/import-workflow.test.ts
@@ -20,7 +20,7 @@ vi.mock('../commands/import-novel.command', () => ({
   },
 }))
 
-import { createImportWorkflow } from '../import-workflow'
+import { createImportWorkflow, loadAuthorImportChapterNumbers } from '../import-workflow'
 import {
   IMPORT_RUN_EFFECT_RECEIPT_SCHEMA_VERSION,
   type ImportRunEffectReceipt,
@@ -68,6 +68,32 @@ beforeEach(() => {
 afterEach(() => useProjectStore.setState({ currentProject: null }))
 
 describe('createImportWorkflow', () => {
+  it('loads sparse frozen chapter numbers from a resumed author run manifest', async () => {
+    const snapshot = run({
+      purpose: 'author-manuscript',
+      effectNamespace: 'import:author-manuscript:import-run-1',
+      stage: 'author-publish',
+      totalChapters: 2,
+      manifestChapterCount: 2,
+      authorityFingerprint: 'c'.repeat(64),
+    })
+    ipcMocks.invoke.mockResolvedValue([
+      { number: 2, title: 'Second', contentFingerprint: 'a'.repeat(64), contentSize: 1, content: 'a' },
+      { number: 7, title: 'Seventh', contentFingerprint: 'b'.repeat(64), contentSize: 1, content: 'b' },
+    ])
+
+    await expect(loadAuthorImportChapterNumbers(snapshot, session, session.projectPath))
+      .resolves.toEqual([2, 7])
+    expect(ipcMocks.invoke).toHaveBeenCalledWith(
+      session,
+      'db:import-run-list-chapters',
+      snapshot.id,
+      0,
+      100,
+      session.projectPath,
+    )
+  })
+
   it('freezes the persisted run id, locale, session, and reference-only staged copy', () => {
     const workflow = createImportWorkflow({ projectPath: session.projectPath, projectSession: session, run: run(), executionOwner })
 
@@ -337,6 +363,7 @@ describe('createImportWorkflow', () => {
         authorityFingerprint: 'c'.repeat(64),
       }),
       executionOwner,
+      authorChapterNumbers: [1],
     })
 
     expect(workflow.title).toBe('导入作者原稿（1 章）')
@@ -368,6 +395,7 @@ describe('createImportWorkflow', () => {
       projectSession: session,
       run: snapshot,
       executionOwner,
+      authorChapterNumbers: [1],
     })
     const workflowContext = context()
     workflowContext.data.importRunExecution = {

--- a/src/services/workflows/__tests__/repair-finalize-workflow.test.ts
+++ b/src/services/workflows/__tests__/repair-finalize-workflow.test.ts
@@ -71,7 +71,12 @@ describe('createRepairFinalizeWorkflow', () => {
       readResourceKeys: ['novel-config', 'architecture', 'blueprints'],
     })
     expect(repair).toMatchObject({
-      resourceKeys: ['chapter:3'],
+      resourceKeys: [
+        'chapter:3',
+        'character-roster',
+        'continuity',
+        'chapter-summary',
+      ],
       readResourceKeys: ['novel-config', 'architecture', 'blueprints'],
     })
   })

--- a/src/services/workflows/__tests__/workflow-resource-claims.test.ts
+++ b/src/services/workflows/__tests__/workflow-resource-claims.test.ts
@@ -95,13 +95,19 @@ function createImportRun(purpose: ImportPurpose, totalChapters = 1): ImportRunSn
   }
 }
 
-function createImport(purpose: ImportPurpose, totalChapters = 1) {
-  return createImportWorkflow({
+function createImport(
+  purpose: ImportPurpose,
+  totalChapters = 1,
+  authorChapterNumbers?: readonly number[],
+) {
+  const params = {
     projectPath: PROJECT_PATH,
     projectSession: PROJECT_SESSION,
     run: createImportRun(purpose, totalChapters),
     executionOwner: 'resource-claim-test',
-  })
+    authorChapterNumbers,
+  }
+  return createImportWorkflow(params)
 }
 
 afterEach(() => {
@@ -249,7 +255,7 @@ describe('workflow factory resource claims', () => {
 
   it('serializes author imports on finalized facts while preserving an unrelated draft', () => {
     setCurrentProject()
-    const authorImport = createImport('author-manuscript', 2)
+    const authorImport = createImport('author-manuscript', 2, [2, 7])
     const architecture = createArchitectureWorkflow({
       projectPath: PROJECT_PATH,
       projectSession: PROJECT_SESSION,
@@ -262,8 +268,8 @@ describe('workflow factory resource claims', () => {
     )
 
     expect(authorImport.resourceKeys).toEqual([
-      'chapter:1',
       'chapter:2',
+      'chapter:7',
       'character-roster',
       'continuity',
       'chapter-summary',
@@ -271,6 +277,9 @@ describe('workflow factory resource claims', () => {
     expect(workflowResourceClaimsConflict(authorImport, createFinalize(3))).toBe(true)
     expect(workflowResourceClaimsConflict(authorImport, directory)).toBe(true)
     expect(workflowResourceClaimsConflict(authorImport, architecture)).toBe(true)
+    expect(workflowResourceClaimsConflict(authorImport, createDraft(7))).toBe(true)
+    expect(workflowResourceClaimsConflict(authorImport, createDraft(2))).toBe(true)
+    expect(workflowResourceClaimsConflict(authorImport, createDraft(1))).toBe(false)
     expect(workflowResourceClaimsConflict(authorImport, createDraft(3))).toBe(false)
   })
 })

--- a/src/services/workflows/__tests__/workflow-resource-claims.test.ts
+++ b/src/services/workflows/__tests__/workflow-resource-claims.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { workflowResourceClaimsConflict } from '../../../shared/workflow-resource-claims'
+import { useProjectStore } from '../../../stores/project-store'
+import { useWorkflowStore } from '../../../stores/workflow-store'
+import {
+  createArchitectureWorkflow,
+  migrateLegacyCharacterRoster,
+} from '../architecture-workflow'
+import {
+  createChapterWorkflow,
+  createFinalizeWorkflow,
+} from '../chapter-workflow'
+import { createBatchChapterWorkflow } from '../batch-chapter-workflow'
+import { createDirectoryWorkflow } from '../directory-workflow'
+
+vi.mock('../commands/legacy-character-roster-repair.command', () => ({
+  RepairLegacyCharacterRosterCommand: class {
+    async execute(): Promise<void> {}
+  },
+}))
+
+const PROJECT_PATH = 'C:\\novels\\workflow-resource-claims'
+const PROJECT_SESSION = Object.freeze({
+  projectId: 'workflow-resource-claims',
+  leaseId: 'lease-workflow-resource-claims',
+  projectPath: PROJECT_PATH,
+})
+
+function setCurrentProject(): void {
+  useProjectStore.setState({
+    currentProject: {
+      id: PROJECT_SESSION.projectId,
+      name: 'Workflow resource claims',
+      path: PROJECT_PATH,
+      sessionLease: PROJECT_SESSION.leaseId,
+      novelConfig: {
+        totalChapters: 3,
+        globalGuidance: '',
+        genre: 'mystery',
+      },
+    } as never,
+  })
+}
+
+function createFinalize(chapterNumber: number) {
+  return createFinalizeWorkflow({
+    projectPath: PROJECT_PATH,
+    chapterNumber,
+    chapterTitle: `Chapter ${chapterNumber}`,
+    draftPath: `vela://draft/${chapterNumber}`,
+    draftContent: `Draft ${chapterNumber}`,
+  }, PROJECT_SESSION)
+}
+
+function createDraft(chapterNumber: number) {
+  return createChapterWorkflow({
+    projectPath: PROJECT_PATH,
+    chapterNumber,
+    title: `Chapter ${chapterNumber}`,
+    role: 'development',
+    purpose: 'advance the plot',
+    characters: [],
+    keyEvents: 'an event',
+  }, PROJECT_SESSION)
+}
+
+afterEach(() => {
+  useProjectStore.setState({ currentProject: null })
+  useWorkflowStore.setState({
+    activeRuns: [],
+    history: [],
+    globalLogs: [],
+    waitingRuns: {},
+    currentRun: null,
+    waitingForConfirm: false,
+    waitingAfterStepIndex: -1,
+  })
+})
+
+describe('workflow factory resource claims', () => {
+  it('serializes finalization against shared fact writers', () => {
+    setCurrentProject()
+    const firstFinalize = createFinalize(1)
+    const secondFinalize = createFinalize(2)
+    const directory = createDirectoryWorkflow(
+      { mode: 'full' },
+      PROJECT_PATH,
+      PROJECT_SESSION,
+    )
+
+    expect(firstFinalize.resourceKeys).toEqual(expect.arrayContaining([
+      'character-roster',
+      'continuity',
+      'chapter-summary',
+    ]))
+    expect(directory.resourceKeys).toContain('character-roster')
+    expect(workflowResourceClaimsConflict(firstFinalize, secondFinalize)).toBe(true)
+    expect(workflowResourceClaimsConflict(firstFinalize, directory)).toBe(true)
+  })
+
+  it('keeps different chapter drafts concurrent when neither writes shared facts', () => {
+    expect(workflowResourceClaimsConflict(createDraft(1), createDraft(2))).toBe(false)
+  })
+
+  it('claims shared facts only for batch workflows that auto-finalize', () => {
+    const autoFinalize = createBatchChapterWorkflow({
+      projectPath: PROJECT_PATH,
+      projectSession: PROJECT_SESSION,
+      startChapterNumber: 1,
+      chapterCount: 1,
+      generationModelId: 'test-model',
+      completionMode: 'auto_finalize',
+    })
+    const reviewDrafts = createBatchChapterWorkflow({
+      projectPath: PROJECT_PATH,
+      projectSession: PROJECT_SESSION,
+      startChapterNumber: 3,
+      chapterCount: 1,
+      generationModelId: 'test-model',
+      completionMode: 'draft_review',
+    })
+
+    expect(autoFinalize.resourceKeys).toEqual(expect.arrayContaining([
+      'character-roster',
+      'continuity',
+      'chapter-summary',
+    ]))
+    expect(reviewDrafts.resourceKeys).toEqual(['chapter:3'])
+    expect(workflowResourceClaimsConflict(autoFinalize, createFinalize(2))).toBe(true)
+    expect(workflowResourceClaimsConflict(reviewDrafts, createFinalize(2))).toBe(false)
+  })
+
+  it('serializes character architecture against other character roster writers', () => {
+    setCurrentProject()
+    const architecture = createArchitectureWorkflow({
+      projectPath: PROJECT_PATH,
+      projectSession: PROJECT_SESSION,
+      selectedSteps: ['characters'],
+    })
+    const finalize = createFinalize(1)
+    const directory = createDirectoryWorkflow(
+      { mode: 'full' },
+      PROJECT_PATH,
+      PROJECT_SESSION,
+    )
+
+    expect(architecture.resourceKeys).toContain('character-roster')
+    expect(workflowResourceClaimsConflict(architecture, finalize)).toBe(true)
+    expect(workflowResourceClaimsConflict(architecture, directory)).toBe(true)
+  })
+
+  it('does not claim the character roster when the character architecture step is omitted', () => {
+    setCurrentProject()
+    const premiseOnly = createArchitectureWorkflow({
+      projectPath: PROJECT_PATH,
+      projectSession: PROJECT_SESSION,
+      selectedSteps: ['premise'],
+    })
+
+    expect(premiseOnly.resourceKeys).toEqual(['architecture'])
+  })
+
+  it('serializes the explicit legacy roster repair against roster writers', async () => {
+    setCurrentProject()
+    await migrateLegacyCharacterRoster(PROJECT_PATH)
+
+    const repair = useWorkflowStore.getState().history.find(run => run.type === 'post_process')
+    expect(repair).toBeDefined()
+    expect(repair?.resourceKeys ?? []).toContain('character-roster')
+    const architecture = createArchitectureWorkflow({
+      projectPath: PROJECT_PATH,
+      projectSession: PROJECT_SESSION,
+      selectedSteps: ['characters'],
+    })
+    const directory = createDirectoryWorkflow(
+      { mode: 'full' },
+      PROJECT_PATH,
+      PROJECT_SESSION,
+    )
+    expect(workflowResourceClaimsConflict(repair ?? {}, architecture)).toBe(true)
+    expect(workflowResourceClaimsConflict(repair ?? {}, createFinalize(1))).toBe(true)
+    expect(workflowResourceClaimsConflict(repair ?? {}, directory)).toBe(true)
+  })
+})

--- a/src/services/workflows/__tests__/workflow-resource-claims.test.ts
+++ b/src/services/workflows/__tests__/workflow-resource-claims.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { workflowResourceClaimsConflict } from '../../../shared/workflow-resource-claims'
+import type { ImportPurpose, ImportRunSnapshot } from '../../../shared/import-run'
 import { useProjectStore } from '../../../stores/project-store'
 import { useWorkflowStore } from '../../../stores/workflow-store'
 import {
@@ -13,6 +14,7 @@ import {
 } from '../chapter-workflow'
 import { createBatchChapterWorkflow } from '../batch-chapter-workflow'
 import { createDirectoryWorkflow } from '../directory-workflow'
+import { createImportWorkflow } from '../import-workflow'
 
 vi.mock('../commands/legacy-character-roster-repair.command', () => ({
   RepairLegacyCharacterRosterCommand: class {
@@ -63,6 +65,43 @@ function createDraft(chapterNumber: number) {
     characters: [],
     keyEvents: 'an event',
   }, PROJECT_SESSION)
+}
+
+function createImportRun(purpose: ImportPurpose, totalChapters = 1): ImportRunSnapshot {
+  return {
+    id: `import-${purpose}`,
+    purpose,
+    rootRunId: `import-${purpose}`,
+    effectNamespace: `import:${purpose}:import-${purpose}`,
+    sourceDisplay: [{ displayName: 'novel.txt', mediaType: 'text/plain', size: 20 }],
+    locale: 'en-US',
+    stage: purpose === 'author-manuscript' ? 'author-commit' : 'knowledge',
+    status: 'running',
+    completedBatches: {},
+    lastError: '',
+    resumable: true,
+    cancelRequested: false,
+    totalChapters,
+    totalContentSize: 20,
+    manifestChapterCount: totalChapters,
+    manifestContentSize: 20,
+    manifestWordCount: 20,
+    completedChapters: 0,
+    createdAt: '2026-01-01',
+    updatedAt: '2026-01-01',
+    ...(purpose === 'author-manuscript'
+      ? { authorityFingerprint: 'a'.repeat(64), manifestFingerprint: 'b'.repeat(64) }
+      : {}),
+  }
+}
+
+function createImport(purpose: ImportPurpose, totalChapters = 1) {
+  return createImportWorkflow({
+    projectPath: PROJECT_PATH,
+    projectSession: PROJECT_SESSION,
+    run: createImportRun(purpose, totalChapters),
+    executionOwner: 'resource-claim-test',
+  })
 }
 
 afterEach(() => {
@@ -181,5 +220,57 @@ describe('workflow factory resource claims', () => {
     expect(workflowResourceClaimsConflict(repair ?? {}, architecture)).toBe(true)
     expect(workflowResourceClaimsConflict(repair ?? {}, createFinalize(1))).toBe(true)
     expect(workflowResourceClaimsConflict(repair ?? {}, directory)).toBe(true)
+  })
+
+  it('serializes reference imports against every project-fact writer they overlap', () => {
+    setCurrentProject()
+    const referenceImport = createImport('reference')
+    const architecture = createArchitectureWorkflow({
+      projectPath: PROJECT_PATH,
+      projectSession: PROJECT_SESSION,
+      selectedSteps: ['characters'],
+    })
+    const directory = createDirectoryWorkflow(
+      { mode: 'full' },
+      PROJECT_PATH,
+      PROJECT_SESSION,
+    )
+
+    expect(referenceImport.resourceKeys).toEqual([
+      'novel-config',
+      'architecture',
+      'character-roster',
+      'blueprints',
+    ])
+    expect(workflowResourceClaimsConflict(referenceImport, createFinalize(1))).toBe(true)
+    expect(workflowResourceClaimsConflict(referenceImport, directory)).toBe(true)
+    expect(workflowResourceClaimsConflict(referenceImport, architecture)).toBe(true)
+  })
+
+  it('serializes author imports on finalized facts while preserving an unrelated draft', () => {
+    setCurrentProject()
+    const authorImport = createImport('author-manuscript', 2)
+    const architecture = createArchitectureWorkflow({
+      projectPath: PROJECT_PATH,
+      projectSession: PROJECT_SESSION,
+      selectedSteps: ['characters'],
+    })
+    const directory = createDirectoryWorkflow(
+      { mode: 'full' },
+      PROJECT_PATH,
+      PROJECT_SESSION,
+    )
+
+    expect(authorImport.resourceKeys).toEqual([
+      'chapter:1',
+      'chapter:2',
+      'character-roster',
+      'continuity',
+      'chapter-summary',
+    ])
+    expect(workflowResourceClaimsConflict(authorImport, createFinalize(3))).toBe(true)
+    expect(workflowResourceClaimsConflict(authorImport, directory)).toBe(true)
+    expect(workflowResourceClaimsConflict(authorImport, architecture)).toBe(true)
+    expect(workflowResourceClaimsConflict(authorImport, createDraft(3))).toBe(false)
   })
 })

--- a/src/services/workflows/architecture-workflow.ts
+++ b/src/services/workflows/architecture-workflow.ts
@@ -126,7 +126,10 @@ export function createArchitectureWorkflow(params: ArchitectureWorkflowParams): 
     title: text('生成故事架构', 'Generate story architecture'),
     projectPath: expectedProjectPath,
     projectSession,
-    resourceKeys: [workflowResourceKey('architecture')],
+    resourceKeys: [
+      workflowResourceKey('architecture'),
+      ...(sel.includes('characters') ? [workflowResourceKey('character-roster')] : []),
+    ],
     readResourceKeys: [workflowResourceKey('novel-config')],
     steps: finalSteps,
     onComplete: { mode: 'silent', message: text('故事架构已生成完成！前往侧边栏「故事架构」查看', 'Story architecture is ready. Open Story Architecture from the sidebar.') },
@@ -284,6 +287,7 @@ export async function migrateLegacyCharacterRoster(projectPath: string): Promise
     title: text('修复：旧角色名单', 'Repair: legacy character roster'),
     projectPath,
     projectSession,
+    resourceKeys: [workflowResourceKey('character-roster')],
     steps: [{
       name: text('安全修复旧角色图谱', 'Safely repair the legacy character graph'),
       description: text(

--- a/src/services/workflows/batch-chapter-workflow.ts
+++ b/src/services/workflows/batch-chapter-workflow.ts
@@ -290,6 +290,9 @@ export function createBatchChapterWorkflow(params: BatchChapterWorkflowParams): 
   const chapterWordsTarget = normalizeChapterWordsTarget(params.chapterWordsTarget)
   const endChapterNumber = startChapterNumber + chapterCount - 1
   const draftReviewContinuity = new Map<number, string>()
+  const chapterResourceKeys = Array.from({ length: chapterCount }, (_, index) => (
+    workflowResourceKey('chapter', startChapterNumber + index)
+  ))
 
   return {
     type: 'batch_generate',
@@ -297,9 +300,14 @@ export function createBatchChapterWorkflow(params: BatchChapterWorkflowParams): 
     projectSession: Object.freeze({ ...params.projectSession }),
     generationModelId,
     chapterWordsTarget,
-    resourceKeys: Array.from({ length: chapterCount }, (_, index) => (
-      workflowResourceKey('chapter', startChapterNumber + index)
-    )),
+    resourceKeys: completionMode === 'auto_finalize'
+      ? [
+          ...chapterResourceKeys,
+          workflowResourceKey('character-roster'),
+          workflowResourceKey('continuity'),
+          workflowResourceKey('chapter-summary'),
+        ]
+      : chapterResourceKeys,
     readResourceKeys: [
       workflowResourceKey('novel-config'),
       workflowResourceKey('architecture'),

--- a/src/services/workflows/batch-chapter-workflow.ts
+++ b/src/services/workflows/batch-chapter-workflow.ts
@@ -9,6 +9,7 @@ import type { Locale } from '../../i18n/types'
 import type { ProjectSessionContext } from '../../shared/ipc-channels'
 import { sameProjectPathKey } from '../../shared/project-session-context'
 import type { FinalizationSnapshot } from '../finalization-snapshot'
+import { FINALIZATION_SHARED_WRITE_RESOURCE_KINDS } from '../../shared/workflow-resource-claims'
 import { requireWorkflowProjectSession } from './workflow-project-session'
 import { normalizeChapterWordsTarget } from './chapter-creation-parameters'
 
@@ -303,9 +304,7 @@ export function createBatchChapterWorkflow(params: BatchChapterWorkflowParams): 
     resourceKeys: completionMode === 'auto_finalize'
       ? [
           ...chapterResourceKeys,
-          workflowResourceKey('character-roster'),
-          workflowResourceKey('continuity'),
-          workflowResourceKey('chapter-summary'),
+          ...FINALIZATION_SHARED_WRITE_RESOURCE_KINDS.map(kind => workflowResourceKey(kind)),
         ]
       : chapterResourceKeys,
     readResourceKeys: [

--- a/src/services/workflows/chapter-workflow.ts
+++ b/src/services/workflows/chapter-workflow.ts
@@ -99,6 +99,19 @@ const CHAPTER_CONTEXT_READ_RESOURCE_KEYS = Object.freeze([
   workflowResourceKey('blueprints'),
 ])
 
+const FINALIZE_SHARED_WRITE_RESOURCE_KEYS = Object.freeze([
+  workflowResourceKey('character-roster'),
+  workflowResourceKey('continuity'),
+  workflowResourceKey('chapter-summary'),
+])
+
+function finalizeWriteResourceKeys(chapterNumber: number): readonly string[] {
+  return Object.freeze([
+    workflowResourceKey('chapter', chapterNumber),
+    ...FINALIZE_SHARED_WRITE_RESOURCE_KEYS,
+  ])
+}
+
 function workflowProjectSession(
   projectPath: string,
   sourceProjectSession: ProjectSessionContext,
@@ -323,7 +336,7 @@ export function createFinalizeWorkflow(
     type: 'chapter_creation',
     projectPath: params.projectPath,
     projectSession: workflowProjectSession(params.projectPath, sourceProjectSession),
-    resourceKeys: [workflowResourceKey('chapter', params.chapterNumber)],
+    resourceKeys: finalizeWriteResourceKeys(params.chapterNumber),
     readResourceKeys: CHAPTER_CONTEXT_READ_RESOURCE_KEYS,
     title: `定稿 — 第${params.chapterNumber}章 ${params.chapterTitle}`,
     steps: [
@@ -362,7 +375,7 @@ export function createRepairFinalizeWorkflow(
     type: 'chapter_creation',
     projectPath,
     projectSession: workflowProjectSession(projectPath, sourceProjectSession),
-    resourceKeys: [workflowResourceKey('chapter', chapterNumber)],
+    resourceKeys: finalizeWriteResourceKeys(chapterNumber),
     readResourceKeys: CHAPTER_CONTEXT_READ_RESOURCE_KEYS,
     title: `修复后处理 — 第${chapterNumber}章`,
     steps: [

--- a/src/services/workflows/chapter-workflow.ts
+++ b/src/services/workflows/chapter-workflow.ts
@@ -6,6 +6,7 @@ import { ipc } from '../ipc-client'
 import type { DraftStatus } from '../../shared/draft-status'
 import type { ProjectSessionContext } from '../../shared/ipc-channels'
 import { sameProjectPathKey } from '../../shared/project-session-context'
+import { FINALIZATION_SHARED_WRITE_RESOURCE_KINDS } from '../../shared/workflow-resource-claims'
 import { normalizeChapterWordsTarget } from './chapter-creation-parameters'
 
 // ==========================================
@@ -100,9 +101,7 @@ const CHAPTER_CONTEXT_READ_RESOURCE_KEYS = Object.freeze([
 ])
 
 const FINALIZE_SHARED_WRITE_RESOURCE_KEYS = Object.freeze([
-  workflowResourceKey('character-roster'),
-  workflowResourceKey('continuity'),
-  workflowResourceKey('chapter-summary'),
+  ...FINALIZATION_SHARED_WRITE_RESOURCE_KINDS.map(kind => workflowResourceKey(kind)),
 ])
 
 function finalizeWriteResourceKeys(chapterNumber: number): readonly string[] {

--- a/src/services/workflows/directory-workflow.ts
+++ b/src/services/workflows/directory-workflow.ts
@@ -264,7 +264,10 @@ export function createDirectoryWorkflow(
       title: params.mode === 'append' ? `续写章节蓝图${params.startChapter ? `（从第 ${params.startChapter} 章）` : ''}` : '生成章节蓝图（全量）',
     projectPath: expectedProjectPath,
     projectSession,
-    resourceKeys: [workflowResourceKey('blueprints')],
+    resourceKeys: [
+      workflowResourceKey('blueprints'),
+      workflowResourceKey('character-roster'),
+    ],
     readResourceKeys: [
       workflowResourceKey('novel-config'),
       workflowResourceKey('architecture'),

--- a/src/services/workflows/import-workflow.ts
+++ b/src/services/workflows/import-workflow.ts
@@ -14,7 +14,11 @@ import { sameProjectSessionContext, projectSessionContextFromProject } from '../
 import { ipc } from '../ipc-client'
 import { useProjectStore } from '../../stores/project-store'
 import { workflowResourceKey, type StepCallbacks, type WorkflowContext, type WorkflowDefinition, type WorkflowStep } from '../../stores/workflow-store'
-import { ImportRunOrchestrator, type ImportRunOrchestratorDependencies } from './import-run-orchestrator'
+import {
+  IMPORT_CHAPTER_PAGE_SIZE,
+  ImportRunOrchestrator,
+  type ImportRunOrchestratorDependencies,
+} from './import-run-orchestrator'
 import { refreshImportDerivedFileTreeBestEffort } from './import-derived-refresh'
 import { promptLanguageText } from '../prompt-language'
 import { retryDirectoryCharacterSync } from './directory-character-sync-recovery'
@@ -28,6 +32,8 @@ export interface ImportWorkflowParams {
   run: ImportRunSnapshot
   /** One frozen renderer execution identity for every step in this workflow. */
   executionOwner: string
+  /** Durable manifest chapter numbers; required for author-manuscript writes. */
+  authorChapterNumbers?: readonly number[]
 }
 
 function textForLocale(locale: ImportRunSnapshot['locale'], zhCNText: string, enUSText: string): string {
@@ -37,6 +43,49 @@ function textForLocale(locale: ImportRunSnapshot['locale'], zhCNText: string, en
 function required<T>(result: { success: boolean; error?: string } & T, fallback: string): T {
   if (!result.success) throw new Error(result.error || fallback)
   return result
+}
+
+function normalizeAuthorChapterNumbers(
+  run: ImportRunSnapshot,
+  values: readonly number[] | undefined,
+): readonly number[] {
+  const chapterNumbers = [...new Set(values ?? [])].sort((left, right) => left - right)
+  if (
+    chapterNumbers.length !== run.totalChapters
+    || chapterNumbers.some(number => !Number.isSafeInteger(number) || number < 1)
+  ) {
+    throw new Error(textForLocale(
+      run.locale,
+      '作者原稿的持久化章节清单不完整，无法安全启动导入。',
+      'The persisted author-manuscript chapter manifest is incomplete, so the import cannot start safely.',
+    ))
+  }
+  return Object.freeze(chapterNumbers)
+}
+
+export async function loadAuthorImportChapterNumbers(
+  run: ImportRunSnapshot,
+  projectSession: ProjectSessionContext,
+  projectPath: string,
+): Promise<readonly number[]> {
+  const chapterNumbers: number[] = []
+  let afterChapterNumber = 0
+  while (chapterNumbers.length < run.totalChapters) {
+    const page = await ipc.invokeWithProjectSession(
+      projectSession,
+      'db:import-run-list-chapters',
+      run.id,
+      afterChapterNumber,
+      IMPORT_CHAPTER_PAGE_SIZE,
+      projectPath,
+    )
+    if (page.length === 0) break
+    chapterNumbers.push(...page.map(chapter => chapter.number))
+    const nextAfterChapterNumber = page[page.length - 1]!.number
+    if (nextAfterChapterNumber <= afterChapterNumber) break
+    afterChapterNumber = nextAfterChapterNumber
+  }
+  return normalizeAuthorChapterNumbers(run, chapterNumbers)
 }
 
 function importedChapter(chapter: ImportRunChapterSnapshot) {
@@ -450,6 +499,10 @@ export function createImportWorkflow(params: ImportWorkflowParams): WorkflowDefi
     },
   }
   if (params.run.purpose === 'author-manuscript') {
+    const authorChapterNumbers = normalizeAuthorChapterNumbers(
+      params.run,
+      params.authorChapterNumbers,
+    )
     return {
       runId: params.run.id,
       type: 'novel_import',
@@ -462,7 +515,7 @@ export function createImportWorkflow(params: ImportWorkflowParams): WorkflowDefi
       projectSession: session,
       uiLocale: params.run.locale,
       resourceKeys: [
-        ...Array.from({ length: count }, (_, index) => workflowResourceKey('chapter', index + 1)),
+        ...authorChapterNumbers.map(chapterNumber => workflowResourceKey('chapter', chapterNumber)),
         ...FINALIZATION_SHARED_WRITE_RESOURCE_KINDS.map(kind => workflowResourceKey(kind)),
       ],
       readResourceKeys: contextReadResourceKeys,

--- a/src/services/workflows/import-workflow.ts
+++ b/src/services/workflows/import-workflow.ts
@@ -13,13 +13,14 @@ import type { FinalizedDraftImportReceipt } from '../../shared/finalized-draft-i
 import { sameProjectSessionContext, projectSessionContextFromProject } from '../../shared/project-session-context'
 import { ipc } from '../ipc-client'
 import { useProjectStore } from '../../stores/project-store'
-import type { StepCallbacks, WorkflowContext, WorkflowDefinition, WorkflowStep } from '../../stores/workflow-store'
+import { workflowResourceKey, type StepCallbacks, type WorkflowContext, type WorkflowDefinition, type WorkflowStep } from '../../stores/workflow-store'
 import { ImportRunOrchestrator, type ImportRunOrchestratorDependencies } from './import-run-orchestrator'
 import { refreshImportDerivedFileTreeBestEffort } from './import-derived-refresh'
 import { promptLanguageText } from '../prompt-language'
 import { retryDirectoryCharacterSync } from './directory-character-sync-recovery'
 import type { WritingLanguage } from '../../shared/writing-language'
 import { countDraftUnits } from '../../shared/draft-units'
+import { FINALIZATION_SHARED_WRITE_RESOURCE_KINDS } from '../../shared/workflow-resource-claims'
 
 export interface ImportWorkflowParams {
   projectPath: string
@@ -391,6 +392,11 @@ export function createImportWorkflow(params: ImportWorkflowParams): WorkflowDefi
   const session = Object.freeze({ ...params.projectSession })
   const count = params.run.totalChapters
   const chapterCountEn = `${count} ${count === 1 ? 'chapter' : 'chapters'}`
+  const contextReadResourceKeys = [
+    workflowResourceKey('novel-config'),
+    workflowResourceKey('architecture'),
+    workflowResourceKey('blueprints'),
+  ]
   const durableCancelHooks: Pick<
     WorkflowDefinition,
     'onCancelRequested' | 'onCancelledAtBoundary'
@@ -455,6 +461,11 @@ export function createImportWorkflow(params: ImportWorkflowParams): WorkflowDefi
       projectPath: params.projectPath,
       projectSession: session,
       uiLocale: params.run.locale,
+      resourceKeys: [
+        ...Array.from({ length: count }, (_, index) => workflowResourceKey('chapter', index + 1)),
+        ...FINALIZATION_SHARED_WRITE_RESOURCE_KINDS.map(kind => workflowResourceKey(kind)),
+      ],
+      readResourceKeys: contextReadResourceKeys,
       ...durableCancelHooks,
       steps: [
         importStep(params.run, params.executionOwner, 'author-commit',
@@ -491,6 +502,12 @@ export function createImportWorkflow(params: ImportWorkflowParams): WorkflowDefi
     projectPath: params.projectPath,
     projectSession: session,
     uiLocale: params.run.locale,
+    resourceKeys: [
+      workflowResourceKey('novel-config'),
+      workflowResourceKey('architecture'),
+      workflowResourceKey('character-roster'),
+      workflowResourceKey('blueprints'),
+    ],
     ...durableCancelHooks,
     steps: [
       importStep(params.run, params.executionOwner, 'knowledge',

--- a/src/services/workflows/import-workflow.ts
+++ b/src/services/workflows/import-workflow.ts
@@ -45,6 +45,14 @@ function required<T>(result: { success: boolean; error?: string } & T, fallback:
   return result
 }
 
+function incompleteAuthorManifestError(run: ImportRunSnapshot): Error {
+  return new Error(textForLocale(
+    run.locale,
+    '作者原稿的持久化章节清单不完整，无法安全启动导入。',
+    'The persisted author-manuscript chapter manifest is incomplete, so the import cannot start safely.',
+  ))
+}
+
 function normalizeAuthorChapterNumbers(
   run: ImportRunSnapshot,
   values: readonly number[] | undefined,
@@ -54,11 +62,7 @@ function normalizeAuthorChapterNumbers(
     chapterNumbers.length !== run.totalChapters
     || chapterNumbers.some(number => !Number.isSafeInteger(number) || number < 1)
   ) {
-    throw new Error(textForLocale(
-      run.locale,
-      '作者原稿的持久化章节清单不完整，无法安全启动导入。',
-      'The persisted author-manuscript chapter manifest is incomplete, so the import cannot start safely.',
-    ))
+    throw incompleteAuthorManifestError(run)
   }
   return Object.freeze(chapterNumbers)
 }
@@ -70,7 +74,8 @@ export async function loadAuthorImportChapterNumbers(
 ): Promise<readonly number[]> {
   const chapterNumbers: number[] = []
   let afterChapterNumber = 0
-  while (chapterNumbers.length < run.totalChapters) {
+  let hasMore = true
+  while (hasMore) {
     const page = await ipc.invokeWithProjectSession(
       projectSession,
       'db:import-run-list-chapters',
@@ -79,10 +84,13 @@ export async function loadAuthorImportChapterNumbers(
       IMPORT_CHAPTER_PAGE_SIZE,
       projectPath,
     )
-    if (page.length === 0) break
+    if (page.length === 0) {
+      hasMore = false
+      continue
+    }
     chapterNumbers.push(...page.map(chapter => chapter.number))
     const nextAfterChapterNumber = page[page.length - 1]!.number
-    if (nextAfterChapterNumber <= afterChapterNumber) break
+    if (nextAfterChapterNumber <= afterChapterNumber) throw incompleteAuthorManifestError(run)
     afterChapterNumber = nextAfterChapterNumber
   }
   return normalizeAuthorChapterNumbers(run, chapterNumbers)

--- a/src/shared/workflow-resource-claims.ts
+++ b/src/shared/workflow-resource-claims.ts
@@ -1,3 +1,12 @@
+export type WorkflowResourceKind =
+  | 'novel-config'
+  | 'architecture'
+  | 'blueprints'
+  | 'chapter'
+  | 'character-roster'
+  | 'continuity'
+  | 'chapter-summary'
+
 export interface WorkflowResourceClaims {
   /** Resources this workflow may mutate. */
   readonly resourceKeys?: readonly string[]

--- a/src/shared/workflow-resource-claims.ts
+++ b/src/shared/workflow-resource-claims.ts
@@ -7,6 +7,12 @@ export type WorkflowResourceKind =
   | 'continuity'
   | 'chapter-summary'
 
+export const FINALIZATION_SHARED_WRITE_RESOURCE_KINDS = Object.freeze([
+  'character-roster',
+  'continuity',
+  'chapter-summary',
+] as const satisfies readonly WorkflowResourceKind[])
+
 export interface WorkflowResourceClaims {
   /** Resources this workflow may mutate. */
   readonly resourceKeys?: readonly string[]

--- a/src/stores/workflow-store.ts
+++ b/src/stores/workflow-store.ts
@@ -25,6 +25,7 @@ import { useLocaleStore } from './locale-store'
 import {
   normalizeWorkflowResourceKeys,
   workflowResourceClaimsConflict,
+  type WorkflowResourceKind,
 } from '../shared/workflow-resource-claims'
 
 // ===== 工作流数据模型 =====
@@ -225,7 +226,7 @@ function normalizeChapterWordsTarget(value: unknown): number | undefined {
 }
 
 export function workflowResourceKey(
-  kind: 'novel-config' | 'architecture' | 'blueprints' | 'chapter',
+  kind: WorkflowResourceKind,
   identifier?: string | number,
 ): string {
   return identifier === undefined ? kind : `${kind}:${identifier}`


### PR DESCRIPTION
## 修复内容
- 补齐所有会写角色名单、连续性、章节摘要、蓝图与导入章节的工作流资源互斥，含稀疏作者原稿章节与恢复路径。
- 修复 Windows 旧版数据烟测：安装前按旧计数校验，应用真实迁移后再按新 Unicode 计数校验。
- 独立 fixture oracle，避免测试复制生产计数算法而自证通过。

## 验证
- TypeScript 与目标 ESLint 通过
- 单元测试：2030 passed，9 skipped
- Windows/导入聚焦回归：155 passed；最终导入边界回归 42 passed
- 浏览器回归：180 passed
- 生产构建与 release profile/adapter 测试通过
- Standards 与 Spec 独立审查均 PASS
- 隐私扫描：0 个凭据、私有路径或测试小说命中

本 PR 只提交修复与测试，不包含安装包、API Key、测试小说或本地运行数据。