### PR TITLE
fix: bound generation retries and preserve finalized facts

### DIFF
--- a/electron/repositories/__tests__/character-roster-repository.test.ts
+++ b/electron/repositories/__tests__/character-roster-repository.test.ts
@@ -96,6 +96,11 @@ beforeEach(() => {
       characters TEXT NOT NULL DEFAULT '[]',
       updated_at TEXT DEFAULT (datetime('now'))
     );
+    CREATE TABLE drafts (
+      id INTEGER PRIMARY KEY,
+      chapter_number INTEGER NOT NULL,
+      status TEXT NOT NULL
+    );
   `)
   ensureCharacterRosterSchema(db)
   vi.mocked(getProjectDb).mockReturnValue(db)
@@ -970,5 +975,75 @@ describe('CharacterRosterRepository public read/commit seam', () => {
       ],
     })).toThrow(/角色名必须唯一/)
     expect(CharacterRosterRepository.read()).toEqual(initial.snapshot)
+  })
+
+  it('rejects chapter progress older than a genuinely finalized character state', () => {
+    const base = commitRequest()
+    const initial = CharacterRosterRepository.commit({
+      ...base,
+      entries: base.entries.map(entry => ({
+        ...entry,
+        currentState: {
+          location: '第三章现场',
+          powerLevel: '',
+          physicalState: '',
+          mentalState: '',
+          keyItems: '',
+          recentEvents: '',
+          updatedAtChapter: 3,
+        },
+      })),
+    })
+    db.prepare('INSERT INTO drafts (id, chapter_number, status) VALUES (?, ?, ?)').run(2, 2, 'finalized')
+    db.prepare('INSERT INTO drafts (id, chapter_number, status) VALUES (?, ?, ?)').run(3, 3, 'finalized')
+    const existing = initial.snapshot.entries[0]
+
+    expect(() => CharacterRosterRepository.commit({
+      operationId: 'older-finalized-chapter-progress',
+      expectedRevision: initial.revision,
+      schemaVersion: 1,
+      intent: 'chapter_progress',
+      entries: [{
+        ...existing,
+        relationships: [],
+        currentState: { ...existing.currentState!, location: '第二章现场', updatedAtChapter: 2 },
+      }],
+    })).toThrow(/较新章节更新/)
+  })
+
+  it('repairs a future character-state chapter when no such finalized draft exists', () => {
+    const base = commitRequest()
+    const initial = CharacterRosterRepository.commit({
+      ...base,
+      entries: base.entries.map(entry => ({
+        ...entry,
+        currentState: {
+          location: '受污染的未来状态',
+          powerLevel: '',
+          physicalState: '',
+          mentalState: '',
+          keyItems: '',
+          recentEvents: '',
+          updatedAtChapter: 3,
+        },
+      })),
+    })
+    db.prepare('INSERT INTO drafts (id, chapter_number, status) VALUES (?, ?, ?)').run(2, 2, 'finalized')
+    const existing = initial.snapshot.entries[0]
+
+    const receipt = CharacterRosterRepository.commit({
+      operationId: 'repair-future-chapter-progress',
+      expectedRevision: initial.revision,
+      schemaVersion: 1,
+      intent: 'chapter_progress',
+      entries: [{
+        ...existing,
+        relationships: [],
+        currentState: { ...existing.currentState!, location: '第二章现场', updatedAtChapter: 2 },
+      }],
+    })
+
+    expect(receipt.snapshot.entries.find(entry => entry.name === existing.name)?.currentState)
+      .toMatchObject({ location: '第二章现场', updatedAtChapter: 2 })
   })
 })

--- a/electron/repositories/__tests__/character-roster-repository.test.ts
+++ b/electron/repositories/__tests__/character-roster-repository.test.ts
@@ -939,6 +939,7 @@ describe('CharacterRosterRepository public read/commit seam', () => {
 
   it('rejects chapter-progress additions and canonical duplicate names at the repository boundary', () => {
     const initial = CharacterRosterRepository.commit(commitRequest())
+    db.prepare('INSERT INTO drafts (id, chapter_number, status) VALUES (?, ?, ?)').run(2, 2, 'finalized')
     const existing = initial.snapshot.entries[0]
     const unknown = {
       ...existing,
@@ -1045,5 +1046,38 @@ describe('CharacterRosterRepository public read/commit seam', () => {
 
     expect(receipt.snapshot.entries.find(entry => entry.name === existing.name)?.currentState)
       .toMatchObject({ location: '第二章现场', updatedAtChapter: 2 })
+  })
+
+  it('rejects chapter progress whose candidate chapter is not finalized', () => {
+    const base = commitRequest()
+    const initial = CharacterRosterRepository.commit({
+      ...base,
+      entries: base.entries.map(entry => ({
+        ...entry,
+        currentState: {
+          location: '第一章现场',
+          powerLevel: '',
+          physicalState: '',
+          mentalState: '',
+          keyItems: '',
+          recentEvents: '',
+          updatedAtChapter: 1,
+        },
+      })),
+    })
+    db.prepare('INSERT INTO drafts (id, chapter_number, status) VALUES (?, ?, ?)').run(2, 2, 'draft')
+    const existing = initial.snapshot.entries[0]
+
+    expect(() => CharacterRosterRepository.commit({
+      operationId: 'unfinalized-chapter-progress',
+      expectedRevision: initial.revision,
+      schemaVersion: 1,
+      intent: 'chapter_progress',
+      entries: [{
+        ...existing,
+        relationships: [],
+        currentState: { ...existing.currentState!, location: '第二章现场', updatedAtChapter: 2 },
+      }],
+    })).toThrow(/尚未定稿/)
   })
 })

--- a/electron/repositories/__tests__/plot-tree-repository.test.ts
+++ b/electron/repositories/__tests__/plot-tree-repository.test.ts
@@ -83,6 +83,23 @@ function seedFacts() {
 }
 
 describe('PlotTreeRepository', () => {
+  it('returns the highest finalized version per chapter even when its id is lower', () => {
+    const db = getProjectDb()!
+    db.prepare(`
+      INSERT INTO blueprints (chapter_number, title, purpose, key_events)
+      VALUES (1, 'Versioned chapter', 'Advance the plot', 'The authoritative version wins.')
+    `).run()
+    db.prepare("INSERT INTO contents (id, body) VALUES (1, 'older'), (2, 'newer')").run()
+    db.prepare(`
+      INSERT INTO drafts (id, chapter_number, version, status, content_id)
+      VALUES (200, 1, 1, 'finalized', 1), (100, 1, 2, 'finalized', 2)
+    `).run()
+
+    expect(PlotTreeRepository.read().finalizedChapters).toEqual([
+      expect.objectContaining({ draftId: 100, chapterNumber: 1 }),
+    ])
+  })
+
   it('does not treat ordinary blueprint notes as a finalized summary without extraction time', () => {
     const db = getProjectDb()!
     db.prepare(`

--- a/electron/repositories/character-roster-repository.ts
+++ b/electron/repositories/character-roster-repository.ts
@@ -422,6 +422,7 @@ function mergeGeneratedEntriesWithExisting(
 }
 
 function mergeIncrementalEntriesWithExisting(
+  db: BetterSqlite3.Database,
   candidates: CharacterRosterEntry[],
   existingEntries: CharacterRosterEntry[],
   intent: Extract<CharacterRosterCommitIntent, 'blueprint_sync' | 'chapter_progress'>,
@@ -435,6 +436,20 @@ function mergeIncrementalEntriesWithExisting(
       && candidate.currentState
       && existing.currentState
       && candidate.currentState.updatedAtChapter < existing.currentState.updatedAtChapter
+      && (
+        db.prepare(`
+          SELECT 1
+          FROM drafts
+          WHERE chapter_number = ? AND status = 'finalized'
+          LIMIT 1
+        `).get(existing.currentState.updatedAtChapter)
+        || !db.prepare(`
+          SELECT 1
+          FROM drafts
+          WHERE chapter_number = ? AND status = 'finalized'
+          LIMIT 1
+        `).get(candidate.currentState.updatedAtChapter)
+      )
     ) {
       throw new Error(`角色「${existing.name}」已由较新章节更新，已拒绝旧章节后处理覆盖`)
     }
@@ -830,6 +845,7 @@ export class CharacterRosterRepository {
             ? mergeGeneratedEntriesWithExisting(request.entries, existingEntries)
             : isIncremental
               ? mergeIncrementalEntriesWithExisting(
+                  db,
                   request.entries,
                   existingEntries,
                   intent as Extract<CharacterRosterCommitIntent, 'blueprint_sync' | 'chapter_progress'>,

--- a/electron/repositories/character-roster-repository.ts
+++ b/electron/repositories/character-roster-repository.ts
@@ -421,12 +421,31 @@ function mergeGeneratedEntriesWithExisting(
   return merged
 }
 
+function hasFinalizedDraft(db: BetterSqlite3.Database, chapterNumber: number): boolean {
+  return db.prepare(`
+    SELECT 1
+    FROM drafts
+    WHERE chapter_number = ? AND status = 'finalized'
+    LIMIT 1
+  `).get(chapterNumber) !== undefined
+}
+
 function mergeIncrementalEntriesWithExisting(
   db: BetterSqlite3.Database,
   candidates: CharacterRosterEntry[],
   existingEntries: CharacterRosterEntry[],
   intent: Extract<CharacterRosterCommitIntent, 'blueprint_sync' | 'chapter_progress'>,
 ): CharacterRosterEntry[] {
+  if (intent === 'chapter_progress') {
+    for (const candidate of candidates) {
+      if (
+        !candidate.currentState
+        || !hasFinalizedDraft(db, candidate.currentState.updatedAtChapter)
+      ) {
+        throw new Error(`角色「${candidate.name}」的章节状态尚未定稿，已拒绝后处理写入`)
+      }
+    }
+  }
   const candidateByName = new Map(candidates.map(entry => [characterRosterIdentityKey(entry.name), entry]))
   const mergedExisting = existingEntries.map((existing) => {
     const candidate = candidateByName.get(characterRosterIdentityKey(existing.name))
@@ -436,20 +455,7 @@ function mergeIncrementalEntriesWithExisting(
       && candidate.currentState
       && existing.currentState
       && candidate.currentState.updatedAtChapter < existing.currentState.updatedAtChapter
-      && (
-        db.prepare(`
-          SELECT 1
-          FROM drafts
-          WHERE chapter_number = ? AND status = 'finalized'
-          LIMIT 1
-        `).get(existing.currentState.updatedAtChapter)
-        || !db.prepare(`
-          SELECT 1
-          FROM drafts
-          WHERE chapter_number = ? AND status = 'finalized'
-          LIMIT 1
-        `).get(candidate.currentState.updatedAtChapter)
-      )
+      && hasFinalizedDraft(db, existing.currentState.updatedAtChapter)
     ) {
       throw new Error(`角色「${existing.name}」已由较新章节更新，已拒绝旧章节后处理覆盖`)
     }

--- a/electron/repositories/plot-tree-repository.ts
+++ b/electron/repositories/plot-tree-repository.ts
@@ -58,7 +58,14 @@ export class PlotTreeRepository {
       LEFT JOIN summary_snapshots ON summary_snapshots.draft_id = drafts.id
       LEFT JOIN blueprints ON blueprints.chapter_number = drafts.chapter_number
       WHERE drafts.status = 'finalized'
-      ORDER BY drafts.chapter_number ASC, drafts.id ASC
+        AND NOT EXISTS (
+          SELECT 1 FROM drafts newer
+          WHERE newer.chapter_number = drafts.chapter_number
+            AND newer.status = 'finalized'
+            AND (newer.version > drafts.version
+              OR (newer.version = drafts.version AND newer.id > drafts.id))
+        )
+      ORDER BY drafts.chapter_number ASC
     `).all() as Array<{
       draft_id: number
       chapter_number: number

--- a/src/services/__tests__/plot-tree-generator.test.ts
+++ b/src/services/__tests__/plot-tree-generator.test.ts
@@ -371,6 +371,8 @@ describe('plot tree AI boundary', () => {
     const threadSources = sources()
     threadSources.blueprints = []
     threadSources.finalizedChapters = []
+    threadSources.narrativeThreads[0]!.targetEndChapter = 3
+    threadSources.narrativeThreads[0]!.events[0]!.chapterNumber = 4
     const complete = vi.fn<GenerationSession['complete']>().mockResolvedValue({
       status: 'completed',
       content: 'not JSON',
@@ -401,9 +403,11 @@ describe('plot tree AI boundary', () => {
       }),
       expect.objectContaining({
         status: 'occurred',
-        sources: [{ type: 'narrative-thread', planId: 7, eventId: 11, chapterNumber: 1 }],
+        chapterNumber: 4,
+        sources: [{ type: 'narrative-thread', planId: 7, eventId: 11, chapterNumber: 4 }],
       }),
     ]))
+    expect(result.tracks[0]?.endChapter).toBe(4)
   })
 
   it.each(['DEADLINE_EXHAUSTED', 'PROVIDER_REQUEST_FAILED'] as const)(

--- a/src/services/__tests__/plot-tree-generator.test.ts
+++ b/src/services/__tests__/plot-tree-generator.test.ts
@@ -162,10 +162,10 @@ describe('plot tree AI boundary', () => {
     }), sources())).toThrow(/章节范围|chapter range/u)
   })
 
-  it('allows one initial request plus one replacement in the ten-minute planning window', () => {
+  it('allows exactly one request in the ten-minute planning window', () => {
     expect(PLOT_TREE_GENERATION_BUDGET).toMatchObject({
-      maxAttempts: 2,
-      maxRequestedOutputTokens: 16_384,
+      maxAttempts: 1,
+      maxRequestedOutputTokens: 8192,
       deadlineMs: 10 * 60_000,
     })
   })
@@ -301,7 +301,109 @@ describe('plot tree AI boundary', () => {
     })
     expect(task?.messages[0]?.content).not.toMatch(/[\u3400-\u9fff]/u)
     expect(result.generatedAt).toBe('2026-09-02T03:04:05.000Z')
+    expect(result.tracks).toEqual(modelResponse.tracks)
     expect(runtime.close).toHaveBeenCalledOnce()
+  })
+
+  it('removes an incompatible blueprint citation from an occurred event without a second request', async () => {
+    const plotSources = sources()
+    plotSources.writingLanguage = 'zh-CN'
+    plotSources.narrativeThreads = []
+    plotSources.blueprints = [1, 2, 3].map(chapterNumber => ({
+      chapterNumber,
+      title: `第${chapterNumber}章`,
+      purpose: `推进第${chapterNumber}章`,
+      keyEvents: `第${chapterNumber}章计划事件`,
+    }))
+    plotSources.finalizedChapters = [1, 2, 3].map(chapterNumber => ({
+      draftId: 40 + chapterNumber,
+      chapterNumber,
+      title: `第${chapterNumber}章`,
+      summary: `第${chapterNumber}章真实定稿摘要`,
+    }))
+    const mixed = {
+      tracks: [{
+        ...modelResponse.tracks[0],
+        events: [{
+          status: 'occurred',
+          chapterNumber: 3,
+          summary: '第三章事件已经发生。',
+          sources: [
+            { type: 'blueprint', chapterNumber: 3 },
+            { type: 'finalized-chapter', draftId: 43, chapterNumber: 3 },
+          ],
+        }],
+      }],
+    }
+    const complete = vi.fn<GenerationSession['complete']>().mockResolvedValue({
+      status: 'completed',
+      content: JSON.stringify(mixed),
+      finishReason: 'stop',
+      receipt: {} as never,
+    })
+    const runtime = {
+      execute: vi.fn(async operation => operation({ session: { budget: {}, complete } })),
+      close: vi.fn().mockResolvedValue(undefined),
+    } as unknown as GenerationRuntime
+
+    const result = await generatePlotTree({
+      modelId: 'grok-frozen',
+      projectSession: PROJECT_SESSION,
+      sources: plotSources,
+      signal: new AbortController().signal,
+    }, {
+      createRuntime: vi.fn().mockResolvedValue(runtime),
+      now: () => '2026-09-02T03:04:05.000Z',
+    })
+
+    expect(complete).toHaveBeenCalledOnce()
+    expect(result.tracks[0]).toMatchObject({
+      startChapter: 3,
+      endChapter: 3,
+      events: [{
+        status: 'occurred',
+        sources: [{ type: 'finalized-chapter', draftId: 43, chapterNumber: 3 }],
+      }],
+    })
+  })
+
+  it('builds a deterministic snapshot from narrative sources after invalid JSON', async () => {
+    const threadSources = sources()
+    threadSources.blueprints = []
+    threadSources.finalizedChapters = []
+    const complete = vi.fn<GenerationSession['complete']>().mockResolvedValue({
+      status: 'completed',
+      content: 'not JSON',
+      finishReason: 'stop',
+      receipt: {} as never,
+    })
+    const runtime = {
+      execute: vi.fn(async operation => operation({ session: { budget: {}, complete } })),
+      close: vi.fn().mockResolvedValue(undefined),
+    } as unknown as GenerationRuntime
+
+    const result = await generatePlotTree({
+      modelId: 'grok-frozen',
+      projectSession: PROJECT_SESSION,
+      sources: threadSources,
+      signal: new AbortController().signal,
+    }, {
+      createRuntime: vi.fn().mockResolvedValue(runtime),
+      now: () => '2026-09-02T03:04:05.000Z',
+    })
+
+    expect(complete).toHaveBeenCalledOnce()
+    expect(result.tracks).toHaveLength(1)
+    expect(result.tracks[0]?.events).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        status: 'planned',
+        sources: [{ type: 'narrative-thread', planId: 7 }],
+      }),
+      expect.objectContaining({
+        status: 'occurred',
+        sources: [{ type: 'narrative-thread', planId: 7, eventId: 11, chapterNumber: 1 }],
+      }),
+    ]))
   })
 
   it.each(['DEADLINE_EXHAUSTED', 'PROVIDER_REQUEST_FAILED'] as const)(
@@ -372,8 +474,8 @@ describe('plot tree AI boundary', () => {
       execute: vi.fn(async operation => operation({
         session: {
           budget: {
-            maxAttempts: 2,
-            maxRequestedOutputTokens: 16_384,
+            maxAttempts: 1,
+            maxRequestedOutputTokens: 8192,
             maxRequestedOutputTokensPerAttempt: 8192,
             deadlineAt: Date.now() + 10 * 60_000,
           },
@@ -481,12 +583,6 @@ describe('plot tree AI boundary', () => {
   })
 
   it.each([
-    ['length', {
-      status: 'incomplete',
-      content: 'PRIVATE_TRUNCATED_OUTPUT',
-      finishReason: 'length',
-      receipt: {} as never,
-    }],
     ['invalid_json', {
       status: 'completed',
       content: 'PRIVATE_MODEL_OUTPUT is not JSON',
@@ -509,21 +605,14 @@ describe('plot tree AI boundary', () => {
       finishReason: 'stop',
       receipt: {} as never,
     }],
-  ] satisfies Array<[string, GenerationOutcome]>)('requests one clean full replacement after %s', async (_reason, firstOutcome) => {
-    const complete = vi.fn<GenerationSession['complete']>()
-      .mockResolvedValueOnce(firstOutcome)
-      .mockResolvedValueOnce({
-        status: 'completed',
-        content: JSON.stringify(modelResponse),
-        finishReason: 'stop',
-        receipt: {} as never,
-      })
+  ] satisfies Array<[string, GenerationOutcome]>)('uses one source-backed fallback after %s', async (_reason, firstOutcome) => {
+    const complete = vi.fn<GenerationSession['complete']>().mockResolvedValue(firstOutcome)
     const runtime = {
       execute: vi.fn(async operation => operation({
         session: {
           budget: {
-            maxAttempts: 2,
-            maxRequestedOutputTokens: 16_384,
+            maxAttempts: 1,
+            maxRequestedOutputTokens: 8192,
             maxRequestedOutputTokensPerAttempt: 8192,
             deadlineAt: Date.now() + 10 * 60_000,
           },
@@ -535,7 +624,7 @@ describe('plot tree AI boundary', () => {
     const plotSources = sources()
     plotSources.writingLanguage = 'zh-CN'
 
-    await expect(generatePlotTree({
+    const result = await generatePlotTree({
       modelId: 'grok-frozen',
       projectSession: PROJECT_SESSION,
       sources: plotSources,
@@ -543,23 +632,35 @@ describe('plot tree AI boundary', () => {
     }, {
       createRuntime: vi.fn().mockResolvedValue(runtime),
       now: () => '2026-09-02T03:04:05.000Z',
-    })).resolves.toMatchObject({ tracks: modelResponse.tracks })
+    })
 
-    expect(complete).toHaveBeenCalledTimes(2)
+    expect(result.tracks).toHaveLength(1)
+    expect(result.tracks[0]?.id).toBe('source-backed-progress')
+    expect(complete).toHaveBeenCalledOnce()
     const initial = complete.mock.calls[0]?.[0]
-    const replacement = complete.mock.calls[1]?.[0]
-    expect(replacement?.purpose).toBe('plot-tree-snapshot-replacement')
-    expect(replacement?.messages.map(message => message.content).join('\n'))
-      .toContain('完整替代')
-    for (const request of [initial, replacement]) {
-      expect(request?.messages.map(message => message.content).join('\n'))
-        .toContain('绝不能输出 source.type="synopsis"')
-    }
-    expect(replacement?.messages.map(message => message.content).join('\n'))
-      .not.toMatch(/PRIVATE_(?:TRUNCATED_)?MODEL_OUTPUT|PRIVATE_TRUNCATED_OUTPUT/u)
+    expect(initial?.purpose).toBe('plot-tree-snapshot')
+    expect(initial?.messages.map(message => message.content).join('\n'))
+      .toContain('绝不能输出 source.type="synopsis"')
+    expect(JSON.stringify(result)).not.toContain('PRIVATE_MODEL_OUTPUT')
   })
 
-  it('reports malformed model output as JSON syntax failure without echoing it', async () => {
+  it('does not rebind a wrong source ID and falls back to exact source facts', async () => {
+    const complete = vi.fn().mockResolvedValue({
+      status: 'completed',
+      content: JSON.stringify({
+        tracks: [{
+          ...modelResponse.tracks[0],
+          events: [{
+            status: 'occurred',
+            chapterNumber: 1,
+            summary: 'PRIVATE_MODEL_OUTPUT',
+            sources: [{ type: 'finalized-chapter', draftId: 999, chapterNumber: 1 }],
+          }],
+        }],
+      }),
+      finishReason: 'stop',
+      receipt: {},
+    })
     const runtime = {
       execute: vi.fn(async operation => operation({
         session: {
@@ -569,84 +670,29 @@ describe('plot tree AI boundary', () => {
             maxRequestedOutputTokensPerAttempt: 8192,
             deadlineAt: Date.now() + 10 * 60_000,
           },
-          complete: vi.fn().mockResolvedValue({
-            status: 'completed',
-            content: 'PRIVATE_MODEL_OUTPUT is not JSON',
-            finishReason: 'stop',
-            receipt: {},
-          }),
+          complete,
         },
       })),
       close: vi.fn().mockResolvedValue(undefined),
     } as unknown as GenerationRuntime
 
-    try {
-      await generatePlotTree({
-        modelId: 'grok-frozen',
-        projectSession: PROJECT_SESSION,
-        sources: sources(),
-        signal: new AbortController().signal,
-      }, {
-        createRuntime: vi.fn().mockResolvedValue(runtime),
-        now: () => '2026-09-02T03:04:05.000Z',
-      })
-      expect.fail('Expected malformed output to be rejected')
-    } catch (error) {
-      expect(error).toBeInstanceOf(Error)
-      expect(error).toMatchObject({ code: 'invalid_json' })
-      expect((error as Error).message).toContain('parseable plot-tree JSON')
-      expect((error as Error).message).not.toContain('PRIVATE_MODEL_OUTPUT')
-    }
-  })
+    const result = await generatePlotTree({
+      modelId: 'grok-frozen',
+      projectSession: PROJECT_SESSION,
+      sources: sources(),
+      signal: new AbortController().signal,
+    }, {
+      createRuntime: vi.fn().mockResolvedValue(runtime),
+      now: () => '2026-09-02T03:04:05.000Z',
+    })
 
-  it('reports a source-contract violation separately from invalid JSON', async () => {
-    const runtime = {
-      execute: vi.fn(async operation => operation({
-        session: {
-          budget: {
-            maxAttempts: 1,
-            maxRequestedOutputTokens: 8192,
-            maxRequestedOutputTokensPerAttempt: 8192,
-            deadlineAt: Date.now() + 10 * 60_000,
-          },
-          complete: vi.fn().mockResolvedValue({
-            status: 'completed',
-            content: JSON.stringify({
-              tracks: [{
-                ...modelResponse.tracks[0],
-                events: [{
-                  status: 'planned',
-                  chapterNumber: 99,
-                  summary: 'PRIVATE_MODEL_OUTPUT',
-                  sources: [{ type: 'blueprint', chapterNumber: 99 }],
-                }],
-              }],
-            }),
-            finishReason: 'stop',
-            receipt: {},
-          }),
-        },
-      })),
-      close: vi.fn().mockResolvedValue(undefined),
-    } as unknown as GenerationRuntime
-
-    try {
-      await generatePlotTree({
-        modelId: 'grok-frozen',
-        projectSession: PROJECT_SESSION,
-        sources: sources(),
-        signal: new AbortController().signal,
-      }, {
-        createRuntime: vi.fn().mockResolvedValue(runtime),
-        now: () => '2026-09-02T03:04:05.000Z',
-      })
-      expect.fail('Expected the source-contract violation to be rejected')
-    } catch (error) {
-      expect(error).toBeInstanceOf(Error)
-      expect(error).toMatchObject({ code: 'invalid_contract' })
-      expect((error as Error).message).toContain('invalid plot-tree structure')
-      expect((error as Error).message).not.toContain('PRIVATE_MODEL_OUTPUT')
-    }
+    expect(complete).toHaveBeenCalledOnce()
+    expect(JSON.stringify(result)).not.toMatch(/PRIVATE_MODEL_OUTPUT|999/u)
+    expect(result.tracks[0]?.events).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        sources: [{ type: 'finalized-chapter', draftId: 41, chapterNumber: 1 }],
+      }),
+    ]))
   })
 
   it.each([

--- a/src/services/plot-tree-generator.ts
+++ b/src/services/plot-tree-generator.ts
@@ -221,25 +221,21 @@ function deterministicPlotTreeSnapshot(
   sources: PlotTreeSourceBundle,
   generatedAt: string,
 ): PlotTreeSnapshot {
-  const finalizedByChapter = new Map<number, typeof sources.finalizedChapters[number]>()
-  for (const chapter of sources.finalizedChapters) {
-    const current = finalizedByChapter.get(chapter.chapterNumber)
-    if ((chapter.summary.trim() || chapter.title.trim())
-      && exactEventSource(
-        { type: 'finalized-chapter', draftId: chapter.draftId, chapterNumber: chapter.chapterNumber },
-        'occurred', chapter.chapterNumber, sources, generatedAt,
-      )
-      && (!current || chapter.draftId > current.draftId)) {
-      finalizedByChapter.set(chapter.chapterNumber, chapter)
-    }
-  }
+  const finalizedChapters = sources.finalizedChapters.filter(chapter => (
+    (chapter.summary.trim() || chapter.title.trim())
+    && exactEventSource(
+      { type: 'finalized-chapter', draftId: chapter.draftId, chapterNumber: chapter.chapterNumber },
+      'occurred', chapter.chapterNumber, sources, generatedAt,
+    )
+  ))
+  const finalizedChapterNumbers = new Set(finalizedChapters.map(chapter => chapter.chapterNumber))
   const candidates: PlotTreeEvent[] = [
-    ...[...finalizedByChapter.values()].map(chapter => ({
+    ...finalizedChapters.map(chapter => ({
       status: 'occurred', chapterNumber: chapter.chapterNumber,
       summary: chapter.summary.trim() || chapter.title.trim(),
       sources: [{ type: 'finalized-chapter', draftId: chapter.draftId, chapterNumber: chapter.chapterNumber }],
     } as PlotTreeEvent)),
-    ...sources.blueprints.filter(blueprint => !finalizedByChapter.has(blueprint.chapterNumber)).map(blueprint => ({
+    ...sources.blueprints.filter(blueprint => !finalizedChapterNumbers.has(blueprint.chapterNumber)).map(blueprint => ({
       status: 'planned', chapterNumber: blueprint.chapterNumber,
       summary: blueprint.keyEvents.trim() || blueprint.purpose.trim() || blueprint.title.trim(),
       sources: [{ type: 'blueprint', chapterNumber: blueprint.chapterNumber }],
@@ -248,9 +244,7 @@ function deterministicPlotTreeSnapshot(
       status: 'planned', chapterNumber: thread.targetStartChapter,
       summary: thread.authorIntent.trim() || thread.title.trim(),
       sources: [{ type: 'narrative-thread', planId: thread.id }],
-    } as PlotTreeEvent, ...thread.events.filter(event => (
-      event.chapterNumber >= thread.targetStartChapter && event.chapterNumber <= thread.targetEndChapter
-    )).map(event => ({
+    } as PlotTreeEvent, ...thread.events.map(event => ({
       status: 'occurred', chapterNumber: event.chapterNumber,
       summary: event.evidence.trim() || event.reason.trim(),
       sources: [{ type: 'narrative-thread', planId: thread.id, eventId: event.id, chapterNumber: event.chapterNumber }],

--- a/src/services/plot-tree-generator.ts
+++ b/src/services/plot-tree-generator.ts
@@ -1,7 +1,10 @@
 import {
   assertPlotTreeSnapshot,
   hasUsablePlotTreeEventSource,
+  type PlotTreeEvent,
+  type PlotTreeEventStatus,
   type PlotTreeSnapshot,
+  type PlotTreeSourceReference,
   type PlotTreeSourceBundle,
 } from '../shared/plot-tree'
 import type { LLMFinishReason, ProjectSessionContext } from '../shared/ipc-channels'
@@ -15,8 +18,8 @@ import {
 } from './generation/generation-runtime'
 
 export const PLOT_TREE_GENERATION_BUDGET = Object.freeze({
-  maxAttempts: 2,
-  maxRequestedOutputTokens: 16_384,
+  maxAttempts: 1,
+  maxRequestedOutputTokens: 8192,
   maxRequestedOutputTokensPerAttempt: 8192,
   deadlineMs: 10 * 60_000,
 })
@@ -136,16 +139,152 @@ export function parsePlotTreeSnapshot(
   sources: PlotTreeSourceBundle,
   generatedAt = new Date().toISOString(),
 ): PlotTreeSnapshot {
-  const trimmed = content.trim()
-  const fenced = /^```json\s*([\s\S]*?)\s*```$/iu.exec(trimmed)
-  const parsed = JSON.parse(fenced ? fenced[1].trim() : trimmed) as Record<string, unknown>
+  return strictSnapshot(parsePlotTreeJSON(content).tracks, sources, generatedAt)
+}
+
+function strictSnapshot(
+  tracks: unknown,
+  sources: PlotTreeSourceBundle,
+  generatedAt: string,
+): PlotTreeSnapshot {
   return assertPlotTreeSnapshot({
     version: 1,
     generatedAt,
     writingLanguage: sources.writingLanguage,
     sourceRevision: sources.sourceRevision,
-    tracks: parsed.tracks,
+    tracks,
   }, sources)
+}
+
+function parsePlotTreeJSON(content: string): Record<string, unknown> {
+  const trimmed = content.trim()
+  const fenced = /^```json\s*([\s\S]*?)\s*```$/iu.exec(trimmed)
+  return JSON.parse(fenced ? fenced[1].trim() : trimmed) as Record<string, unknown>
+}
+
+function object(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null
+}
+
+function exactEventSource(
+  value: unknown,
+  status: PlotTreeEventStatus,
+  chapterNumber: number,
+  sources: PlotTreeSourceBundle,
+  generatedAt: string,
+): PlotTreeSourceReference | null {
+  try {
+    return strictSnapshot([{
+      id: 'source-check', title: 'source-check', role: 'main',
+      startChapter: chapterNumber, endChapter: chapterNumber, summary: 'source-check',
+      events: [{ status, chapterNumber, summary: 'source-check', sources: [value] }],
+    }], sources, generatedAt).tracks[0]!.events[0]!.sources[0]!
+  } catch {
+    return null
+  }
+}
+
+function normalizePlotTreeSnapshot(
+  parsed: Record<string, unknown>,
+  sources: PlotTreeSourceBundle,
+  generatedAt: string,
+): PlotTreeSnapshot {
+  const tracks = (Array.isArray(parsed.tracks) ? parsed.tracks : []).flatMap((candidate) => {
+    const track = object(candidate)
+    if (!track || !Array.isArray(track.events)) return []
+    const events = track.events.flatMap((candidateEvent) => {
+      const event = object(candidateEvent)
+      if (!event || !['planned', 'occurred'].includes(String(event.status))
+        || !Number.isSafeInteger(event.chapterNumber) || !Array.isArray(event.sources)) return []
+      const status = event.status as PlotTreeEventStatus
+      const chapterNumber = event.chapterNumber as number
+      const seen = new Set<string>()
+      const eventSources = event.sources.flatMap((value) => {
+        const source = exactEventSource(value, status, chapterNumber, sources, generatedAt)
+        const key = JSON.stringify(source)
+        if (!source || seen.has(key)) return []
+        seen.add(key)
+        return [source]
+      })
+      return eventSources.length > 0 ? [{ ...event, status, chapterNumber, sources: eventSources }] : []
+    })
+    if (events.length === 0) return []
+    const chapters = events.map(event => event.chapterNumber)
+    return [{ ...track, startChapter: Math.min(...chapters), endChapter: Math.max(...chapters), events }]
+  })
+  return strictSnapshot(tracks, sources, generatedAt)
+}
+
+function deterministicPlotTreeSnapshot(
+  sources: PlotTreeSourceBundle,
+  generatedAt: string,
+): PlotTreeSnapshot {
+  const finalizedByChapter = new Map<number, typeof sources.finalizedChapters[number]>()
+  for (const chapter of sources.finalizedChapters) {
+    const current = finalizedByChapter.get(chapter.chapterNumber)
+    if ((chapter.summary.trim() || chapter.title.trim())
+      && exactEventSource(
+        { type: 'finalized-chapter', draftId: chapter.draftId, chapterNumber: chapter.chapterNumber },
+        'occurred', chapter.chapterNumber, sources, generatedAt,
+      )
+      && (!current || chapter.draftId > current.draftId)) {
+      finalizedByChapter.set(chapter.chapterNumber, chapter)
+    }
+  }
+  const candidates: PlotTreeEvent[] = [
+    ...[...finalizedByChapter.values()].map(chapter => ({
+      status: 'occurred', chapterNumber: chapter.chapterNumber,
+      summary: chapter.summary.trim() || chapter.title.trim(),
+      sources: [{ type: 'finalized-chapter', draftId: chapter.draftId, chapterNumber: chapter.chapterNumber }],
+    } as PlotTreeEvent)),
+    ...sources.blueprints.filter(blueprint => !finalizedByChapter.has(blueprint.chapterNumber)).map(blueprint => ({
+      status: 'planned', chapterNumber: blueprint.chapterNumber,
+      summary: blueprint.keyEvents.trim() || blueprint.purpose.trim() || blueprint.title.trim(),
+      sources: [{ type: 'blueprint', chapterNumber: blueprint.chapterNumber }],
+    } as PlotTreeEvent)),
+    ...sources.narrativeThreads.flatMap(thread => [{
+      status: 'planned', chapterNumber: thread.targetStartChapter,
+      summary: thread.authorIntent.trim() || thread.title.trim(),
+      sources: [{ type: 'narrative-thread', planId: thread.id }],
+    } as PlotTreeEvent, ...thread.events.filter(event => (
+      event.chapterNumber >= thread.targetStartChapter && event.chapterNumber <= thread.targetEndChapter
+    )).map(event => ({
+      status: 'occurred', chapterNumber: event.chapterNumber,
+      summary: event.evidence.trim() || event.reason.trim(),
+      sources: [{ type: 'narrative-thread', planId: thread.id, eventId: event.id, chapterNumber: event.chapterNumber }],
+    } as PlotTreeEvent)),
+    ]),
+  ]
+
+  const seen = new Set<string>()
+  const sortedEvents = candidates.filter((event) => {
+    const source = exactEventSource(event.sources[0], event.status, event.chapterNumber, sources, generatedAt)
+    const key = JSON.stringify(source)
+    if (!event.summary || !source || seen.has(key)) return false
+    event.sources = [source]
+    seen.add(key)
+    return true
+  }).sort((left, right) => (
+    left.chapterNumber - right.chapterNumber
+    || left.status.localeCompare(right.status)
+    || JSON.stringify(left.sources[0]).localeCompare(JSON.stringify(right.sources[0]))
+  ))
+  if (sortedEvents.length === 0) throw new PlotTreeSourceError()
+  return strictSnapshot([{
+    id: 'source-backed-progress',
+    title: promptLanguageText(sources.writingLanguage, '剧情进展', 'Plot progress'),
+    role: 'main',
+    startChapter: sortedEvents[0].chapterNumber,
+    endChapter: sortedEvents.at(-1)!.chapterNumber,
+    summary: promptLanguageText(
+      sources.writingLanguage,
+      '基于当前章节与叙事线索的只读进展。',
+      'Read-only progress from current chapters and narrative threads.',
+    ),
+    events: sortedEvents,
+  }], sources, generatedAt)
 }
 
 function boundedText(value: string, maximum: number): string {
@@ -195,28 +334,6 @@ function generationFacts(sources: PlotTreeSourceBundle) {
   }
 }
 
-function responseError(
-  error: unknown,
-  writingLanguage: WritingLanguage,
-): PlotTreeResponseError {
-  const invalidJson = error instanceof SyntaxError
-  const message = promptLanguageText(
-    writingLanguage,
-    invalidJson
-      ? '模型未返回可解析的剧情树 JSON，旧快照保持不变。'
-      : '模型返回的剧情树结构或来源引用无效，旧快照保持不变。',
-    invalidJson
-      ? 'The model did not return parseable plot-tree JSON; the previous snapshot remains unchanged.'
-      : 'The model returned an invalid plot-tree structure or source reference; the previous snapshot remains unchanged.',
-  )
-  return new PlotTreeResponseError(invalidJson ? 'invalid_json' : 'invalid_contract', message)
-}
-
-function shouldRequestReplacement(error: unknown): boolean {
-  return error instanceof PlotTreeResponseError
-    || (error instanceof PlotTreeIncompleteError && error.finishReason === 'length')
-}
-
 export async function generatePlotTree(
   input: GeneratePlotTreeInput,
   dependencies: PlotTreeGeneratorDependencies = {
@@ -240,8 +357,8 @@ export async function generatePlotTree(
   })
   try {
     return await runtime.execute(async ({ session }) => {
-      const task = (replacement: boolean) => ({
-        purpose: replacement ? 'plot-tree-snapshot-replacement' : 'plot-tree-snapshot',
+      const task = {
+        purpose: 'plot-tree-snapshot',
         reasoningStage: 'planning' as const,
         output: 'structured-data' as const,
         messages: [
@@ -254,37 +371,37 @@ export async function generatePlotTree(
                 '区分 main 主线与 subplot 支线；每条支线必须用 parentTrackId 关联一条主线，主线不能有 parentTrackId。planned 只能来自章节蓝图或人工叙事计划，occurred 只能来自已定稿章节或已确认叙事事件。',
                 '情节总大纲只用于归纳轨道和摘要，不是可引用来源；绝不能在事件 sources 中引用它，也绝不能输出 source.type="synopsis"。每个事件必须至少引用一个同章节的真实来源，且只能使用以下格式：{"type":"blueprint","chapterNumber":1}、{"type":"finalized-chapter","draftId":1,"chapterNumber":1}、{"type":"narrative-thread","planId":1}、{"type":"narrative-thread","planId":1,"eventId":1,"chapterNumber":1}。不得编造 ID 或章节。',
                 '只输出 JSON 对象：{"tracks":[{"id":"stable-id","title":"","role":"main","startChapter":1,"endChapter":1,"summary":"","events":[{"status":"planned|occurred","chapterNumber":1,"summary":"","sources":[]}]}]}。仅 subplot 轨道增加 parentTrackId。不要输出解释或 Markdown。',
-                ...(replacement ? ['上一轮结果已完全丢弃。请从给定资料重新生成一个完整替代 JSON，不得续写或引用上一轮结果。'] : []),
               ].join('\n'),
               [
                 'You are a fiction plot-structure editor. Derive a read-only plot tree from the supplied synopsis, chapter blueprints, finalized chapter summaries, and author-confirmed narrative threads.',
                 'Separate main tracks from subplot tracks. Every subplot must reference one main track with parentTrackId; main tracks must not have parentTrackId. planned must be supported by a chapter blueprint or human narrative plan; occurred must be supported by a finalized chapter or confirmed narrative event.',
                 'The synopsis is context for synthesizing tracks and summaries, not a citable source. Never cite it in event sources and never emit source.type="synopsis". Every event must cite at least one real source for the same chapter using only these forms: {"type":"blueprint","chapterNumber":1}, {"type":"finalized-chapter","draftId":1,"chapterNumber":1}, {"type":"narrative-thread","planId":1}, or {"type":"narrative-thread","planId":1,"eventId":1,"chapterNumber":1}. Never invent an ID or chapter.',
                 'Return only one JSON object: {"tracks":[{"id":"stable-id","title":"","role":"main","startChapter":1,"endChapter":1,"summary":"","events":[{"status":"planned|occurred","chapterNumber":1,"summary":"","sources":[]}]}]}. Add parentTrackId only to subplot tracks. Do not return explanations or Markdown.',
-                ...(replacement ? ['The previous result was discarded in full. Generate one complete replacement JSON from the supplied facts; do not continue or quote the previous result.'] : []),
               ].join('\n'),
             ),
           },
           { role: 'user' as const, content: facts },
         ],
-      })
-      const complete = async (replacement: boolean): Promise<PlotTreeSnapshot> => {
-        const outcome = await session.complete(task(replacement), { signal: input.signal })
-        if (outcome.status !== 'completed') {
-          throw new PlotTreeIncompleteError(input.sources.writingLanguage, outcome.finishReason)
-        }
-        try {
-          return parsePlotTreeSnapshot(outcome.content, input.sources, dependencies.now())
-        } catch (error) {
-          throw responseError(error, input.sources.writingLanguage)
-        }
       }
-
+      const outcome = await session.complete(task, { signal: input.signal })
+      if (outcome.status !== 'completed') {
+        throw new PlotTreeIncompleteError(input.sources.writingLanguage, outcome.finishReason)
+      }
+      const generatedAt = dependencies.now()
+      let parsed: Record<string, unknown>
       try {
-        return await complete(false)
-      } catch (error) {
-        if (!shouldRequestReplacement(error)) throw error
-        return complete(true)
+        parsed = parsePlotTreeJSON(outcome.content)
+      } catch {
+        return deterministicPlotTreeSnapshot(input.sources, generatedAt)
+      }
+      try {
+        return strictSnapshot(parsed.tracks, input.sources, generatedAt)
+      } catch {
+        try {
+          return normalizePlotTreeSnapshot(parsed, input.sources, generatedAt)
+        } catch {
+          return deterministicPlotTreeSnapshot(input.sources, generatedAt)
+        }
       }
     })
   } catch (error) {

--- a/src/services/workflows/commands/__tests__/architecture.command.test.ts
+++ b/src/services/workflows/commands/__tests__/architecture.command.test.ts
@@ -942,9 +942,13 @@ describe('GenerateCharactersCommand structured roster seam', () => {
     const generatedDetails = fullEntries.map((entry, index) => {
       const details: Partial<CharacterRosterEntry> = { ...entry }
       delete details.relationships
+      details.currentState = {
+        ...entry.currentState!,
+        updatedAtChapter: index + 1,
+      }
       if (index === 0) (details as { age: unknown }).age = 18
       if (index === 0) details.currentState = {
-        ...entry.currentState!,
+        ...details.currentState!,
         keyItems: ['钥匙', '旧照片'],
         recentEvents: ['收到密信', '躲过追捕'],
       } as unknown as CharacterRosterEntry['currentState']
@@ -1249,39 +1253,6 @@ describe('GenerateCharactersCommand structured roster seam', () => {
     expect((committedRequest as { entries: unknown[] }).entries).toHaveLength(4)
     expect(committedEntries[0]!.appearance).toBe(authorAppearance)
   })
-
-  it.each(['-1', '1.5', '', 'abc'])(
-    'rejects invalid decimal-string initial chapter %j before roster commit',
-    async (updatedAtChapter) => {
-      const invalid = JSON.parse(detailBatchResponses(rosterEntries)[0]!) as { entries: Array<Record<string, unknown>> }
-      const state = invalid.entries[0]!.currentState as Record<string, unknown>
-      state.updatedAtChapter = updatedAtChapter
-      const generateStream = createResponseStream([
-        JSON.stringify(manifestFor(rosterEntries)),
-        JSON.stringify(invalid),
-      ])
-      useLLMStore.setState({ defaultModelId: 'model-1', generateStream })
-      const invoke = vi.fn(async (channel: string) => {
-        if (channel === 'prompt:load-global') return { templates: [], diagnostics: [] }
-        if (channel === 'fs:check-exists') return false
-        if (channel === 'db:project-core-get') {
-          return { premise: '这是一段足够长且包含明确冲突与人物目标的故事前提，用于验证非法角色状态章节必须在角色事实提交之前安全失败。' }
-        }
-        throw new Error(`Unexpected IPC channel: ${channel}`)
-      })
-      vi.stubGlobal('window', {
-        velaAPI: { invoke, on: vi.fn(), once: vi.fn(), send: vi.fn(), setZoomLevel: vi.fn(), setZoomFactor: vi.fn(), getZoomLevel: vi.fn() },
-      })
-      const command = new GenerateCharactersCommand({
-        expectedProjectPath: projectAPath,
-        novelConfig: { genre: '玄幻', totalChapters: 100, wordsPerChapter: 3000 } as never,
-      })
-
-      await expect(command.execute({ step: {}, context, callbacks }))
-        .rejects.toThrow('角色详情 slotId=slot-1 字段 currentState.updatedAtChapter 必须是非负整数')
-      expect(domainIpcChannels(invoke)).toEqual(['db:project-core-get'])
-    },
-  )
 
   it('normalizes integer identity and relation IDs before details and one atomic roster commit', async () => {
     const numericManifest = {

--- a/src/services/workflows/commands/__tests__/finalize-postprocess-character.integration.test.ts
+++ b/src/services/workflows/commands/__tests__/finalize-postprocess-character.integration.test.ts
@@ -61,6 +61,16 @@ function initialRosterRequest(): CharacterRosterCommitRequest {
   }
 }
 
+function insertFinalizedDraft(draftId: number, chapterNumber: number): void {
+  const db = getProjectDb()!
+  db.prepare('INSERT INTO contents (id, body) VALUES (?, ?)')
+    .run(draftId, `Chapter ${chapterNumber} finalized content`)
+  db.prepare(`
+    INSERT INTO drafts (id, chapter_number, version, status, content_id, word_count)
+    VALUES (?, ?, 1, 'finalized', ?, 0)
+  `).run(draftId, chapterNumber, draftId)
+}
+
 function installRealRepositoryIpc(): void {
   vi.stubGlobal('window', {
     velaAPI: {
@@ -229,6 +239,7 @@ describe('RunFinalizePostProcessCommand character-state persistence', () => {
   })
 
   it('covers the full finalized source and atomically persists one valid state change', async () => {
+    insertFinalizedDraft(7, 2)
     const draftContent = Array.from({ length: 2350 }, (_, index) => {
       if (index === 0) return 'HEAD_FACT'
       if (index === 1175) return 'MIDDLE_ONLY_HANDOFF_FACT_LIN_LAN_GIVES_BRASS_KEY_TO_ZHOU_YAN'
@@ -305,6 +316,8 @@ describe('RunFinalizePostProcessCommand character-state persistence', () => {
 
   it('rejects an older Chinese chapter retry after a newer character state is committed', async () => {
     workflowContext.writingLanguage = 'zh-CN'
+    insertFinalizedDraft(7, 2)
+    insertFinalizedDraft(8, 3)
     const beforeChapterThree = CharacterRosterRepository.read()
     const existing = beforeChapterThree.entries[0]
     const chapterThree = CharacterRosterRepository.commit({
@@ -373,6 +386,7 @@ describe('RunFinalizePostProcessCommand character-state persistence', () => {
   })
 
   it('cancels before commit and safely retries only the unfinished post-process step', async () => {
+    insertFinalizedDraft(7, 2)
     let cancelledOnce = false
     useLLMStore.setState({
       defaultModelId: 'test-model',
@@ -422,6 +436,7 @@ describe('RunFinalizePostProcessCommand character-state persistence', () => {
   })
 
   it('retries one selected failed step without invoking successful steps again', async () => {
+    insertFinalizedDraft(7, 2)
     cardResponse = '{}'
     const initial = await command('The brass key changes hands.').execute({
       step: {}, context: workflowContext, callbacks: callbacks(),

--- a/src/services/workflows/commands/__tests__/generate-draft.command.test.ts
+++ b/src/services/workflows/commands/__tests__/generate-draft.command.test.ts
@@ -482,31 +482,6 @@ describe('GenerateDraftCommand generation runtime boundary', () => {
     expectNoDraftPersistence(invoke)
   })
 
-  it('persists the original and failed length-replacement candidates with lineage', async () => {
-    const original = '原始章节内容。'.repeat(120)
-    const replacement = '替代版本仍被截断。'.repeat(20)
-    const runtime = fakeOutcomes(
-      outcome(original, 'stop', 1),
-      outcome(replacement, 'length', 2),
-    )
-    const { invoke, context, callbacks, command } = setup({ runtime, wordsTarget: 500 })
-
-    await expect(command.execute({ step: { id: 'draft-step' }, context, callbacks }))
-      .rejects.toThrow(/长度修复未完整结束/u)
-
-    const records = invoke.mock.calls.filter(([channel]) => channel === 'db:recovery-candidate-record')
-    expect(records).toHaveLength(2)
-    expect(records[0]?.[1]).toMatchObject({
-      stepId: 'draft-step',
-      visibleText: original,
-    })
-    expect(records[1]?.[1]).toMatchObject({
-      stepId: 'chapter-draft-length-repair',
-      visibleText: replacement,
-      replacesCandidateId: 'candidate-1',
-    })
-  })
-
   it('keeps the in-memory text and reports when candidate persistence fails', async () => {
     const runtime = fakeRuntime(() => outcome('正文太短。', 'stop'))
     const { invoke, context, callbacks, command } = setup({ runtime, wordsTarget: 500 })
@@ -1438,6 +1413,30 @@ describe('GenerateDraftCommand generation runtime boundary', () => {
     expect(runtime.complete).toHaveBeenCalledOnce()
   })
 
+  it.each([1604, 2285])(
+    'persists a complete %i-unit result above a 1000-unit target without length repair',
+    async visibleUnits => {
+      const draft = '正'.repeat(visibleUnits)
+      const runtime = fakeOutcomes(outcome(draft, 'stop'))
+      const { invoke, context, callbacks, command } = setup({
+        runtime,
+        wordsPerChapter: 1000,
+        wordsTarget: 1000,
+      })
+
+      await expect(command.execute({ step: {}, context, callbacks })).resolves.toBe(draft)
+
+      expect(runtime.complete).toHaveBeenCalledOnce()
+      expect(runtime.complete.mock.calls.map(([task]) => task.purpose)).toEqual(['chapter-draft'])
+      expect(invoke).toHaveBeenCalledWith(
+        'db:draft-create',
+        expect.objectContaining({ content: draft, wordCount: visibleUnits }),
+        expect.anything(),
+        expect.anything(),
+      )
+    },
+  )
+
   it('continues a length result even after it has crossed 82%', async () => {
     const runtime = fakeOutcomes(
       outcome('初'.repeat(5000), 'length', 1),
@@ -1449,12 +1448,12 @@ describe('GenerateDraftCommand generation runtime boundary', () => {
     expect(runtime.complete).toHaveBeenCalledTimes(2)
   })
 
-  it('routes an over-target length candidate into the bounded full-chapter replacement', async () => {
+  it('continues an over-target length candidate and commits only after a stop result', async () => {
     const initialCandidate = `${'甲'.repeat(4000)}。`
-    const replacement = `${'乙'.repeat(2800)}。`
+    const continuation = `${'乙'.repeat(2800)}。`
     const runtime = fakeOutcomes(
       outcome(initialCandidate, 'length', 1),
-      outcome(replacement, 'stop', 2),
+      outcome(continuation, 'stop', 2),
     )
     const { invoke, context, callbacks, command } = setup({
       runtime,
@@ -1462,24 +1461,22 @@ describe('GenerateDraftCommand generation runtime boundary', () => {
       wordsTarget: 3000,
     })
 
-    await expect(command.execute({ step: {}, context, callbacks })).resolves.toBe(replacement)
+    const completedDraft = `${initialCandidate}\n\n${continuation}`
+    await expect(command.execute({ step: {}, context, callbacks })).resolves.toBe(completedDraft)
 
     expect(runtime.complete.mock.calls.map(([task]) => task.purpose)).toEqual([
       'chapter-draft',
-      'chapter-draft-length-repair',
+      'chapter-draft-continuation',
     ])
-    const repairPrompt = runtime.complete.mock.calls[1]?.[0].messages
-      .find(message => message.role === 'user')?.content ?? ''
-    expect(repairPrompt).toContain(initialCandidate)
     expect(invoke).toHaveBeenCalledWith(
       'db:draft-create',
-      expect.objectContaining({ content: replacement }),
+      expect.objectContaining({ content: completedDraft }),
       expect.anything(),
       expect.anything(),
     )
   })
 
-  it('keeps an over-target length candidate visible when the shared budget cannot replace it', async () => {
+  it('keeps an over-target length candidate visible when the shared budget cannot continue it', async () => {
     const initialCandidate = `${'甲'.repeat(4000)}。`
     const runtime = fakeRuntime((attempt) => {
       if (attempt === 1) return outcome(initialCandidate, 'length', 1)
@@ -1497,14 +1494,14 @@ describe('GenerateDraftCommand generation runtime boundary', () => {
 
     expect(runtime.complete.mock.calls.map(([task]) => task.purpose)).toEqual([
       'chapter-draft',
-      'chapter-draft-length-repair',
+      'chapter-draft-continuation',
     ])
     expect(replaceText).toHaveBeenLastCalledWith(initialCandidate)
     expect(callbacks.log).toHaveBeenCalledWith(expect.stringContaining('已保存为项目恢复候选'))
     expectNoDraftPersistence(setupResult.invoke)
   })
 
-  it('keeps frozen relevant state, continuity, and selected references in continuation and compression', async () => {
+  it('keeps frozen relevant state, continuity, and selected references in continuations', async () => {
     const characterStateSentinel = 'UNIQUE_ROLE_STATE_MIDDLE_SENTINEL'
     const continuitySentinel = 'UNIQUE_FINALIZED_FACT_MIDDLE_SENTINEL'
     const referenceSentinel = 'UNIQUE_SELECTED_REFERENCE_MIDDLE_SENTINEL'
@@ -1571,25 +1568,29 @@ describe('GenerateDraftCommand generation runtime boundary', () => {
     const continuationPrompt = continuationRuntime.complete.mock.calls[1]?.[0].messages
       .find(message => message.role === 'user')?.content ?? ''
 
-    const compressionRuntime = fakeOutcomes(
+    const overTargetContinuationRuntime = fakeOutcomes(
       outcome(`${'甲'.repeat(4000)}。`, 'length', 1),
       outcome(`${'乙'.repeat(2800)}。`, 'stop', 2),
     )
-    const compression = setup({
-      runtime: compressionRuntime,
+    const overTargetContinuation = setup({
+      runtime: overTargetContinuationRuntime,
       wordsPerChapter: 3000,
       wordsTarget: 3000,
       ...sharedSetup,
     })
-    await compression.command.execute({ step: {}, context: compression.context, callbacks: compression.callbacks })
-    const compressionPrompt = compressionRuntime.complete.mock.calls[1]?.[0].messages
+    await overTargetContinuation.command.execute({
+      step: {},
+      context: overTargetContinuation.context,
+      callbacks: overTargetContinuation.callbacks,
+    })
+    const overTargetContinuationPrompt = overTargetContinuationRuntime.complete.mock.calls[1]?.[0].messages
       .find(message => message.role === 'user')?.content ?? ''
 
-    for (const prompt of [initialPrompt, continuationPrompt, compressionPrompt]) {
+    for (const prompt of [initialPrompt, continuationPrompt, overTargetContinuationPrompt]) {
       expect(prompt).toContain(characterStateSentinel)
       expect(prompt).not.toContain('IRRELEVANT_ROLE_STATE_SENTINEL')
     }
-    for (const prompt of [continuationPrompt, compressionPrompt]) {
+    for (const prompt of [continuationPrompt, overTargetContinuationPrompt]) {
       expect(prompt).toContain(continuitySentinel)
       expect(prompt).toContain(referenceSentinel)
     }
@@ -1704,273 +1705,6 @@ describe('GenerateDraftCommand generation runtime boundary', () => {
     expect(prompt).not.toMatch(/\{\{(?:chapter_info|future_blueprints|user_guidance)\}\}/u)
     expect(prompt).toContain('第2章 蓝门回声：追查蓝色漆屑与撞击声')
     expect(prompt).toContain('第一章必须以潮湿灯塔开场')
-  })
-
-  it('uses the bounded final rewrite when the first English length repair underfills', async () => {
-    const initialSource = `ORIGINAL_SOURCE_HEAD ${'alpha '.repeat(900)} ORIGINAL_SOURCE_MIDDLE ${'alpha '.repeat(929)}`
-    const continuationSource = `${'beta '.repeat(1031)} ORIGINAL_SOURCE_TAIL`
-    const acceptedDraft = 'delta '.repeat(2250)
-    const repairDraft = [
-      'REPAIR_SOURCE_HEAD',
-      'gamma '.repeat(900),
-      'REPAIR_SOURCE_MIDDLE',
-      'gamma '.repeat(932),
-      'REPAIR_SOURCE_TAIL',
-    ].join(' ')
-    const runtime = fakeOutcomes(
-      outcome(initialSource, 'stop', 1),
-      outcome(continuationSource, 'stop', 2),
-      outcome(repairDraft, 'stop', 3),
-      outcome(acceptedDraft, 'stop', 4),
-    )
-    const { invoke, context, callbacks, command } = setup({
-      runtime,
-      writingLanguage: 'en-US',
-      wordsPerChapter: 6000,
-      wordsTarget: 2500,
-      globalGuidance: 'FROZEN_GLOBAL_RULE',
-      coreOutline: 'FROZEN_CORE_FACT',
-    })
-
-    await expect(command.execute({ step: {}, context, callbacks })).resolves.toBe(acceptedDraft.trim())
-
-    expect(runtime.complete.mock.calls.map(([task]) => task.purpose)).toEqual([
-      'chapter-draft',
-      'chapter-draft-continuation',
-      'chapter-draft-length-repair',
-      'chapter-draft-length-final-rewrite',
-    ])
-    const repairPrompt = runtime.complete.mock.calls[2]?.[0].messages
-      .find(message => message.role === 'user')?.content ?? ''
-    expect(repairPrompt).toContain('locally counted prose units')
-    const finalRewriteRequest = runtime.complete.mock.calls[3]?.[0].messages
-      .map(message => message.content).join('\n') ?? ''
-    expect(finalRewriteRequest).toContain('ORIGINAL_SOURCE_HEAD')
-    expect(finalRewriteRequest).toContain('ORIGINAL_SOURCE_MIDDLE')
-    expect(finalRewriteRequest).toContain('ORIGINAL_SOURCE_TAIL')
-    expect(finalRewriteRequest).not.toContain('REPAIR_SOURCE_MIDDLE')
-    expect(finalRewriteRequest).toContain('FROZEN_GLOBAL_RULE')
-    expect(finalRewriteRequest).toContain('FROZEN_CORE_FACT')
-    expect(invoke).toHaveBeenCalledWith(
-      'db:draft-create',
-      expect.objectContaining({ content: acceptedDraft.trim() }),
-      expect.anything(),
-      expect.anything(),
-    )
-  })
-
-  it('repairs an overlong complete result once in the same session instead of truncating it', async () => {
-    const overlongDraft = Array.from(
-      { length: 20 },
-      (_, index) => `第${index + 1}段${'甲'.repeat(195)}。`,
-    ).join('\n\n') + '\n\n原稿最终事件：警报解除，林岚带着证据走出机房。'
-    const repairedDraft = `${'乙'.repeat(2750)}。林岚发现密钥，切断警报，带着证据走出机房。`
-    const runtime = fakeOutcomes(
-      outcome(overlongDraft, 'stop'),
-      outcome(repairedDraft, 'stop', 2),
-    )
-    const { invoke, context, callbacks, command } = setup({
-      runtime,
-      wordsPerChapter: 6000,
-      wordsTarget: 3000,
-      keyEvents: '发现密钥；切断警报；带着证据离开机房',
-    })
-
-    await expect(command.execute({ step: {}, context, callbacks })).resolves.toBe(repairedDraft)
-
-    expect(runtime.execute).toHaveBeenCalledOnce()
-    expect(runtime.complete).toHaveBeenCalledTimes(2)
-    expect(runtime.complete.mock.calls[1]?.[0]).toMatchObject({
-      purpose: 'chapter-draft-length-repair',
-      output: 'visible-text',
-    })
-    const repairPrompt = runtime.complete.mock.calls[1]?.[0].messages
-      .find(message => message.role === 'user')?.content ?? ''
-    expect(repairPrompt).toContain('发现密钥；切断警报；带着证据离开机房')
-    expect(repairPrompt).toContain(overlongDraft)
-    const persisted = invoke.mock.calls.find(([channel]) => channel === 'db:draft-create')
-    const content = (persisted?.[1] as { content: string }).content
-    expect(content).toBe(repairedDraft)
-  })
-
-  it.each([
-    { writingLanguage: 'zh-CN' as const, wordsTarget: 100, finalTarget: 90, paragraphs: 4, paragraphUnits: 23 },
-    { writingLanguage: 'zh-CN' as const, wordsTarget: 500, finalTarget: 450, paragraphs: 5, paragraphUnits: 90 },
-    { writingLanguage: 'zh-CN' as const, wordsTarget: 2500, finalTarget: 2250, paragraphs: 23, paragraphUnits: 98 },
-    { writingLanguage: 'en-US' as const, wordsTarget: 2500, finalTarget: 2250, paragraphs: 23, paragraphUnits: 98 },
-    { writingLanguage: 'en-US' as const, wordsTarget: 20_000, finalTarget: 18_000, paragraphs: 80, paragraphUnits: 225 },
-  ])('uses a satisfiable scaled final-rewrite contract for $writingLanguage target $wordsTarget', async ({
-    writingLanguage,
-    wordsTarget,
-    finalTarget,
-    paragraphs,
-    paragraphUnits,
-  }) => {
-    const endingFact = 'ENDING_SENTINEL。林岚发现密钥，切断警报，带着证据离开机房。'
-    const fixedText = `FRONT_SENTINEL。MIDDLE_SENTINEL。尾段结束。${endingFact}`
-    const firstRepairUnits = Math.max(1200, Math.floor(wordsTarget * 1.12) + 100)
-    const sourceFiller = '甲'.repeat(firstRepairUnits + 100 - countDraftUnits(fixedText))
-    const originalSource = `FRONT_SENTINEL。MIDDLE_SENTINEL。${sourceFiller}尾段结束。\n\n${endingFact}`
-    const firstRepair = '乙'.repeat(firstRepairUnits)
-    expect(countDraftUnits(firstRepair)).toBe(firstRepairUnits)
-    const finalDraft = '丙'.repeat(finalTarget)
-    const runtime = fakeOutcomes(
-      outcome(originalSource, 'stop'),
-      outcome(firstRepair, 'stop', 2),
-      outcome(finalDraft, 'stop', 3),
-    )
-    const { invoke, context, callbacks, command } = setup({
-      runtime,
-      wordsPerChapter: 6000,
-      wordsTarget,
-      keyEvents: '发现密钥；切断警报；带着证据离开机房',
-      writingLanguage,
-    })
-
-    await expect(command.execute({ step: {}, context, callbacks })).resolves.toBe(finalDraft)
-
-    expect(runtime.complete.mock.calls.map(([task]) => task.purpose)).toEqual([
-      'chapter-draft',
-      'chapter-draft-length-repair',
-      'chapter-draft-length-final-rewrite',
-    ])
-    const finalPrompt = runtime.complete.mock.calls[2]?.[0].messages
-      .find(message => message.role === 'user')?.content ?? ''
-    expect(finalPrompt).not.toContain(String(firstRepairUnits))
-    expect(finalPrompt).toContain(writingLanguage === 'zh-CN'
-      ? '从空白页重新写作'
-      : 'rewrite it from a blank page')
-    expect(finalPrompt).toContain(writingLanguage === 'zh-CN'
-      ? `本次兜底写作目标为 ${finalTarget} 个正文单位，不得超过 ${finalTarget} 个正文单位`
-      : `The fallback writing target is ${finalTarget} prose units; do not exceed ${finalTarget} prose units`)
-    expect(finalPrompt).toContain(writingLanguage === 'zh-CN'
-      ? `全章绝对不得超过 ${paragraphs} 个自然段，每段不得超过约 ${paragraphUnits} 个正文单位`
-      : `Use no more than ${paragraphs} natural paragraphs, with each paragraph no longer than about ${paragraphUnits} prose units`)
-    expect(finalPrompt).toContain(writingLanguage === 'zh-CN'
-      ? '交付前自行核对段落数与正文单位预算，不要输出核对过程'
-      : 'Before delivery, silently verify the paragraph count and prose-unit budget; do not output the verification')
-    expect(finalPrompt).toContain(writingLanguage === 'zh-CN'
-      ? '对白必须并入人物动作、反应或环境描写所在的段落'
-      : 'Fold dialogue into the paragraph containing character action, reaction, or setting')
-    expect(finalPrompt).toContain(writingLanguage === 'zh-CN'
-      ? '【待重写的完整章节草稿】'
-      : '[Complete chapter draft to rewrite]')
-    expect(finalPrompt).toContain(`"wordsTarget": ${finalTarget}`)
-    expect(finalPrompt).not.toContain(`"wordsTarget": ${wordsTarget}`)
-    expect(finalPrompt).toContain('发现密钥；切断警报；带着证据离开机房')
-    expect(finalPrompt).toContain('ENDING_SENTINEL')
-    expect(finalPrompt).toContain('FRONT_SENTINEL')
-    expect(finalPrompt).toContain('MIDDLE_SENTINEL')
-    expect(finalPrompt).toContain('甲'.repeat(80))
-    const persisted = invoke.mock.calls.find(([channel]) => channel === 'db:draft-create')
-    expect((persisted?.[1] as { content: string }).content).toBe(finalDraft)
-  })
-
-  it('accepts a noncompliant 2700-unit final rewrite that remains inside the local boundary', async () => {
-    const finalDraft = '丙'.repeat(2700)
-    const runtime = fakeOutcomes(
-      outcome('甲'.repeat(3100), 'stop'),
-      outcome('乙'.repeat(3000), 'stop', 2),
-      outcome(finalDraft, 'stop', 3),
-    )
-    const { invoke, context, callbacks, command } = setup({ runtime, wordsTarget: 2500 })
-
-    await expect(command.execute({ step: {}, context, callbacks })).resolves.toBe(finalDraft)
-
-    expect(runtime.complete).toHaveBeenCalledTimes(3)
-    const finalPrompt = runtime.complete.mock.calls[2]?.[0].messages
-      .find(message => message.role === 'user')?.content ?? ''
-    expect(finalPrompt).toContain('本次兜底写作目标为 2250 个正文单位，不得超过 2250 个正文单位')
-    const persisted = invoke.mock.calls.find(([channel]) => channel === 'db:draft-create')
-    expect((persisted?.[1] as { content: string }).content).toBe(finalDraft)
-  })
-
-  it.each([
-    { writingLanguage: 'zh-CN' as const, finalUnits: 3075, boundary: 'above the local maximum' },
-    { writingLanguage: 'en-US' as const, finalUnits: 2000, boundary: 'below the local minimum' },
-  ])(
-    'allows one last-chance rewrite after a stopped final rewrite $boundary in $writingLanguage',
-    async ({ writingLanguage, finalUnits }) => {
-      const originalSourceDraft = [
-        'ORIGINAL_SOURCE_HEAD',
-        '甲'.repeat(2_400),
-        'ORIGINAL_SOURCE_MIDDLE',
-        '乙'.repeat(2_400),
-        'ORIGINAL_SOURCE_TAIL',
-      ].join('\n')
-      const acceptedDraft = '丁'.repeat(2200)
-      const runtime = fakeOutcomes(
-        outcome(originalSourceDraft, 'stop'),
-        outcome(`${'乙'.repeat(4276)}。`, 'stop', 2),
-        outcome(`${'丙'.repeat(finalUnits)}。`, 'stop', 3),
-        outcome(acceptedDraft, 'stop', 4),
-      )
-      const { invoke, context, callbacks, command } = setup({
-        runtime,
-        wordsPerChapter: 6000,
-        wordsTarget: 2500,
-        writingLanguage,
-      })
-
-      await expect(command.execute({ step: {}, context, callbacks })).resolves.toBe(acceptedDraft)
-
-      expect(runtime.complete.mock.calls.map(([task]) => task.purpose)).toEqual([
-        'chapter-draft',
-        'chapter-draft-length-repair',
-        'chapter-draft-length-final-rewrite',
-        'chapter-draft-length-final-rewrite-retry',
-      ])
-      const retryPrompt = runtime.complete.mock.calls[3]?.[0].messages
-        .find(message => message.role === 'user')?.content ?? ''
-      expect(retryPrompt).toContain(writingLanguage === 'zh-CN'
-        ? '本次兜底写作目标为 2250 个正文单位，不得超过 2250 个正文单位'
-        : 'The fallback writing target is 2250 prose units; do not exceed 2250 prose units')
-      expect(retryPrompt).toContain(writingLanguage === 'zh-CN'
-        ? '全章绝对不得超过 23 个自然段，每段不得超过约 98 个正文单位'
-        : 'Use no more than 23 natural paragraphs, with each paragraph no longer than about 98 prose units')
-      for (const [task] of runtime.complete.mock.calls.slice(1)) {
-        const recoveryPrompt = task.messages.find(message => message.role === 'user')?.content ?? ''
-        expect(recoveryPrompt).toContain('ORIGINAL_SOURCE_HEAD')
-        expect(recoveryPrompt).toContain('ORIGINAL_SOURCE_MIDDLE')
-        expect(recoveryPrompt).toContain('ORIGINAL_SOURCE_TAIL')
-      }
-      const persisted = invoke.mock.calls.find(([channel]) => channel === 'db:draft-create')
-      expect((persisted?.[1] as { content: string }).content).toBe(acceptedDraft)
-    },
-  )
-
-  it.each([
-    { finishReason: 'stop' as const, content: `${'丁'.repeat(2900)}。`, expectedError: '仍超过 2800' },
-    { finishReason: 'stop' as const, content: `${'丁'.repeat(2000)}。`, expectedError: '删减过多' },
-    { finishReason: 'length' as const, content: `${'丁'.repeat(2200)}。`, expectedError: '重试未完整结束' },
-  ])('rejects a $finishReason last-chance rewrite without persistence', async ({
-    finishReason,
-    content,
-    expectedError,
-  }) => {
-    const runtime = fakeOutcomes(
-      outcome(`${'甲'.repeat(3100)}。`, 'stop'),
-      outcome(`${'乙'.repeat(3000)}。`, 'stop', 2),
-      outcome(`${'丙'.repeat(2900)}。`, 'stop', 3),
-      outcome(content, finishReason, 4),
-    )
-    const { invoke, context, callbacks, command } = setup({
-      runtime,
-      wordsPerChapter: 6000,
-      wordsTarget: 2500,
-    })
-
-    await expect(command.execute({ step: {}, context, callbacks }))
-      .rejects.toThrow(expectedError)
-
-    expect(runtime.complete.mock.calls.map(([task]) => task.purpose)).toEqual([
-      'chapter-draft',
-      'chapter-draft-length-repair',
-      'chapter-draft-length-final-rewrite',
-      'chapter-draft-length-final-rewrite-retry',
-    ])
-    expectNoDraftPersistence(invoke)
-    expect(context.data).not.toHaveProperty('draft')
   })
 
   it.each(['content_filter', 'error', 'unknown', 'cancelled'] as const)(

--- a/src/services/workflows/commands/__tests__/mutation-failure-boundary.test.ts
+++ b/src/services/workflows/commands/__tests__/mutation-failure-boundary.test.ts
@@ -915,6 +915,34 @@ describe('workflow mutation failure boundaries', () => {
     expect(invoke.mock.calls.filter(([channel]) => channel === 'db:character-roster-commit')).toHaveLength(2)
   })
 
+  it('regenerates character state after malformed model output fails parsing', async () => {
+    const allCharacters = [{ name: '林岚', role: 'protagonist', relationships: [], currentState: {} }]
+    const invoke = vi.fn(async (channel: string) => {
+      if (channel === 'db:character-roster-read') {
+        return { status: 'ready', revision: 4, entries: allCharacters }
+      }
+      if (channel === 'db:character-roster-commit') {
+        return { success: true, receipt: { revision: 5 } }
+      }
+      throw new Error(`unexpected IPC: ${channel}`)
+    })
+    stubVelaIpc(invoke)
+    const complete = vi.fn()
+      .mockResolvedValueOnce('{"updates":{}}')
+      .mockResolvedValueOnce(JSON.stringify({
+        updates: [{ name: '林岚', currentState: { location: '车站' } }],
+      }))
+    const step = buildFinalizePostProcessSteps(
+      { path: PROJECT_PATH }, 1, '第一章', '正文', { complete },
+    ).find(candidate => candidate.key === 'character_cards')!
+
+    await expect(step.executor(callbacks(), context())).rejects.toThrow('updates 必须是列表')
+    await expect(step.executor(callbacks(), context())).resolves.toBeUndefined()
+
+    expect(complete).toHaveBeenCalledTimes(2)
+    expect(invoke.mock.calls.filter(([channel]) => channel === 'db:character-roster-commit')).toHaveLength(1)
+  })
+
   it('does not persist post-process output when the stream omits terminal evidence', async () => {
     const invoke = vi.fn(async (channel: string) => {
       if (channel === 'db:blueprint-update-notes') return { success: true }

--- a/src/services/workflows/commands/__tests__/mutation-failure-boundary.test.ts
+++ b/src/services/workflows/commands/__tests__/mutation-failure-boundary.test.ts
@@ -366,6 +366,30 @@ describe('workflow mutation failure boundaries', () => {
     expect(stepCallbacks.log).not.toHaveBeenCalledWith(expect.stringContaining('剧情要点提取完成'))
   })
 
+  it('reuses generated chapter notes when an executor retry only repairs persistence', async () => {
+    let persistenceAttempts = 0
+    const invoke = vi.fn(async (channel: string) => {
+      if (channel === 'db:blueprint-update-notes') {
+        persistenceAttempts += 1
+        return persistenceAttempts === 1
+          ? { success: false, error: 'transient notes failure' }
+          : { success: true }
+      }
+      throw new Error(`unexpected IPC: ${channel}`)
+    })
+    stubVelaIpc(invoke)
+    const complete = vi.fn(async () => '一次生成的章节要点')
+    const step = buildFinalizePostProcessSteps(
+      { path: PROJECT_PATH }, 1, '第一章', '正文', { complete },
+    ).find(candidate => candidate.key === 'chapter_notes')!
+
+    await expect(step.executor(callbacks(), context())).rejects.toThrow('transient notes failure')
+    await expect(step.executor(callbacks(), context())).resolves.toBeUndefined()
+
+    expect(complete).toHaveBeenCalledOnce()
+    expect(invoke.mock.calls.filter(([channel]) => channel === 'db:blueprint-update-notes')).toHaveLength(2)
+  })
+
   it('persists notes but omits unsupported facts when the author chapter has no blueprint', async () => {
     const invoke = vi.fn(async (channel: string) => {
       if (channel === 'db:continuity-save-finalized') return { success: true }
@@ -859,6 +883,36 @@ describe('workflow mutation failure boundaries', () => {
       'db:character-roster-read',
       'db:character-roster-commit',
     ])
+  })
+
+  it('reuses generated character state when an executor retry only repairs persistence', async () => {
+    const allCharacters = [{ name: '林岚', role: 'protagonist', relationships: [], currentState: {} }]
+    let persistenceAttempts = 0
+    const invoke = vi.fn(async (channel: string) => {
+      if (channel === 'db:character-roster-read') {
+        return { status: 'ready', revision: 4, entries: allCharacters }
+      }
+      if (channel === 'db:character-roster-commit') {
+        persistenceAttempts += 1
+        return persistenceAttempts === 1
+          ? { success: false, error: 'transient roster failure' }
+          : { success: true, receipt: { revision: 5 } }
+      }
+      throw new Error(`unexpected IPC: ${channel}`)
+    })
+    stubVelaIpc(invoke)
+    const complete = vi.fn(async () => JSON.stringify({
+      updates: [{ name: '林岚', currentState: { location: '车站' } }],
+    }))
+    const step = buildFinalizePostProcessSteps(
+      { path: PROJECT_PATH }, 1, '第一章', '正文', { complete },
+    ).find(candidate => candidate.key === 'character_cards')!
+
+    await expect(step.executor(callbacks(), context())).rejects.toThrow('transient roster failure')
+    await expect(step.executor(callbacks(), context())).resolves.toBeUndefined()
+
+    expect(complete).toHaveBeenCalledOnce()
+    expect(invoke.mock.calls.filter(([channel]) => channel === 'db:character-roster-commit')).toHaveLength(2)
   })
 
   it('does not persist post-process output when the stream omits terminal evidence', async () => {

--- a/src/services/workflows/commands/architecture.command.ts
+++ b/src/services/workflows/commands/architecture.command.ts
@@ -362,12 +362,6 @@ function normalizeBoundedDetailText(value: unknown, maxChars: number): unknown {
   return Array.from(value.trim()).slice(0, maxChars).join('')
 }
 
-function normalizeUpdatedAtChapter(value: unknown): unknown {
-  if (typeof value !== 'string' || !/^\d+$/u.test(value)) return value
-  const chapter = Number(value)
-  return Number.isSafeInteger(chapter) ? chapter : value
-}
-
 export interface ArchitectureProjectSnapshot {
   expectedProjectPath: string
   novelConfig: Readonly<NovelConfig>
@@ -967,7 +961,9 @@ export class GenerateCharactersCommand extends BaseWorkflowCommand<string> {
               ...candidate.currentState,
               keyItems: normalizeDetailStringList(candidate.currentState.keyItems, '、'),
               recentEvents: normalizeDetailStringList(candidate.currentState.recentEvents, '；'),
-              updatedAtChapter: normalizeUpdatedAtChapter(candidate.currentState.updatedAtChapter),
+              // Architecture generation describes the pre-chapter baseline. A
+              // model-supplied future chapter must never become persisted fact.
+              updatedAtChapter: 0,
             }
             for (const field of CHARACTER_STATE_TEXT_FIELDS) {
               normalizedState[field] = normalizeBoundedDetailText(

--- a/src/services/workflows/commands/finalize-chapter.command.ts
+++ b/src/services/workflows/commands/finalize-chapter.command.ts
@@ -262,6 +262,8 @@ export function buildFinalizePostProcessSteps(
 ): PostProcessStep[] {
   const steps: PostProcessStep[] = []
   const text = (zhCNText: string, enUSText: string) => localize(uiLocale, zhCNText, enUSText)
+  let generatedChapterNotes: string | undefined
+  let generatedCharacterCards: string | undefined
 
   // ─── 步骤 1: 导入知识库 ───────────────────────────────────────────
   steps.push({
@@ -335,7 +337,8 @@ export function buildFinalizePostProcessSteps(
           .withChapterNumber(chapterNumber)
           .withChapterTitle(chapterTitle)
 
-        const cleanNotes = await generation.complete(notesBuilder, callbacks, 'visible-text', context)
+        generatedChapterNotes ??= await generation.complete(notesBuilder, callbacks, 'visible-text', context)
+        const cleanNotes = generatedChapterNotes
         if (context?.cancelled) throw new Error(workflowUiText(context, '工作流已取消', 'Workflow was cancelled.'))
 
         if (finalizedDraftId !== undefined) {
@@ -432,12 +435,13 @@ export function buildFinalizePostProcessSteps(
           .withChapterNumber(chapterNumber)
           .withExistingCardsJson(simpleCards)
 
-        const cardsResult = await generation.complete(
+        generatedCharacterCards ??= await generation.complete(
           cardBuilder,
           callbacks,
           'structured-data',
           context,
         )
+        const cardsResult = generatedCharacterCards
         if (context?.cancelled) throw new Error(workflowUiText(context, '工作流已取消', 'Workflow was cancelled.'))
         const updatesByName = parseCharacterStateUpdates(cardsResult, allChars, chapterNumber)
         let updatedCount = 0

--- a/src/services/workflows/commands/finalize-chapter.command.ts
+++ b/src/services/workflows/commands/finalize-chapter.command.ts
@@ -435,15 +435,15 @@ export function buildFinalizePostProcessSteps(
           .withChapterNumber(chapterNumber)
           .withExistingCardsJson(simpleCards)
 
-        generatedCharacterCards ??= await generation.complete(
+        const cardsResult = generatedCharacterCards ?? await generation.complete(
           cardBuilder,
           callbacks,
           'structured-data',
           context,
         )
-        const cardsResult = generatedCharacterCards
         if (context?.cancelled) throw new Error(workflowUiText(context, '工作流已取消', 'Workflow was cancelled.'))
         const updatesByName = parseCharacterStateUpdates(cardsResult, allChars, chapterNumber)
+        generatedCharacterCards = cardsResult
         let updatedCount = 0
         const changedEntries: CharacterRosterEntry[] = []
         for (const character of allChars) {

--- a/src/services/workflows/commands/generate-draft.command.ts
+++ b/src/services/workflows/commands/generate-draft.command.ts
@@ -45,7 +45,6 @@ export { countDraftUnits } from '../../../shared/draft-units'
 const CONTINUE_PROMPT_MAX_CHARS = 1600
 const MIN_TARGET_COMPLETION_RATIO = 0.82
 const MAX_AUTO_CONTINUE_ROUNDS = 7
-const MAX_TARGET_OVERAGE_RATIO = 0.12
 const PREVIOUS_ENDING_MAX_CHARS = 1000
 const NEXT_CHAPTER_HEAD_MAX_CHARS = 1200
 const CROSS_CHAPTER_REUSE_CJK_NGRAM_CHARS = 8
@@ -134,10 +133,6 @@ function createDraftStreamPreview(
       timer = undefined
     },
   }
-}
-
-function maxDraftCharsForTarget(targetChars: number): number {
-  return Math.floor(targetChars * (1 + MAX_TARGET_OVERAGE_RATIO))
 }
 
 export const DRAFT_GENERATION_BUDGET = Object.freeze({
@@ -501,7 +496,6 @@ export class GenerateDraftCommand extends BaseWorkflowCommand {
       ),
     ].join('\n\n')
     const targetChars = normalizeChapterWordsTarget(this.chapterInfo.wordsTarget, novelConfig.wordsPerChapter)
-    const maxDraftChars = maxDraftCharsForTarget(targetChars)
 
     callbacks.log(uiText(
       '调用 AI 生成章节草稿...',
@@ -509,19 +503,9 @@ export class GenerateDraftCommand extends BaseWorkflowCommand {
     ))
     let draftPersisted = false
     let recoverableDraftCandidate = ''
-    const recoveryAlternatives: Array<{ stepId: string; visibleText: string }> = []
     const workflowStepId = step && typeof step === 'object' && 'id' in step && typeof step.id === 'string'
       ? step.id
       : 'generate-draft'
-    const rememberAlternative = (stepId: string, text: string) => {
-      const visibleText = sanitizeDraftText(text)
-      if (
-        !visibleText
-        || visibleText === recoverableDraftCandidate
-        || recoveryAlternatives.at(-1)?.visibleText === visibleText
-      ) return
-      recoveryAlternatives.push({ stepId, visibleText })
-    }
     try {
       this.assertNotCancelled(context)
       const cancellation = observeWorkflowCancellation(context)
@@ -612,220 +596,7 @@ export class GenerateDraftCommand extends BaseWorkflowCommand {
             onRecoverableCandidate: candidate => { recoverableDraftCandidate = candidate },
           })
           recoverableDraftCandidate = completedDraft
-          const completedUnits = countDraftUnits(completedDraft)
-          if (completedUnits <= maxDraftChars) return completedDraft
-
-          callbacks.log(uiText(
-            `  草稿超过目标容差，将在当前模型会话中压缩至不超过 ${maxDraftChars} 个正文单位`,
-            `  Draft exceeded the target tolerance; compressing it in the current model session to at most ${maxDraftChars} prose units`,
-          ))
-          const minimumDraftChars = Math.floor(targetChars * MIN_TARGET_COMPLETION_RATIO)
-          const originalSourceDraft = completedDraft
-          const lengthRewritePrompt = (currentUnits: number, final: boolean) => {
-            const rewriteMaxDraftChars = final ? Math.floor(targetChars * 0.9) : maxDraftChars
-            const paragraphCount = Math.max(4, Math.min(80, Math.round(rewriteMaxDraftChars / 100)))
-            const paragraphUnits = Math.round(rewriteMaxDraftChars / paragraphCount)
-            const rewriteChapterInfo = final
-              ? { ...this.chapterInfo, wordsTarget: rewriteMaxDraftChars }
-              : this.chapterInfo
-            return promptLanguageText(
-              writingLanguage,
-              `${final
-                ? '上一轮完整重写结果未落入本地长度范围；这是最终压缩阶段的有界完整重写。不要继续逐句删改上一稿；请从空白页重新写作。'
-                : `当前完整章节经本地计数有 ${currentUnits} 个正文单位，需要压缩并完整重写。`}
-
-【硬性要求】
-- 只输出重写后的完整章节正文，不要解释、总结、Markdown 或思考过程。
-${final
-  ? `- 本次兜底写作目标为 ${rewriteMaxDraftChars} 个正文单位，不得超过 ${rewriteMaxDraftChars} 个正文单位；中文汉字与英文单词计数，标点和空白不计。`
-  : `- 本地计数结果不得少于 ${minimumDraftChars} 个正文单位，也不得超过 ${rewriteMaxDraftChars} 个正文单位；中文汉字与英文单词计数，标点和空白不计。`}
-${final ? `- 全章绝对不得超过 ${paragraphCount} 个自然段，每段不得超过约 ${paragraphUnits} 个正文单位；总计不得超过上述兜底目标。
-- 对白必须并入人物动作、反应或环境描写所在的段落，不得让一句对白或单个动作独占一段。
-- 交付前自行核对段落数与正文单位预算，不要输出核对过程。` : ''}
-- 完整保留本章蓝图中的每一个事件、角色行动、因果关系与关键结果。
-- 保留原稿结尾的最终事件与结果，并以完整、自然的句子或段落收束。
-- 优先删除重复说明、复述、冗余对话和装饰性描写，不得用删除蓝图事件或结尾来满足长度。
-- 不得只输出节选，不得提前写后续章节。
-
-【本章蓝图】
-${JSON.stringify(rewriteChapterInfo, null, 2)}
-
-【冻结的作者约束】
-全局写作要求：
-${mergedGuidance}
-
-文风要求：
-${writingStyle}
-
-作者小说配置事实：
-${novelConfigFactsJson}
-
-【冻结的相关角色状态】
-${characterState}
-
-【冻结的已定稿连续性与活跃线索】
-${frozenContinuityContext}
-
-【冻结的本章相关规划资料（仅作参考，不代表已经发生）】
-${filteredContext}
-
-【待重写的完整章节草稿】
-${originalSourceDraft}`,
-              `${final
-                ? 'The previous full rewrite fell outside the local length range. This is a bounded full rewrite in the final compression stage. Do not keep line-editing the prior draft; rewrite it from a blank page.'
-                : `The complete chapter currently contains ${currentUnits} locally counted prose units and must be compressed and rewritten in full.`}
-
-[Requirements]
-- Output only the complete rewritten chapter prose; do not include explanations, summaries, Markdown, or reasoning.
-${final
-  ? `- The fallback writing target is ${rewriteMaxDraftChars} prose units; do not exceed ${rewriteMaxDraftChars} prose units. Chinese Han characters and English words count, while punctuation and whitespace do not.`
-  : `- The local count must be at least ${minimumDraftChars} prose units and no more than ${rewriteMaxDraftChars}; Chinese Han characters and English words count, while punctuation and whitespace do not.`}
-${final ? `- Use no more than ${paragraphCount} natural paragraphs, with each paragraph no longer than about ${paragraphUnits} prose units; the total must not exceed the fallback target above.
-- Fold dialogue into the paragraph containing character action, reaction, or setting; do not give one line of dialogue or one action its own paragraph.
-- Before delivery, silently verify the paragraph count and prose-unit budget; do not output the verification.` : ''}
-- Preserve every blueprint event, character action, causal link, and key outcome.
-- Preserve the final event and outcome from the original ending, and finish with a complete, natural sentence or paragraph.
-- Remove repeated explanation, recap, redundant dialogue, and decorative description first; never remove blueprint events or the ending to meet the limit.
-- Do not output an excerpt and do not advance into later chapters.
-
-[Current chapter blueprint]
-${JSON.stringify(rewriteChapterInfo, null, 2)}
-
-[Frozen author constraints]
-Global writing guidance:
-${mergedGuidance}
-
-Writing style:
-${writingStyle}
-
-Author novel-configuration facts:
-${novelConfigFactsJson}
-
-[Frozen relevant character states]
-${characterState}
-
-[Frozen finalized continuity and active threads]
-${frozenContinuityContext}
-
-[Frozen planning material relevant to this chapter (reference only; not established history)]
-${filteredContext}
-
-[Complete chapter draft to rewrite]
-${originalSourceDraft}`,
-            )
-          }
-          const repairPrompt = lengthRewritePrompt(
-            completedUnits,
-            false,
-          )
-          const completeLengthRewrite = async (purpose: string, userPrompt: string) => {
-            let streamedText = ''
-            try {
-              return await draftingSession.complete({
-                purpose,
-                reasoningStage: 'drafting',
-                output: 'visible-text',
-                messages: [
-                  { role: 'system', content: promptBuilder.getSystemRole() },
-                  { role: 'user', content: userPrompt },
-                ],
-              }, {
-                signal: cancellation.signal,
-                onChunk: chunk => { streamedText += chunk },
-              })
-            } catch (error) {
-              rememberAlternative(purpose, visibleDraftStreamText(streamedText))
-              throw error
-            }
-          }
-          const repairOutcome = await completeLengthRewrite('chapter-draft-length-repair', repairPrompt)
-          const repairCompletion = completionFromOutcome(repairOutcome)
-          logDraftAttempt(
-            callbacks,
-            context,
-            { zhCN: '章节长度修复', enUS: 'Chapter length repair' },
-            repairOutcome.receipt,
-          )
-          this.assertNotCancelled(context)
-          const repairedDraft = sanitizeDraftText(this.stripThinkingTags(repairCompletion.content))
-          rememberAlternative('chapter-draft-length-repair', repairedDraft)
-          if (repairCompletion.finishReason !== 'stop') {
-            throw new Error(uiText(
-              '章节长度修复未完整结束，结果未保存。',
-              'The chapter length repair did not complete, so the result was not saved.',
-            ))
-          }
-          const repairedUnits = countDraftUnits(repairedDraft)
-          if (repairedUnits > maxDraftChars || repairedUnits < minimumDraftChars) {
-            callbacks.log(uiText(
-              `  首次长度修复结果为 ${repairedUnits} 个正文单位，超出本地长度范围，将执行最后一次完整重写`,
-              `  The first length repair has ${repairedUnits} prose units, outside the local length range; running one final full rewrite`,
-            ))
-            const finalOutcome = await completeLengthRewrite(
-              'chapter-draft-length-final-rewrite',
-              lengthRewritePrompt(repairedUnits, true),
-            )
-            const finalCompletion = completionFromOutcome(finalOutcome)
-            logDraftAttempt(
-              callbacks,
-              context,
-              { zhCN: '最终完整重写', enUS: 'Final full rewrite' },
-              finalOutcome.receipt,
-            )
-            this.assertNotCancelled(context)
-            let finalDraft = sanitizeDraftText(this.stripThinkingTags(finalCompletion.content))
-            rememberAlternative('chapter-draft-length-final-rewrite', finalDraft)
-            if (finalCompletion.finishReason !== 'stop') {
-              throw new Error(uiText(
-                '最终完整重写未完整结束，结果未保存。',
-                'The final full rewrite did not complete, so the result was not saved.',
-              ))
-            }
-            let finalUnits = countDraftUnits(finalDraft)
-            if (finalUnits > maxDraftChars || finalUnits < minimumDraftChars) {
-              callbacks.log(uiText(
-                `  最终完整重写结果为 ${finalUnits} 个正文单位，超出本地长度范围，将执行唯一一次重写重试`,
-                `  The final full rewrite has ${finalUnits} prose units, outside the local length range; running the single rewrite retry`,
-              ))
-              const retryOutcome = await completeLengthRewrite(
-                'chapter-draft-length-final-rewrite-retry',
-                lengthRewritePrompt(finalUnits, true),
-              )
-              const retryCompletion = completionFromOutcome(retryOutcome)
-              logDraftAttempt(
-                callbacks,
-                context,
-                { zhCN: '最终完整重写重试', enUS: 'Final full rewrite retry' },
-                retryOutcome.receipt,
-              )
-              this.assertNotCancelled(context)
-              if (retryCompletion.finishReason !== 'stop') {
-                throw new Error(uiText(
-                  '最终完整重写重试未完整结束，结果未保存。',
-                  'The final full rewrite retry did not complete, so the result was not saved.',
-                ))
-              }
-              finalDraft = sanitizeDraftText(this.stripThinkingTags(retryCompletion.content))
-              rememberAlternative('chapter-draft-length-final-rewrite-retry', finalDraft)
-              finalUnits = countDraftUnits(finalDraft)
-              if (finalUnits > maxDraftChars) {
-                throw new Error(uiText(
-                  `最终完整重写后仍超过 ${maxDraftChars} 个正文单位，结果未保存。`,
-                  `The final full rewrite still exceeds ${maxDraftChars} prose units, so the result was not saved.`,
-                ))
-              }
-            }
-            if (finalUnits < minimumDraftChars) {
-              throw new Error(uiText(
-                '最终完整重写删减过多，结果未保存。',
-                'The final full rewrite removed too much prose, so the result was not saved.',
-              ))
-            }
-            callbacks.replaceText?.(finalDraft)
-            return finalDraft
-          }
-          callbacks.replaceText?.(repairedDraft)
-          return repairedDraft
+          return completedDraft
         })
       } catch (error) {
         if (context.cancelled) throw new Error(uiText('工作流已取消', 'Workflow was cancelled.'))
@@ -927,7 +698,6 @@ ${originalSourceDraft}`,
         const failureReason = error instanceof Error ? error.message : String(error)
         const candidates = [
           { stepId: workflowStepId, visibleText: recoverableDraftCandidate },
-          ...recoveryAlternatives,
         ]
         let replacesCandidateId: string | undefined
         try {
@@ -989,8 +759,7 @@ ${originalSourceDraft}`,
     if (finishReason === 'stop') {
       return currentChars < Math.floor(targetChars * MIN_TARGET_COMPLETION_RATIO)
     }
-    if (finishReason !== 'length') return false
-    return currentChars < maxDraftCharsForTarget(targetChars)
+    return finishReason === 'length'
   }
 
   private async extendDraftIfNeeded(params: {
@@ -1220,17 +989,6 @@ ${visibleTail}`,
     }
 
     this.assertNotCancelled(params.context)
-    // A length finish is always an incomplete physical response. Reaching a
-    // word-count threshold is not proof that the model completed its sentence
-    // or scene, so never persist it as a successful chapter.
-    if (
-      lastFinishReason === 'length'
-      && countDraftUnits(draft) > maxDraftCharsForTarget(params.targetChars)
-    ) {
-      // This is still an incomplete candidate; the caller must run the bounded
-      // full-chapter length replacement before it can be persisted.
-      return draft
-    }
     if (lastFinishReason !== 'stop') {
       const error = this.createIncompleteCompletionError(lastFinishReason)
       error.message = uiText(error.message, (() => {

--- a/src/services/workflows/commands/generate-draft.command.ts
+++ b/src/services/workflows/commands/generate-draft.command.ts
@@ -696,33 +696,25 @@ export class GenerateDraftCommand extends BaseWorkflowCommand {
         callbacks.replaceText?.(recoverableDraftCandidate)
         const failureCode = recoveryFailureCode(error, context.cancelled)
         const failureReason = error instanceof Error ? error.message : String(error)
-        const candidates = [
-          { stepId: workflowStepId, visibleText: recoverableDraftCandidate },
-        ]
-        let replacesCandidateId: string | undefined
         try {
-          for (const candidate of candidates) {
-            const result = await ipc.invokeWithProjectSession(
-              projectSession,
-              'db:recovery-candidate-record',
-              {
-                runId: context.runId,
-                stepId: candidate.stepId,
-                chapterNumber: this.chapterInfo.chapterNumber,
-                chapterTitle: this.chapterInfo.title,
-                source: recoveryChapterSource(this.chapterInfo),
-                sourceDraft: sourceDraft ? { id: sourceDraft.id, version: sourceDraft.version } : null,
-                visibleText: candidate.visibleText,
-                failureCode,
-                failureReason,
-                ...(replacesCandidateId ? { replacesCandidateId } : {}),
-              },
-              expectedProjectPath,
-            )
-            if (!result.success || !result.candidate) {
-              throw new Error(result.error || uiText('未知存储错误', 'Unknown storage error.'))
-            }
-            replacesCandidateId = result.candidate.candidateId
+          const result = await ipc.invokeWithProjectSession(
+            projectSession,
+            'db:recovery-candidate-record',
+            {
+              runId: context.runId,
+              stepId: workflowStepId,
+              chapterNumber: this.chapterInfo.chapterNumber,
+              chapterTitle: this.chapterInfo.title,
+              source: recoveryChapterSource(this.chapterInfo),
+              sourceDraft: sourceDraft ? { id: sourceDraft.id, version: sourceDraft.version } : null,
+              visibleText: recoverableDraftCandidate,
+              failureCode,
+              failureReason,
+            },
+            expectedProjectPath,
+          )
+          if (!result.success || !result.candidate) {
+            throw new Error(result.error || uiText('未知存储错误', 'Unknown storage error.'))
           }
           callbacks.log(uiText(
             '生成未能安全完成；已收到的可见正文已保存为项目恢复候选，未进入草稿库。',

--- a/src/shared/plot-tree.ts
+++ b/src/shared/plot-tree.ts
@@ -148,6 +148,15 @@ function plotTreeSourceChapterBounds(
       && validChapterRange(thread.targetStartChapter, thread.targetEndChapter)
       && [thread.title, thread.type, thread.authorIntent].every(nonEmptyString)) {
       ranges.push([thread.targetStartChapter, thread.targetEndChapter])
+      for (const event of Array.isArray(thread.events) ? thread.events : []) {
+        if (Number.isSafeInteger(event?.id)
+          && event.id >= 1
+          && validChapterNumber(event.chapterNumber)
+          && ['planted', 'progressing', 'resolved', 'abandoned'].includes(event.type)
+          && [event.evidence, event.reason].every(nonEmptyString)) {
+          ranges.push([event.chapterNumber, event.chapterNumber])
+        }
+      }
     }
   }
   if (ranges.length === 0) return null


### PR DESCRIPTION
## 中文

本 PR 从已合并 PR #193 的实际头部继续，修复中文三章真实验收中发现的运行问题：

- 完整草稿接近或超过章节目标时直接接受，不再使用固定 1,120 字门槛或超长压缩链。
- 将草稿续写限制在共享预算内，避免长度恢复导致调用次数失控。
- 后处理持久化失败时复用已验证的模型结果，避免重复调用模型。
- 人物状态只按真实已定稿章节推进，并可修复未来章节污染。
- 剧情树最多调用模型一次；无效结构改用严格、可追溯的事实来源兜底。
- 每章剧情来源选取最高定稿版本，并保留提前或延期确认的叙事事件。
- DSH 完全不在变更范围内。

### 验证

- Astra/medium Standards review: PASS
- Astra/medium Spec review: PASS
- pnpm test: 288 files, 2554 passed, 9 skipped
- TypeScript typecheck: PASS
- ESLint for all 14 changed files: PASS
- NarrativeThreadEditor browser tests: 28/28 PASS
- DeepSeek V4 Flash 中文三章验收：三章均定稿
- 剧情树真实复验：一次模型调用，UI 成功显示 1 条主线与 8 个事件，快照成功持久化

相关 Issue：#185、#187、#191（本 PR 不自动关闭；按各自未覆盖场景另行判定）。

## English

This PR continues from the actual head of merged PR #193 and fixes runtime issues found during a real three-chapter Chinese acceptance run:

- Accept complete drafts near or above the chapter target without a fixed 1,120-unit gate or an overlength rewrite chain.
- Bound draft continuation within one shared generation budget.
- Reuse validated post-processing model output when persistence retries, preventing duplicate model calls.
- Advance character state only from actually finalized chapters and self-heal polluted future markers.
- Limit plot-tree generation to one model call and fall back to strictly validated source facts.
- Select the authoritative finalized version per chapter and preserve confirmed narrative events that happen early or late.
- DSH is entirely excluded.

### Verification

- Astra/medium Standards review: PASS
- Astra/medium Spec review: PASS
- pnpm test: 288 files, 2554 passed, 9 skipped
- TypeScript typecheck: PASS
- ESLint across all 14 changed files: PASS
- NarrativeThreadEditor browser tests: 28/28 PASS
- Real Chinese DeepSeek V4 Flash acceptance: all three chapters finalized
- Real plot-tree rerun: one model call, one rendered track with eight events, snapshot persisted

Related issues: #185, #187, #191. This PR does not auto-close them; remaining scenarios are assessed separately.