### PR TITLE
fix: harden updater exports and workflow notifications

### DIFF
--- a/electron/services/__tests__/update-service.test.ts
+++ b/electron/services/__tests__/update-service.test.ts
@@ -333,7 +333,7 @@ describe('UpdateService', () => {
   })
 
   it('recovers a remembered release without pretending the prior-process installer is ready', async () => {
-    const updater = new FakeUpdater({ updateInfo: { version: '0.2.6' } })
+    const updater = new FakeUpdater({ updateInfo: { version: '0.2.7' } })
     const preferences = createPreferencesStore({
       lastAutomaticCheckDate: '2026-07-25',
       availableUpdate: { version: '0.2.6', releaseName: 'v0.2.6' },
@@ -358,10 +358,114 @@ describe('UpdateService', () => {
     await service.checkAutomatically()
     expect(updater.checkCalls).toBe(0)
 
-    await service.checkManually()
-    expect(updater.checkCalls).toBe(1)
     await service.downloadUpdate()
-    expect(service.getState()).toMatchObject({ status: 'downloaded' })
+    expect(updater.checkCalls).toBe(1)
+    expect(updater.downloadCalls).toBe(1)
+    expect(service.getState()).toMatchObject({ status: 'downloaded', availableVersion: '0.2.7' })
+  })
+
+  it.each(['withdrawn', 'check-failed', 'lower-version'] as const)(
+    'does not download a remembered release when its recheck is %s',
+    async (failure) => {
+      const updater = new FakeUpdater(failure === 'lower-version'
+        ? { updateInfo: { version: '0.2.6' } }
+        : null)
+      if (failure === 'check-failed') updater.checkError = new Error('offline')
+      const service = new UpdateService({
+        updater,
+        currentVersion: '0.2.5',
+        isPackaged: true,
+        preferences: createPreferencesStore({
+          availableUpdate: { version: failure === 'lower-version' ? '0.2.7' : '0.2.6' },
+        }),
+      })
+
+      await expect(service.downloadUpdate()).resolves.toMatchObject({ success: false })
+      expect(updater.checkCalls).toBe(1)
+      expect(updater.downloadCalls).toBe(0)
+    },
+  )
+
+  it('does not duplicate the recheck or download after a remembered-release double click', async () => {
+    const recheck = deferred<UpdateCheckResult | null>()
+    const checkForUpdates = vi.fn(() => recheck.promise)
+    const downloadUpdate = vi.fn(async () => [])
+    const service = new UpdateService({
+      updater: { checkForUpdates, downloadUpdate, quitAndInstall: () => undefined },
+      currentVersion: '0.2.5',
+      isPackaged: true,
+      preferences: createPreferencesStore({ availableUpdate: { version: '0.2.6' } }),
+    })
+
+    const first = service.downloadUpdate()
+    const second = service.downloadUpdate()
+    await vi.waitFor(() => expect(checkForUpdates).toHaveBeenCalledOnce())
+    await expect(second).resolves.toMatchObject({ success: false })
+    recheck.resolve({ updateInfo: { version: '0.2.6' } })
+    await expect(first).resolves.toMatchObject({ success: true })
+    expect(checkForUpdates).toHaveBeenCalledOnce()
+    expect(downloadUpdate).toHaveBeenCalledOnce()
+  })
+
+  it('skips a queued manual check after a remembered-release recheck starts downloading', async () => {
+    const recheck = deferred<UpdateCheckResult | null>()
+    const download = deferred<string[]>()
+    const checkForUpdates = vi.fn()
+      .mockImplementationOnce(() => recheck.promise)
+      .mockResolvedValue({ updateInfo: { version: '0.2.7' } })
+    const downloadUpdate = vi.fn(() => download.promise)
+    const service = new UpdateService({
+      updater: { checkForUpdates, downloadUpdate, quitAndInstall: () => undefined },
+      currentVersion: '0.2.5',
+      isPackaged: true,
+      preferences: createPreferencesStore({ availableUpdate: { version: '0.2.6' } }),
+    })
+
+    const downloading = service.downloadUpdate()
+    await vi.waitFor(() => expect(checkForUpdates).toHaveBeenCalledOnce())
+    const manualCheck = service.checkManually()
+    recheck.resolve({ updateInfo: { version: '0.2.6' } })
+    await vi.waitFor(() => expect(downloadUpdate).toHaveBeenCalledOnce())
+
+    await expect(manualCheck).resolves.toMatchObject({
+      success: true,
+      checked: false,
+      updateAvailable: true,
+      state: { status: 'downloading', availableVersion: '0.2.6' },
+    })
+    expect(checkForUpdates).toHaveBeenCalledOnce()
+    download.resolve([])
+    await expect(downloading).resolves.toMatchObject({
+      success: true,
+      state: { status: 'downloaded', availableVersion: '0.2.6' },
+    })
+  })
+
+  it('skips a manual check while an already-confirmed update is downloading', async () => {
+    const updater = new FakeUpdater({ updateInfo: { version: '0.2.6' } })
+    const download = deferred<string[]>()
+    updater.downloadUpdate = vi.fn(() => download.promise)
+    const service = new UpdateService({
+      updater,
+      currentVersion: '0.2.5',
+      isPackaged: true,
+      preferences: createPreferencesStore(),
+    })
+    await service.checkManually()
+
+    const downloading = service.downloadUpdate()
+    await vi.waitFor(() => expect(updater.downloadUpdate).toHaveBeenCalledOnce())
+    await expect(service.checkManually()).resolves.toMatchObject({
+      success: true,
+      checked: false,
+      state: { status: 'downloading', availableVersion: '0.2.6' },
+    })
+    expect(updater.checkCalls).toBe(1)
+    download.resolve([])
+    await expect(downloading).resolves.toMatchObject({
+      success: true,
+      state: { status: 'downloaded', availableVersion: '0.2.6' },
+    })
   })
 
   it('keeps a remembered available update visible after an automatic network failure', async () => {

--- a/electron/services/update-service.ts
+++ b/electron/services/update-service.ts
@@ -194,6 +194,7 @@ export class UpdateService {
   private state: UpdateState
   private reminder?: UpdateReminder
   private downloadedVersion?: string
+  private checkedAvailableVersion?: string
   private readonly listeners = new Set<(state: UpdateState) => void>()
   private checkQueue: Promise<void> = Promise.resolve()
 
@@ -311,8 +312,8 @@ export class UpdateService {
 
   private async performCheck(mode: 'automatic' | 'manual', now: Date): Promise<UpdateCheckResponse> {
     // Re-check inside the serialized queue: an earlier queued check may have
-    // completed the download after this operation passed its public guard.
-    if (this.downloadedVersion) {
+    // started or completed the download after this operation passed its public guard.
+    if (this.state.status === 'downloading' || this.downloadedVersion) {
       return this.response({ success: true, checked: false, updateAvailable: true })
     }
     this.setState({
@@ -331,6 +332,7 @@ export class UpdateService {
 
     const update = result?.updateInfo
     if (!update || !isHigherStableVersion(update.version, this.options.currentVersion)) {
+      this.checkedAvailableVersion = undefined
       this.forgetAvailableUpdate()
       this.setState({
         ...this.state,
@@ -347,6 +349,7 @@ export class UpdateService {
       return this.response({ success: true, checked: true })
     }
 
+    this.checkedAvailableVersion = update.version
     this.rememberAvailableUpdate(update)
     this.setState({
       ...this.state,
@@ -366,6 +369,7 @@ export class UpdateService {
   async downloadUpdate(): Promise<UpdateActionResponse> {
     if (
       !this.options.isPackaged
+      || this.options.updateConfiguration === 'missing'
       || this.state.updateAction !== 'download'
       || !this.state.availableVersion
     ) {
@@ -378,6 +382,21 @@ export class UpdateService {
       return this.actionResponse(false, makeUpdateError('DOWNLOAD_NOT_READY', 'download', 'not-ready', true, 'DOWNLOAD_NOT_READY'))
     }
 
+    const displayedVersion = this.state.availableVersion
+    if (this.checkedAvailableVersion !== displayedVersion) {
+      this.setState({ ...this.state, status: 'checking', error: undefined })
+      const checked = await this.enqueueCheck(() => this.performCheck('manual', this.now()))
+      if (!checked.success
+        || !this.checkedAvailableVersion
+        || (this.checkedAvailableVersion !== displayedVersion
+          && !isHigherStableVersion(this.checkedAvailableVersion, displayedVersion))) {
+        return this.actionResponse(false, checked.error
+          ?? makeUpdateError('DOWNLOAD_NOT_READY', 'download', 'not-ready', true, 'DOWNLOAD_NOT_READY'))
+      }
+    }
+    if (this.state.status !== 'available' || !this.state.availableVersion) {
+      return this.actionResponse(false, makeUpdateError('DOWNLOAD_NOT_READY', 'download', 'not-ready', true, 'DOWNLOAD_NOT_READY'))
+    }
     const version = this.state.availableVersion
     this.setState({ ...this.state, status: 'downloading', downloadProgress: undefined, error: undefined })
     try {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -145,9 +145,8 @@ export default function App() {
       const completedRun = activeRuns.find(r => r.id === runId)
         ?? history.find(r => r.id === runId)
       if (!completedRun) return
-      const shortTitle = completedRun.title.replace(/^[^\s]+\s/, '')
       actionToast.workflowComplete(
-        text(`「${shortTitle}」已完成`, `“${shortTitle}” completed`),
+        text(`「${completedRun.title}」已完成`, `“${completedRun.title}” completed`),
         () => useLayoutStore.getState().openRightPanel('ai-output')
       )
     })

--- a/src/__tests__/app-workflow-complete.test.ts
+++ b/src/__tests__/app-workflow-complete.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { runInNewContext } from 'node:vm'
+import ts from 'typescript'
+import { expect, it, vi } from 'vitest'
+
+it('preserves complete workflow titles in Chinese and English completion notifications', () => {
+  const source = ts.createSourceFile('App.tsx', readFileSync(resolve('src/App.tsx'), 'utf8'), ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX)
+  let handler: ts.Expression | undefined
+  function visit(node: ts.Node) {
+    if (ts.isCallExpression(node)
+      && node.expression.getText(source) === 'globalEventBus.on'
+      && node.arguments[0]?.getText(source) === "'WORKFLOW_COMPLETE'") {
+      handler = node.arguments[1]
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(source)
+  expect(handler).toBeDefined()
+  const workflowComplete = vi.fn()
+  const completedRun = { id: 'run-1', title: '' }
+  let english = false
+  // Execute the actual App event handler without mounting unrelated application panels.
+  const notify = runInNewContext(`(${handler!.getText(source)})`, {
+    sameProjectSessionContext: () => true,
+    projectSessionContextFromProject: () => ({}),
+    useProjectStore: { getState: () => ({ currentProject: {} }) },
+    useWorkflowStore: { getState: () => ({ activeRuns: [], history: [completedRun] }) },
+    useLocaleStore: { getState: () => ({ text: (zh: string, en: string) => english ? en : zh }) },
+    actionToast: { workflowComplete },
+  })
+
+  for (const title of [
+    '续写章节蓝图（从第 1 章）',
+    'AI 生成小说配置',
+    '写稿 — 第 1 章 · 初遇',
+    'Continue chapter blueprints (from chapter 1)',
+    'Apply review — Chapter 2 A New Term',
+  ]) {
+    completedRun.title = title
+    for (english of [false, true]) {
+      notify({ projectSession: {}, runId: completedRun.id })
+      expect(workflowComplete).toHaveBeenLastCalledWith(
+        english ? `“${title}” completed` : `「${title}」已完成`,
+        expect.any(Function),
+      )
+    }
+  }
+})

--- a/src/services/__tests__/export-service-integration.test.ts
+++ b/src/services/__tests__/export-service-integration.test.ts
@@ -123,7 +123,7 @@ describe('authoritative finalized export integration', () => {
       },
     })
 
-    await expect(exportNovel(
+    const first = await exportNovel(
       { format: 'split-md', grantId: grant.grantId },
       {
         id: projectSession.projectId,
@@ -137,13 +137,33 @@ describe('authoritative finalized export integration', () => {
         },
       },
       projectSession,
-    )).resolves.toEqual({ success: true, path: 'Sparse Novel' })
+    )
+    expect(first).toMatchObject({ success: true })
+    if (!first.path) throw new Error('Expected first export path')
 
-    expect(fs.readFileSync(path.join(exportPath, 'Sparse Novel', 'chapter_1.md'), 'utf8'))
+    expect(fs.readFileSync(path.join(exportPath, first.path, 'chapter_1.md'), 'utf8'))
       .toBe(`# 第1章 ${facts[0].title}\n\n${facts[0].content}`)
-    expect(fs.readFileSync(path.join(exportPath, 'Sparse Novel', 'chapter_4.md'), 'utf8'))
+    expect(fs.readFileSync(path.join(exportPath, first.path, 'chapter_4.md'), 'utf8'))
       .toBe(`# 第4章 ${facts[1].title}\n\n${facts[1].content}`)
-    expect(fs.readdirSync(path.join(exportPath, 'Sparse Novel')).sort())
+    expect(fs.readdirSync(path.join(exportPath, first.path)).sort())
       .toEqual(['chapter_1.md', 'chapter_4.md'])
+
+    db.prepare("UPDATE drafts SET status = 'archived' WHERE chapter_number = 4").run()
+    const second = await exportNovel(
+      { format: 'split-md', grantId: grant.grantId },
+      {
+        id: projectSession.projectId,
+        sessionLease: projectSession.leaseId,
+        path: projectPath,
+        name: 'Sparse Novel',
+        novelConfig: { genre: 'fantasy', targetAudience: 'general', writingLanguage: 'zh-CN' },
+      },
+      projectSession,
+    )
+    expect(second).toMatchObject({ success: true })
+    expect(second.path).not.toBe(first.path)
+    if (!second.path) throw new Error('Expected second export path')
+    expect(fs.readdirSync(path.join(exportPath, second.path)))
+      .toEqual(['chapter_1.md'])
   }, 15_000)
 })

--- a/src/services/__tests__/export-service-project-session.test.ts
+++ b/src/services/__tests__/export-service-project-session.test.ts
@@ -360,6 +360,42 @@ describe('exportNovel project session ownership', () => {
     },
   )
 
+  it('uses a fresh split directory so a later export cannot retain a withdrawn chapter', async () => {
+    let exportIndex = 0
+    vi.mocked(ipc.invokeWithProjectSession).mockImplementation((async (_session: ProjectSessionContext, channel: string) => {
+      if (channel === 'db:draft-export-snapshot') {
+        const snapshots = [
+          [
+            { draftId: 1, chapterNumber: 1, version: 1, title: '', content: 'one', ...authority(1) },
+            { draftId: 2, chapterNumber: 2, version: 1, title: '', content: 'two', ...authority(2) },
+          ],
+          [{ draftId: 1, chapterNumber: 1, version: 1, title: '', content: 'one', ...authority(1) }],
+        ]
+        return snapshots[exportIndex++] as never
+      }
+      if (channel === 'db:draft-export-authority-current') return true as never
+      throw new Error(`Unexpected channel: ${channel}`)
+    }) as never)
+
+    const first = await exportNovel(
+      { format: 'split-md', grantId: 'export-grant' }, projectSnapshot, projectSession,
+    )
+    const second = await exportNovel(
+      { format: 'split-md', grantId: 'export-grant' }, projectSnapshot, projectSession,
+    )
+
+    expect(first).toMatchObject({ success: true })
+    expect(second).toMatchObject({ success: true })
+    expect(second.path).not.toBe(first.path)
+    const writes = vi.mocked(ipc.invoke).mock.calls
+      .filter(([channel]) => channel === 'fs:grant-write-file')
+      .map(call => call[2] as string)
+    expect(writes.filter(file => file.startsWith(`${first.path}/`)).sort())
+      .toEqual([`${first.path}/chapter_1.md`, `${first.path}/chapter_2.md`])
+    expect(writes.filter(file => file.startsWith(`${second.path}/`)))
+      .toEqual([`${second.path}/chapter_1.md`])
+  })
+
   it.each([
     { label: 'missing body', row: { draftId: 7, chapterNumber: 1, version: 2, title: '', content: '', ...authority(7) } },
     { label: 'wrong draft id', row: { draftId: 0, chapterNumber: 1, version: 2, title: '', content: '正文', ...authority(7) } },
@@ -415,12 +451,12 @@ describe('exportNovel project session ownership', () => {
       projectSession,
     )).resolves.toEqual({
       success: false,
-      error: expect.stringMatching(/重新确认导出.*已确认写入: Project A\/chapter_1\.md.*可能已写入: 无/u),
+      error: expect.stringMatching(/重新确认导出.*已确认写入: Project A-[^/]+\/chapter_1\.md.*可能已写入: 无/u),
     })
     expect(vi.mocked(ipc.invoke).mock.calls
       .filter(([channel]) => channel === 'fs:grant-write-file')
       .map(call => call[2]))
-      .toEqual(['Project A/chapter_1.md'])
+      .toEqual([expect.stringMatching(/^Project A-[^/]+\/chapter_1\.md$/u)])
   })
 
   it('reports files already written when a split export fails partway through', async () => {
@@ -440,15 +476,15 @@ describe('exportNovel project session ownership', () => {
       projectSession,
     )).resolves.toEqual({
       success: false,
-      error: expect.stringMatching(/已确认写入: Project A\/chapter_1\.md.*可能已写入: 无.*确定写入失败: Project A\/chapter_2\.md/u),
+      error: expect.stringMatching(/已确认写入: Project A-[^/]+\/chapter_1\.md.*可能已写入: 无.*确定写入失败: Project A-[^/]+\/chapter_2\.md/u),
     })
 
     const writePaths = vi.mocked(ipc.invoke).mock.calls
       .filter(([channel]) => channel === 'fs:grant-write-file')
       .map(call => call[2])
     expect(writePaths).toEqual([
-      'Project A/chapter_1.md',
-      'Project A/chapter_2.md',
+      expect.stringMatching(/^Project A-[^/]+\/chapter_1\.md$/u),
+      expect.stringMatching(/^Project A-[^/]+\/chapter_2\.md$/u),
     ])
   })
 
@@ -473,13 +509,16 @@ describe('exportNovel project session ownership', () => {
       projectSession,
     )).resolves.toEqual({
       success: false,
-      error: expect.stringMatching(/已确认写入: Project A\/chapter_1\.md.*可能已写入: Project A\/chapter_2\.md.*确定写入失败: 无.*不要盲目重试/u),
+      error: expect.stringMatching(/已确认写入: Project A-[^/]+\/chapter_1\.md.*可能已写入: Project A-[^/]+\/chapter_2\.md.*确定写入失败: 无.*不要盲目重试/u),
     })
 
     expect(vi.mocked(ipc.invoke).mock.calls
       .filter(([channel]) => channel === 'fs:grant-write-file')
       .map(call => call[2]))
-      .toEqual(['Project A/chapter_1.md', 'Project A/chapter_2.md'])
+      .toEqual([
+        expect.stringMatching(/^Project A-[^/]+\/chapter_1\.md$/u),
+        expect.stringMatching(/^Project A-[^/]+\/chapter_2\.md$/u),
+      ])
   })
 
   it('reports the committed split file when the project session expires after its write receipt', async () => {

--- a/src/services/export-service.ts
+++ b/src/services/export-service.ts
@@ -22,6 +22,7 @@ import {
   sameProjectSessionContext,
 } from '../shared/project-session-context'
 import type { WritingLanguage } from '../shared/writing-language'
+import { randomUUID } from '../utils/id'
 
 
 export type ExportFormat = 'merged-md' | 'split-md' | 'txt'
@@ -334,7 +335,7 @@ export async function exportNovel(
 
       case 'split-md': {
         // 每章一个 Markdown
-        const splitDir = projectFileStem
+        const splitDir = `${projectFileStem}-${randomUUID()}`
         const authorityCurrent = await ipc.invokeWithProjectSession(
           projectSession,
           'db:draft-export-authority-current',


### PR DESCRIPTION
## 修复内容

- 修复下载进行期间被排队的更新检查覆盖已确认版本、重复调用更新源的问题。
- 拆分 Markdown 导出改为每次创建独立 UUID 目录，避免旧章节残留进入后续导出。
- 工作流完成通知保留完整标题，不再按第一个空格错误截断。

## 验证

- `pnpm exec vitest run electron/services/__tests__/update-service.test.ts src/services/__tests__/export-service-integration.test.ts src/services/__tests__/export-service-project-session.test.ts src/__tests__/app-workflow-complete.test.ts`：4 个文件、69 项通过。
- `pnpm run typecheck`：通过。
- `pnpm run lint`：通过，0 warning。
- `pnpm run check:i18n`：通过。
- 完整套件：289 个测试文件、2562 项通过、9 项按设计跳过。
- Windows x64 解压包构建、原生模块装载和 30 秒应用启动烟测通过。
- 中文三章真实模型流程完成；三次正文草稿调用均无失败或异常重试；拆分导出两次均生成独立目录。

## 尚未包含

- 本轮发现的章节字数上限问题目前只完成独立审计，尚未在本 PR 中修复；不会把该项标记为已完成。
- 正式安装器升级路径、带更新配置的真实更新流程及 macOS 安装验证不属于本 PR 的已通过证据。

保持 Draft，等待审查；不合并、不发布、不打 tag、不关闭 Issue。