### PR TITLE
feat(workflows): recover long-output truncation in plot outlines, blueprint batches, and reviews

### DIFF
--- a/src/components/dialogs/ArchitectureConfirmDialog.tsx
+++ b/src/components/dialogs/ArchitectureConfirmDialog.tsx
@@ -36,8 +36,15 @@ interface Props {
   archStatus: Record<string, boolean>
   /** 预先选中的步骤（单文件生成时传入） */
   initialSelectedSteps?: ArchStepKey[]
-  onConfirm: (selectedSteps: ArchStepKey[], stepGuidance: Record<string, string>) => Promise<void>
+  onConfirm: (
+    selectedSteps: ArchStepKey[],
+    stepGuidance: Record<string, string>,
+    synopsisChapters?: number,
+  ) => Promise<void>
 }
+
+/** 默认视作「全书一口气生成」的章数阈值，超过时提示分批。 */
+const SCOPE_WARNING_THRESHOLD = 20
 
 /** 生成架构确认弹框（含步骤勾选） */
 export default function ArchitectureConfirmDialog({
@@ -64,10 +71,13 @@ export default function ArchitectureConfirmDialog({
   const [stepGuidance, setStepGuidance] = useState<Record<string, string>>({})
   // 是否展开指导输入区
   const [showGuidance, setShowGuidance] = useState(false)
+  // 情节大纲本次详写章节数（前 N 章；空 = 全书）
+  const [synopsisScope, setSynopsisScope] = useState('')
 
   // 每次弹窗打开时重置选中状态
   const resetChecked = () => {
     setChecked(createDefaultArchitectureSelection(archStatus, initialSelectedSteps))
+    setSynopsisScope('')
   }
 
   const [isConfirming, setIsConfirming] = useState(false)
@@ -85,6 +95,15 @@ export default function ArchitectureConfirmDialog({
 
   const selectedSteps = (Object.keys(checked) as ArchStepKey[]).filter(k => checked[k])
   const noneSelected = selectedSteps.length === 0
+
+  // 情节大纲本次详写章节数：空/非法 = 全书；超过全书章数按全书处理。
+  const totalChapters = Number(config.totalChapters) > 0 ? Number(config.totalChapters) : 0
+  const synopsisScopeValue = (() => {
+    if (!checked.synopsis || !synopsisScope.trim() || totalChapters <= 0) return undefined
+    const parsed = Number(synopsisScope)
+    if (!Number.isSafeInteger(parsed) || parsed <= 0) return undefined
+    return Math.min(parsed, totalChapters)
+  })()
 
   const handleConfirm = async () => {
     if (noneSelected) return
@@ -107,7 +126,7 @@ export default function ArchitectureConfirmDialog({
       }
 
       setGuardError(null)
-      await onConfirm(selectedSteps, stepGuidance)
+      await onConfirm(selectedSteps, stepGuidance, synopsisScopeValue)
       onClose()
       const stepNames = selectedSteps.map(k => {
         const item = ARCH_FILES.find(f => f.key === k)
@@ -231,6 +250,57 @@ export default function ArchitectureConfirmDialog({
               )
             })}
           </div>
+
+          {/* 情节大纲 —— 本次生成范围（警示 + 章节数量输入；仅总章数较多时提示分批） */}
+          {checked.synopsis && totalChapters > SCOPE_WARNING_THRESHOLD && (
+            <div
+              className="rounded-lg p-3 space-y-2"
+              style={{ backgroundColor: 'var(--color-panel)', border: '1px solid var(--color-border)' }}
+            >
+              <div className="flex items-center gap-1.5 text-xs font-medium" style={{ color: 'var(--color-warning-text)' }}>
+                <AlertTriangle size={13} />
+                {text('情节大纲 · 本次生成范围', 'Plot outline · batch scope')}
+              </div>
+              <p
+                role="note"
+                className="text-xs leading-relaxed m-0"
+                style={{ color: 'var(--color-text-secondary)' }}
+              >
+                  {text(
+                    `全书共 ${totalChapters} 章。若一口气生成全部章节大纲，等待时间会明显变长，且单次输出过长容易被模型输出上限截断、导致大纲质量下降（AI 一次写不完时还会浪费已用额度）。建议分块：先填一个较小的数量（如 20），生成中断或完成后，可在提示处点击「继续生成情节大纲」补齐剩余章节。`,
+                    `The book spans ${totalChapters} chapters. Generating the full outline in one pass takes much longer, and an oversized single output tends to be cut off by the model output limit and lose quality (when the AI cannot finish in one pass, tokens are wasted). Generate it in blocks: enter a smaller number (e.g. 20); after an interruption or a completed batch, click “Continue plot outline” in the notice to finish the remaining chapters.`,
+                  )}
+                </p>
+                <div className="flex items-center gap-2">
+                <input
+                  type="number"
+                  min={1}
+                  max={totalChapters}
+                  value={synopsisScope}
+                  onChange={e => setSynopsisScope(e.target.value)}
+                  placeholder={String(totalChapters)}
+                  aria-label={text('本次详细生成的章节数（前 N 章）', 'Chapters detailed in this batch (first N)')}
+                  className="w-24 rounded-md px-2 py-1.5 text-xs outline-none transition-colors"
+                  style={{
+                    color: 'var(--color-text)',
+                    backgroundColor: 'var(--color-bg)',
+                    border: '1px solid var(--color-border)',
+                  }}
+                />
+                <span className="text-xs flex-1" style={{ color: 'var(--color-text-muted)' }}>
+                  {synopsisScopeValue && synopsisScopeValue < totalChapters
+                    ? text(
+                      `本次将详细生成前 ${synopsisScopeValue} 章；第 ${synopsisScopeValue + 1}–${totalChapters} 章以占位概览，之后可分批补齐`,
+                      `This batch details the first ${synopsisScopeValue} chapters; chapters ${synopsisScopeValue + 1}–${totalChapters} become a placeholder overview to finish in later batches`,
+                    )
+                    : text(
+                      `本次详写章节数（留空或填 ${totalChapters} = 生成全书 ${totalChapters} 章）`,
+                      `Chapters to detail in this batch (leave empty or enter ${totalChapters} to generate the whole ${totalChapters}-chapter outline)`,
+                    )}
+                </span>
+              </div>
+            </div>
+          )}
 
           {/* 逐步指导区域（可折叠） */}
           {selectedSteps.length > 0 && (

--- a/src/components/editor/ArchFileViewer.tsx
+++ b/src/components/editor/ArchFileViewer.tsx
@@ -347,7 +347,11 @@ function ArchFileViewerSession({
   }, [handleReload, loadCharacterRosterStatus, projectKey])
 
   /** 确认后启动架构生成工作流 */
-  const handleConfirm = async (selectedSteps: ArchStepKey[], stepGuidance: Record<string, string>) => {
+  const handleConfirm = async (
+    selectedSteps: ArchStepKey[],
+    stepGuidance: Record<string, string>,
+    synopsisChapters?: number,
+  ) => {
     const projectSession = captureProjectSession(useProjectStore.getState().currentProject)
     if (!projectSession || !isProjectSessionPath(projectSession, projectKey)) {
       throw new Error('项目会话已切换，未启动架构生成')
@@ -357,6 +361,7 @@ function ArchFileViewerSession({
       workflow: 'generate_architecture',
       selectedSteps,
       stepGuidance,
+      synopsisChapters,
     }, projectSession)
   }
 

--- a/src/components/editor/WorldBuildingEditor.tsx
+++ b/src/components/editor/WorldBuildingEditor.tsx
@@ -56,6 +56,8 @@ export default function WorldBuildingEditor({ projectKey }: { projectKey: string
   const projectMatches = currentProject?.path === projectKey
   const [archStatus, setArchStatus] = useState<Record<string, boolean>>({})
   const [wordCounts, setWordCounts] = useState<Record<string, number>>({})
+  const [synopsisIncomplete, setSynopsisIncomplete] = useState(false)
+  const [resumingSynopsis, setResumingSynopsis] = useState(false)
   const [loading, setLoading] = useState(true)
   const [showArchDialog, setShowArchDialog] = useState(false)
   const lastCompletedArchitectureRunRef = useRef<string | null>(null)
@@ -76,6 +78,7 @@ export default function WorldBuildingEditor({ projectKey }: { projectKey: string
       archStatusRequestGate.current.begin()
       setArchStatus({})
       setWordCounts({})
+      setSynopsisIncomplete(false)
       setLoading(false)
       return
     }
@@ -87,6 +90,21 @@ export default function WorldBuildingEditor({ projectKey }: { projectKey: string
       'db:project-core-get',
       projectPath,
     )
+    // 情节大纲可能处于「输出长度中断、已完成部分已保存」状态 → 提供断点续写
+    let interrupted = false
+    try {
+      const partialResult = await ipc.invokeWithProjectSession(
+        projectSession,
+        'fs:read-json',
+        `${projectPath}/.vela/partial_arch.json`,
+        projectPath,
+      )
+      interrupted = partialResult?.success === true
+        && (partialResult as { data?: { synopsis_incomplete?: boolean; synopsis_result?: string } }).data?.synopsis_incomplete === true
+        && ((partialResult as { data?: { synopsis_result?: string } }).data?.synopsis_result?.length ?? 0) > 50
+    } catch {
+      interrupted = false
+    }
     const status: Record<string, boolean> = {
       premise: (core?.premise?.length ?? 0) > 50,
       characters: rosterSnapshot?.status === 'ready',
@@ -105,6 +123,7 @@ export default function WorldBuildingEditor({ projectKey }: { projectKey: string
     ) return
     setArchStatus(status)
     setWordCounts(counts)
+    setSynopsisIncomplete(interrupted && Boolean(status.synopsis))
     setLoading(false)
     // ✅ 只依赖 path 字符串，避免 novelConfig 等变化导致 loadStatus 重建
   }, [currentProject, projectKey, projectMatches, rosterSnapshot])
@@ -200,7 +219,11 @@ export default function WorldBuildingEditor({ projectKey }: { projectKey: string
   }
 
   /** 确认后启动架构工作流 */
-  const handleConfirm = async (selectedSteps: ArchStepKey[], stepGuidance: Record<string, string>) => {
+  const handleConfirm = async (
+    selectedSteps: ArchStepKey[],
+    stepGuidance: Record<string, string>,
+    synopsisChapters?: number,
+  ) => {
     const projectSession = captureProjectSession(currentProject)
     if (!projectMatches || !projectSession || !isProjectSessionPath(projectSession, projectKey)) throw new Error(text('项目会话已切换，未启动架构生成', 'The project session changed, so architecture generation was not started.'))
     if (!isProjectSessionCurrent(projectSession)) throw new Error(text('项目会话已切换，未启动架构生成', 'The project session changed, so architecture generation was not started.'))
@@ -208,7 +231,29 @@ export default function WorldBuildingEditor({ projectKey }: { projectKey: string
       workflow: 'generate_architecture',
       selectedSteps,
       stepGuidance,
+      synopsisChapters,
     }, projectSession)
+  }
+
+  /** 从上次输出长度中断的检查点继续生成情节大纲 */
+  const handleResumeSynopsis = async () => {
+    const projectSession = captureProjectSession(currentProject)
+    if (!projectMatches || !projectSession || !isProjectSessionPath(projectSession, projectKey)) return
+    if (!isProjectSessionCurrent(projectSession) || resumingSynopsis) return
+    setResumingSynopsis(true)
+    try {
+      await launchCreativeWorkflow({
+        workflow: 'generate_architecture',
+        selectedSteps: ['synopsis'],
+        resumeSynopsis: true,
+      }, projectSession)
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error)
+      const { toast } = await import('../ui/Toast')
+      toast.error(text(`续写启动失败：${detail}`, `Failed to start the continuation: ${detail}`))
+    } finally {
+      setResumingSynopsis(false)
+    }
   }
 
   if (!projectMatches) {
@@ -372,12 +417,41 @@ export default function WorldBuildingEditor({ projectKey }: { projectKey: string
                     </>
                   ) : generated ? (
                     <>
-                      <span className="text-[0.7rem] px-1.5 py-0.5 rounded font-medium bg-green-500/10 text-[var(--color-success-text)]">
-                        {text('已生成', 'Generated')}
-                      </span>
+                      {f.key === 'synopsis' && synopsisIncomplete ? (
+                        <span className="text-[0.7rem] px-1.5 py-0.5 rounded font-medium bg-yellow-500/15 text-[var(--color-warning-text)]">
+                          {text('不完整 · 已存部分', 'Incomplete · partial saved')}
+                        </span>
+                      ) : (
+                        <span className="text-[0.7rem] px-1.5 py-0.5 rounded font-medium bg-green-500/10 text-[var(--color-success-text)]">
+                          {text('已生成', 'Generated')}
+                        </span>
+                      )}
                       <span className="text-xs" style={{ color: 'var(--color-text-muted)' }}>
                         {words.toLocaleString()} {text('字符', 'characters')}
                       </span>
+                      {f.key === 'synopsis' && synopsisIncomplete && !loading && (
+                        <Button
+                          size="sm"
+                          disabled={resumingSynopsis}
+                          className="gap-1.5 mt-0.5 bg-gradient-to-r from-amber-500 to-orange-500 text-white shadow-sm hover:from-amber-600 hover:to-orange-600 border-none hover:shadow hover:-translate-y-[0.5px] transition-all"
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            void handleResumeSynopsis()
+                          }}
+                          title={text(
+                            '上次生成被输出长度中断，已完成部分已保存。点击后 AI 从断点继续生成剩余情节大纲。',
+                            'The previous run stopped at the output length limit and the completed part was saved. Click to continue the outline from the break point.',
+                          )}
+                        >
+                          {resumingSynopsis
+                            ? <RefreshCw size={12} className="animate-spin opacity-90" />
+                            : <RefreshCw size={12} className="opacity-90" />
+                          }
+                          {resumingSynopsis
+                            ? text('续写中...', 'Resuming...')
+                            : text('断点续写大纲', 'Continue outline')}
+                        </Button>
+                      )}
                     </>
                   ) : (
                     <span

--- a/src/components/panels/AIOutputPanel.tsx
+++ b/src/components/panels/AIOutputPanel.tsx
@@ -22,6 +22,9 @@ import { presentWorkflowFailure } from './ai-output-failure-presentation'
 import { useLocaleStore } from '../../stores/locale-store'
 import type { Locale } from '../../i18n/types'
 import { ipc } from '../../services/ipc-client'
+import { launchCreativeWorkflow } from '../../services/workflows/creative-workflow-launcher'
+import { PLOT_OUTLINE_RESUME_ERROR_CODE } from '../../services/workflows/commands/architecture.command'
+import { toast } from '../ui/Toast'
 
 function runText(locale: Locale, zhCNText: string, enUSText: string): string {
   return locale === 'en-US' ? enUSText : zhCNText
@@ -321,6 +324,33 @@ function ActiveRunView({
   const cancelWorkflow = useWorkflowStore.getState().cancelWorkflow
   const prevLenRef = useRef(0)
 
+  // 情节大纲断点续写：错误码匹配且有可用的项目会话
+  const failedStep = run.steps.find(s => s.status === 'failed')
+  const resumeSynopsisAvailable = run.errorCode === PLOT_OUTLINE_RESUME_ERROR_CODE
+    || failedStep?.errorCode === PLOT_OUTLINE_RESUME_ERROR_CODE
+  const [resumingSynopsis, setResumingSynopsis] = useState(false)
+  const resumePlotOutline = async () => {
+    if (resumingSynopsis || !resumeSynopsisAvailable || !run.projectSession) return
+    const project = useProjectStore.getState().currentProject
+    if (
+      !project
+      || !sameProjectSessionContext(run.projectSession, projectSessionContextFromProject(project))
+    ) return
+    setResumingSynopsis(true)
+    try {
+      await launchCreativeWorkflow({
+        workflow: 'generate_architecture',
+        selectedSteps: ['synopsis'],
+        resumeSynopsis: true,
+      }, run.projectSession)
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error)
+      toast.error(runText(locale, `续写启动失败：${detail}`, `Failed to start the continuation: ${detail}`))
+    } finally {
+      setResumingSynopsis(false)
+    }
+  }
+
   // 提取当前步骤 + 内容
   const currentStep = run.steps[run.currentStepIndex] || run.steps[0]
   const rawText = currentStep?.result || ''
@@ -433,6 +463,9 @@ function ActiveRunView({
                 && !(currentStep?.result || '').trim()
               }
               locale={locale}
+              resumeSynopsisAvailable={resumeSynopsisAvailable}
+              resumingSynopsis={resumingSynopsis}
+              onResumeSynopsis={() => { void resumePlotOutline() }}
             />
           )}
 
@@ -620,6 +653,9 @@ function WorkflowFailureNotice({
   projectSession,
   isUnpersistedChapterDraft,
   locale,
+  resumeSynopsisAvailable = false,
+  resumingSynopsis = false,
+  onResumeSynopsis,
 }: {
   failureCode?: WorkflowFailureCode
   error?: string
@@ -628,6 +664,10 @@ function WorkflowFailureNotice({
   projectSession: ProjectSessionContext | null
   isUnpersistedChapterDraft: boolean
   locale: 'zh-CN' | 'en-US'
+  /** 情节大纲生成被截断且已完成部分已保存 → 可断点续写。 */
+  resumeSynopsisAvailable?: boolean
+  resumingSynopsis?: boolean
+  onResumeSynopsis?: () => void
 }) {
   const currentProject = useProjectStore(s => s.currentProject)
   const presentation = presentWorkflowFailure(
@@ -698,6 +738,48 @@ function WorkflowFailureNotice({
               ? '此结果属于另一项目会话。请切回该项目后再打开小说配置。'
               : 'This result belongs to another project session. Switch back to that project before opening Novel configuration.'}
           </p>
+        )}
+
+        {/* 断点续写：已完成部分已自动保存，点击后 AI 接着往下写 */}
+        {resumeSynopsisAvailable && (
+          <div className="mt-2">
+            <button
+              type="button"
+              onClick={onResumeSynopsis}
+              disabled={!matchesCurrentProject || resumingSynopsis}
+              className="inline-flex items-center gap-1.5 rounded-full px-3.5 py-1.5 text-xs font-medium shadow-sm transition-colors"
+              style={{
+                color: '#fff',
+                backgroundColor: 'var(--color-accent)',
+                border: '1px solid var(--color-accent)',
+                opacity: matchesCurrentProject ? 1 : 0.5,
+                cursor: matchesCurrentProject ? 'pointer' : 'not-allowed',
+              }}
+            >
+              {resumingSynopsis
+                ? <Loader2 size={12} className="animate-spin" aria-hidden="true" />
+                : <Sparkles size={12} aria-hidden="true" />}
+              {resumingSynopsis
+                ? runText(locale, '正在从断点续写...', 'Resuming from the break point...')
+                : runText(locale, '继续生成情节大纲（断点续写）', 'Continue plot outline (resume)')}
+            </button>
+            <p className="m-0 mt-1.5" style={{ color: 'var(--color-text-muted)' }}>
+              {runText(
+                locale,
+                '已完成的部分已保存为不完整大纲，不会被覆盖；本次将让 AI 接着上次的末尾继续写。',
+                'The completed part is already saved as an incomplete outline and will not be lost; the AI will continue from where it stopped.',
+              )}
+            </p>
+            {!matchesCurrentProject && (
+              <p className="m-0 mt-1" style={{ color: 'var(--color-text-muted)' }}>
+                {runText(
+                  locale,
+                  '此结果属于另一项目会话。请切回该项目后再续写。',
+                  'This result belongs to another project session. Switch back to that project before continuing.',
+                )}
+              </p>
+            )}
+          </div>
         )}
       </div>
     </div>

--- a/src/services/workflows/architecture-workflow.ts
+++ b/src/services/workflows/architecture-workflow.ts
@@ -26,6 +26,8 @@ export interface PartialArchData {
   character_state_result?: string
   world_building_result?: string
   synopsis_result?: string
+  /** 情节大纲在上一次生成中被输出长度中断；synopsis_result 为已完成部分。 */
+  synopsis_incomplete?: boolean
 }
 
 export interface ArchitectureWorkflowParams {
@@ -36,6 +38,10 @@ export interface ArchitectureWorkflowParams {
   selectedSteps?: Array<'premise' | 'characters' | 'worldbuilding' | 'synopsis'>
   /** 每步的补充指导（如 { premise: "多强调金手指的限制" }） */
   stepGuidance?: Record<string, string>
+  /** 情节大纲本次只详写前 N 章（0/空 = 全书）；仅对全新生成的 synopsis 步骤生效。 */
+  synopsisChapters?: number | null
+  /** 从上次输出长度中断的检查点续写情节大纲（工作流只包含 synopsis 一步）。 */
+  resumeSynopsis?: boolean
 }
 
 export interface ConfigGenerationWorkflowParams {
@@ -57,7 +63,10 @@ export function createArchitectureWorkflow(
   uiLocale: Locale = useLocaleStore.getState().locale,
 ): WorkflowDefinition {
   const text = (zhCNText: string, enUSText: string) => localize(uiLocale, zhCNText, enUSText)
-  const sel = params.selectedSteps ?? ['premise', 'characters', 'worldbuilding', 'synopsis']
+  const resumingSynopsis = params.resumeSynopsis === true
+  const sel = resumingSynopsis
+    ? ['synopsis' as const]
+    : params.selectedSteps ?? ['premise', 'characters', 'worldbuilding', 'synopsis']
   const expectedProjectPath = params.projectPath
   const project = useProjectStore.getState().currentProject
   const currentProjectSession = projectSessionContextFromProject(project)
@@ -115,11 +124,16 @@ export function createArchitectureWorkflow(
     {
       name: text('情节大纲', 'Plot outline'),
       key: 'synopsis',
-      description: stepDesc('synopsis', '整合所有碎片，按选定结构模式生成情节大纲', 'Integrate all inputs into a plot outline using the selected structure'),
+      description: resumingSynopsis
+        ? text('从上次中断点继续生成情节大纲', 'Resume the plot outline from the interrupted point')
+        : stepDesc('synopsis', '整合所有碎片，按选定结构模式生成情节大纲', 'Integrate all inputs into a plot outline using the selected structure'),
       executor: async (step: unknown, context: WorkflowContext, callbacks: StepCallbacks) => {
         context.data.stepGuidance = guidance
         const { GeneratePlotArchitectureCommand } = await import('./commands/architecture.command')
-        return new GeneratePlotArchitectureCommand(sel, projectSnapshot).execute({ step, context, callbacks })
+        return new GeneratePlotArchitectureCommand(sel, projectSnapshot, undefined, {
+          resumeSynopsis: params.resumeSynopsis,
+          synopsisChapters: params.synopsisChapters ?? null,
+        }).execute({ step, context, callbacks })
       },
     },
   ]
@@ -128,7 +142,9 @@ export function createArchitectureWorkflow(
 
   return {
     type: 'architecture_generation',
-    title: text('生成故事架构', 'Generate story architecture'),
+    title: resumingSynopsis
+      ? text('继续生成情节大纲（断点续写）', 'Continue plot outline (resume)')
+      : text('生成故事架构', 'Generate story architecture'),
     projectPath: expectedProjectPath,
     projectSession,
     uiLocale,

--- a/src/services/workflows/bounded-completion.ts
+++ b/src/services/workflows/bounded-completion.ts
@@ -75,6 +75,16 @@ export interface BoundedCompletionRequest {
   isCancelled?: () => boolean
   redactVisibleText?: (text: string) => string
   mergeVisibleText?: (existing: string, addition: string) => string
+  /**
+   * Called with the latest merged visible content just before a failure that
+   * still leaves recoverable text behind (automatic continuations exhausted,
+   * no-progress stop, or a mechanically-incomplete stop). Callers may persist
+   * the partial result so a later user-initiated continuation can resume from
+   * where the output actually stopped. Not called for cancellations,
+   * content-filter stops, or unknown terminal states where the visible text is
+   * not trustworthy.
+   */
+  onInterrupted?: (content: string) => void
 }
 
 /** Remove hidden reasoning and malformed thinking-tag remnants before any continuation context is composed. */
@@ -468,6 +478,7 @@ export async function completeBoundedCompletion(request: BoundedCompletionReques
     assertNotCancelled(uiLocale, request.isCancelled)
     if (finishReason !== 'length') throw incompleteCompletionError(finishReason, uiLocale)
     if (continuationCount >= request.maxContinuations) {
+      request.onInterrupted?.(content)
       throw continuationLimitExceededError(request.maxContinuations, uiLocale)
     }
 
@@ -494,6 +505,7 @@ export async function completeBoundedCompletion(request: BoundedCompletionReques
     } else {
       const merged = merge(content, nextVisible)
       if (visibleProseUnitCount(merged) <= visibleProseUnitCount(content)) {
+        request.onInterrupted?.(content)
         throw noVisibleContinuationProgressError(uiLocale)
       }
       content = merged
@@ -502,6 +514,16 @@ export async function completeBoundedCompletion(request: BoundedCompletionReques
   }
 
   assertNotCancelled(uiLocale, request.isCancelled)
-  if (request.mode === 'append-visible-text') assertMechanicallyCompleteVisibleText(content, uiLocale)
+  if (request.mode === 'append-visible-text') {
+    try {
+      assertMechanicallyCompleteVisibleText(content, uiLocale)
+    } catch (error) {
+      // The merged text may be a usable partial document even when it cannot
+      // be mechanically confirmed as complete (e.g. a leftover truncation
+      // marker). Hand it back before failing closed.
+      request.onInterrupted?.(content)
+      throw error
+    }
+  }
   return content
 }

--- a/src/services/workflows/commands/__tests__/mutation-failure-boundary.test.ts
+++ b/src/services/workflows/commands/__tests__/mutation-failure-boundary.test.ts
@@ -1276,7 +1276,7 @@ describe('workflow mutation failure boundaries', () => {
       step: {},
       context: { ...context(), uiLocale: 'en-US', writingLanguage: 'en-US' },
       callbacks: callbacks(),
-    })).rejects.toThrow('The AI review response was invalid, so no report was saved.')
+    })).rejects.toThrow('The AI review response was invalid twice')
 
     expect(invoke.mock.calls.map(([channel]) => channel)).not.toContain('db:review-create')
     expect(useEditorStore.getState().tabs).toEqual([])
@@ -1327,6 +1327,61 @@ describe('workflow mutation failure boundaries', () => {
 
     expect(generateStream).toHaveBeenCalledTimes(2)
     expect(generateStream.mock.calls[1]?.[0][1]?.content).toContain('上一轮结构化输出因长度限制而中断')
+    expect(invoke.mock.calls.filter(([channel]) => channel === 'db:review-create')).toHaveLength(1)
+  })
+
+  it('recovers a stop-reported truncated review with one complete replacement before persistence', async () => {
+    // 模型/网关在输出上限截断时把 finishReason 报成 stop（而非 length）：
+    // 坏 JSON 直接进入解析 → 命令应自动补一次完整替代输出并成功保存。
+    const completeReview = JSON.stringify({
+      items: [{ category: '剧情连贯性', severity: 'pass', description: '未发现矛盾' }],
+      summary: '审稿完成',
+    })
+    const invoke = vi.fn(async (channel: string) => {
+      if (channel === 'kb:search') return []
+      if (channel === 'db:character-get-all') return []
+      if (channel === 'db:project-core-get') return {}
+      if (channel === 'db:draft-get-meta') {
+        return { id: 1, chapterNumber: 1, version: 1, status: 'draft', source: 'write' }
+      }
+      if (channel === 'db:review-next-index') return 1
+      if (channel === 'db:review-create') return { success: true, id: 10 }
+      if (channel === 'db:blueprint-get') return null
+      throw new Error(`unexpected IPC: ${channel}`)
+    })
+    stubVelaIpc(invoke)
+    const rebuildPrompts: string[] = []
+    const generateStream = vi.fn(async (
+      messages: Parameters<ReturnType<typeof useLLMStore.getState>['generateStream']>[0],
+      streamCallbacks: Parameters<ReturnType<typeof useLLMStore.getState>['generateStream']>[1],
+    ) => {
+      const firstAttempt = generateStream.mock.calls.length === 1
+      if (!firstAttempt) {
+        rebuildPrompts.push(messages.map(message => message.content).join('\n'))
+      }
+      streamCallbacks.onDone?.(
+        firstAttempt ? '{"summary":"审稿","items":[' : completeReview,
+        undefined,
+        'stop',
+      )
+      return `review-request-${generateStream.mock.calls.length}`
+    })
+    useLLMStore.setState({ defaultModelId: 'model', generateStream })
+    const command = new ReviewChapterCommand({
+      draftPath: 'vela://draft/1',
+      draftContent: '待审正文',
+      chapterNumber: 1,
+    })
+
+    await expect(command.execute({
+      step: {},
+      context: context(),
+      callbacks: callbacks(),
+    })).resolves.toBe(completeReview)
+
+    expect(generateStream).toHaveBeenCalledTimes(2)
+    expect(rebuildPrompts[0]).toContain('上一轮审稿输出未通过合同校验')
+    expect(rebuildPrompts[0]).toContain('完整审稿 JSON')
     expect(invoke.mock.calls.filter(([channel]) => channel === 'db:review-create')).toHaveLength(1)
   })
 

--- a/src/services/workflows/commands/__tests__/plot-outline-batch.command.test.ts
+++ b/src/services/workflows/commands/__tests__/plot-outline-batch.command.test.ts
@@ -1,0 +1,359 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useLLMStore } from '../../../../stores/llm-store'
+import { useProjectStore } from '../../../../stores/project-store'
+import type { StepCallbacks, WorkflowContext } from '../../../../stores/workflow-store'
+import {
+  GeneratePlotArchitectureCommand,
+  PLOT_OUTLINE_RESUME_ERROR_CODE,
+  PlotOutlineResumeAvailableError,
+} from '../architecture.command'
+import { createWorkflowRuntimeDependencies } from './workflow-generation-runtime.fixture'
+import { clearProjectCustomPrompts } from '../../../prompt-templates'
+
+/**
+ * 情节大纲分批/断流保护：自动续写拼接、长度耗尽自动落盘、检查点续写、
+ * 「本次只详写前 N 章」分块指令。
+ */
+
+const projectAPath = 'C:\\novels\\plot-batch'
+const originalGenerateStream = useLLMStore.getState().generateStream
+const originalDefaultModelId = useLLMStore.getState().defaultModelId
+
+const novelConfig = {
+  genre: '玄幻',
+  targetAudience: '男频',
+  subGenre: '东方玄幻',
+  totalChapters: 100,
+  wordsPerChapter: 3000,
+  plotStructure: 'three_act',
+  narrativePOV: 'third_limited',
+  coreOutline: '主角在宗门废墟中找到失落的传承，必须赶在终局灾难前成长。',
+  worldSetting: '灵脉决定城邦兴衰，宗门垄断资源，边境异变正在瓦解旧有秩序。',
+  goldenFinger: '主角能够解析残缺功法，但每次使用都会付出记忆损耗的代价。',
+  protagonistProfile: '外表谨慎克制，内心执着于守护家人。',
+  globalGuidance: '保持因果推进。\n保留已建立的角色状态。\n用行动升级冲突。\n收束已兑现的伏笔。',
+  writingStyle: '节奏紧凑，行动描写强调因果。',
+} as const
+
+const coreSeed = {
+  premise: '这是足够长的故事前提：主角林舟在铁砧镇当学徒，宗门封锁后他必须找到失落传承才能守住家人，大陆深处的终局灾难正在逼近。'.repeat(2),
+  charactersArch: '角色图谱：林舟（主角）、苏绾（引导者）、顾岩（执法者）。三人关系在封锁中不断反转。'.repeat(2),
+  worldbuilding: '世界观：灵脉决定城邦兴衰，宗门垄断资源，边境异变正在瓦解旧有秩序。'.repeat(2),
+}
+
+function project(path: string) {
+  return {
+    id: 'main',
+    name: path,
+    path,
+    sessionLease: 'lease-main',
+    novelConfig,
+  }
+}
+
+const context: WorkflowContext = {
+  runId: 'plot-batch-run',
+  projectPath: projectAPath,
+  projectSession: { projectId: 'main', leaseId: 'lease-main', projectPath: projectAPath },
+  writingLanguage: 'zh-CN',
+  uiLocale: 'zh-CN',
+  data: {},
+  cancelled: false,
+}
+
+const callbacks: StepCallbacks = {
+  log: vi.fn(),
+  setProgress: vi.fn(),
+  appendText: vi.fn(),
+}
+
+/** 依调用顺序返回响应的 generateStream mock。 */
+function responseStream(
+  responses: readonly string[],
+  finishReasons: ReadonlyArray<'stop' | 'length'> = responses.map(() => 'stop'),
+) {
+  let nextResponseIndex = 0
+  return vi.fn((
+    _messages: Parameters<ReturnType<typeof useLLMStore.getState>['generateStream']>[0],
+    streamCallbacks: Parameters<ReturnType<typeof useLLMStore.getState>['generateStream']>[1],
+  ) => {
+    const index = nextResponseIndex++
+    const output = responses[index]
+    if (output === undefined) throw new Error(`unexpected generation attempt ${index + 1}`)
+    streamCallbacks.onDone?.(output, undefined, finishReasons[index] ?? 'stop')
+    return Promise.resolve(`plot-request-${index + 1}`)
+  })
+}
+
+interface IpcHarness {
+  invoke: ReturnType<typeof vi.fn>
+  coreUpdates: Array<Record<string, unknown>>
+  partialWrites: Array<Record<string, unknown>>
+}
+
+function harnessWith(core: Record<string, string> = {}): IpcHarness {
+  const coreUpdates: Array<Record<string, unknown>> = []
+  const partialWrites: Array<Record<string, unknown>> = []
+  const invoke = vi.fn(async (_channel: string, ...rest: unknown[]) => {
+    const channel = String(_channel)
+    if (channel === 'prompt:load-global') return { templates: [], diagnostics: [] }
+    if (channel === 'fs:check-exists') return false
+    if (channel === 'db:project-core-get') return { ...coreSeed, ...core }
+    if (channel === 'db:project-core-update') {
+      const update = rest[0] as Record<string, unknown>
+      coreUpdates.push(update)
+      return { success: true }
+    }
+    if (channel === 'fs:read-json') return { success: true, data: {} }
+    if (channel === 'fs:write-json') {
+      partialWrites.push(rest[1] as Record<string, unknown>)
+      return { success: true }
+    }
+    if (channel === 'fs:write-file') return { success: true }
+    throw new Error(`Unexpected IPC channel: ${channel}`)
+  })
+  vi.stubGlobal('window', {
+    velaAPI: {
+      invoke, on: vi.fn(), once: vi.fn(), send: vi.fn(),
+      setZoomLevel: vi.fn(), setZoomFactor: vi.fn(), getZoomLevel: vi.fn(),
+    },
+  })
+  return { invoke, coreUpdates, partialWrites }
+}
+
+function snapshot() {
+  return { expectedProjectPath: projectAPath, novelConfig } as never
+}
+
+function expectSynopsisBody(persisted: string): string {
+  // DB 内容为 `# 情节大纲\n\n<body>`；此处剥掉标题便于断言正文。
+  const withoutHeading = persisted.replace(/^# 情节大纲\n\n/u, '')
+  return withoutHeading.replace(/\n$/u, '')
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  useProjectStore.setState({
+    currentProject: project(projectAPath) as never,
+  })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+  useLLMStore.setState({
+    defaultModelId: originalDefaultModelId,
+    generateStream: originalGenerateStream,
+  })
+  useProjectStore.setState({ currentProject: null })
+  clearProjectCustomPrompts()
+})
+
+describe('GeneratePlotArchitectureCommand 分批/断流保护', () => {
+  it('首次输出即 stop 时：单次调用并按完整大纲落库', async () => {
+    const body = '## 第一卷\n\n第一章：铁砧镇的学徒。\n\n第二章：宗门封锁。\n\n'
+    useLLMStore.setState({
+      defaultModelId: 'model-1',
+      generateStream: responseStream([body]),
+    })
+    const harness = harnessWith()
+    const command = new GeneratePlotArchitectureCommand(
+      ['synopsis'], snapshot(), createWorkflowRuntimeDependencies(),
+    )
+
+    const result = await command.execute({ step: {}, context, callbacks })
+
+    expect(result).toContain('第二章：宗门封锁')
+    const synopsisUpdate = harness.coreUpdates.find(update => typeof update.synopsis === 'string')
+    expect(synopsisUpdate).toBeDefined()
+    expect(expectSynopsisBody(String(synopsisUpdate!.synopsis))).toContain('第一章：铁砧镇的学徒')
+    expect(String(synopsisUpdate!.synopsis)).not.toContain('未完成')
+    const partialWrite = harness.partialWrites[harness.partialWrites.length - 1]
+    expect(partialWrite).toEqual(expect.objectContaining({
+      synopsis_incomplete: false,
+    }))
+  })
+
+  it('输出 length 时自动续写：第二次响应 stop 后拼接保存且无标题重复', async () => {
+    const first = '## 第一卷\n\n第一章：铁砧镇的学徒。宗门封锁前夜，林舟发现了旧铁锤里的秘密。\n\n第二章：宗门封锁。'
+    const second = '\n\n第三章：废墟里的传承。林舟在宗门废墟中找到了残缺功法。\n\n第四章：边境异变。'
+    useLLMStore.setState({
+      defaultModelId: 'model-1',
+      generateStream: responseStream([first, second], ['length', 'stop']),
+    })
+    const harness = harnessWith()
+    const command = new GeneratePlotArchitectureCommand(
+      ['synopsis'], snapshot(), createWorkflowRuntimeDependencies(),
+    )
+
+    const result = await command.execute({ step: {}, context, callbacks })
+
+    expect(useLLMStore.getState().generateStream).toHaveBeenCalledTimes(2)
+    expect(result).toContain('第一章：铁砧镇的学徒')
+    expect(result).toContain('第四章：边境异变')
+    // 续写提示要求模型只输出新增内容；重叠合并不得产生重复章节行。
+    expect(result.split('第四章：边境异变').length - 1).toBe(1)
+    const synopsisUpdate = harness.coreUpdates.find(update => typeof update.synopsis === 'string')
+    expect(expectSynopsisBody(String(synopsisUpdate!.synopsis))).toContain('第四章：边境异变')
+    const partialWrite = harness.partialWrites[harness.partialWrites.length - 1]
+    expect(partialWrite).toEqual(expect.objectContaining({
+      synopsis_incomplete: false,
+      synopsis_result: expect.stringContaining('第四章：边境异变') as never,
+    }))
+    expect(vi.mocked(callbacks.log)).toHaveBeenCalledWith(expect.stringContaining('自动续写第 1 轮请求已发起'))
+  })
+
+  it('自动续写耗尽时：先自动保存已完成部分，再抛出可续写错误（带 resume 错误码）', async () => {
+    const segments = [
+      '## 第一卷\n\n第一章：铁砧镇的学徒。宗门封锁前夜，林舟发现了旧铁锤里的秘密。',
+      '第二章：宗门封锁。苏绾带来大陆深处的警告，顾岩的执法队包围了铁砧镇。',
+      '第三章：废墟里的传承。林舟在宗门废墟中找到了残缺功法，但代价是记忆损耗。',
+      '第四章：边境异变。妖兽潮冲击边关，宗门封锁线开始崩溃。',
+    ]
+    useLLMStore.setState({
+      defaultModelId: 'model-1',
+      generateStream: responseStream(segments, ['length', 'length', 'length', 'length']),
+    })
+    const harness = harnessWith()
+    const command = new GeneratePlotArchitectureCommand(
+      ['synopsis'], snapshot(), createWorkflowRuntimeDependencies(),
+    )
+
+    const execution = command.execute({ step: {}, context, callbacks })
+    const failure = await execution.catch((error: unknown) => error)
+    expect(failure).toBeInstanceOf(PlotOutlineResumeAvailableError)
+    expect(failure).toMatchObject({ code: PLOT_OUTLINE_RESUME_ERROR_CODE })
+    expect((failure as Error).message).toContain('已自动保存为不完整大纲')
+
+    // 已完成部分必须已经自动落库（DB 带未完成标记；partial 检查点带断点数据）
+    const synopsisUpdate = harness.coreUpdates.find(update => typeof update.synopsis === 'string')
+    expect(synopsisUpdate).toBeDefined()
+    const persisted = String(synopsisUpdate!.synopsis)
+    expect(persisted).toContain('第一章：铁砧镇的学徒')
+    expect(persisted).toContain('第四章：边境异变')
+    expect(persisted).toContain('本大纲未完成')
+    const partialWrite = harness.partialWrites[harness.partialWrites.length - 1]
+    expect(partialWrite).toEqual(expect.objectContaining({
+      synopsis_incomplete: true,
+      synopsis_result: expect.stringContaining('第四章：边境异变') as never,
+    }))
+  })
+
+  it('断点续写：读取中断检查点作为种子，只续写新增内容且覆盖未完成标记', async () => {
+    const seedBody = '## 第一卷\n\n第一章：铁砧镇的学徒。宗门封锁前夜，林舟发现了旧铁锤里的秘密。\n\n第二章：宗门封锁。'
+    const addition = '\n\n第三章：废墟里的传承。林舟在宗门废墟中找到了残缺功法。\n\n第四章：边境异变。'
+    const invoke = vi.fn(async (_channel: string) => {
+      const channel = String(_channel)
+      if (channel === 'prompt:load-global') return { templates: [], diagnostics: [] }
+      if (channel === 'fs:check-exists') return false
+      if (channel === 'db:project-core-get') return { ...coreSeed }
+      if (channel === 'fs:read-json') {
+        // 中断检查点：上次自动保存的已完成部分
+        return { success: true, data: { synopsis_result: seedBody, synopsis_incomplete: true } }
+      }
+      if (channel === 'db:project-core-update') return { success: true }
+      if (channel === 'fs:write-json') return { success: true }
+      if (channel === 'fs:write-file') return { success: true }
+      throw new Error(`Unexpected IPC channel: ${channel}`)
+    })
+    vi.stubGlobal('window', {
+      velaAPI: {
+        invoke, on: vi.fn(), once: vi.fn(), send: vi.fn(),
+        setZoomLevel: vi.fn(), setZoomFactor: vi.fn(), getZoomLevel: vi.fn(),
+      },
+    })
+    let resumedPrompt = ''
+    const generateStream = vi.fn((
+      messages: Parameters<ReturnType<typeof useLLMStore.getState>['generateStream']>[0],
+      streamCallbacks: Parameters<ReturnType<typeof useLLMStore.getState>['generateStream']>[1],
+    ) => {
+      resumedPrompt = messages.map(message => message.content).join('\n')
+      streamCallbacks.onDone?.(addition, undefined, 'stop')
+      return Promise.resolve('plot-resume-request')
+    })
+    useLLMStore.setState({ defaultModelId: 'model-1', generateStream })
+    const command = new GeneratePlotArchitectureCommand(
+      ['synopsis'], snapshot(), createWorkflowRuntimeDependencies(),
+      { resumeSynopsis: true },
+    )
+
+    const result = await command.execute({ step: {}, context, callbacks })
+
+    // 续写模式不重发已有正文的首轮任务，只发「从断点继续」指令并携带种子末尾
+    expect(useLLMStore.getState().generateStream).toHaveBeenCalledTimes(1)
+    expect(resumedPrompt).toContain('上一轮文本因长度限制而中断')
+    expect(resumedPrompt).toContain('从已完成文本的末尾自然续写')
+    expect(resumedPrompt).toContain('第二章：宗门封锁')
+    expect(result).toContain('第一章：铁砧镇的学徒')
+    expect(result).toContain('第四章：边境异变')
+
+    const updates = (invoke.mock.calls as unknown as Array<[string, unknown]>)
+      .filter(([channel]) => channel === 'db:project-core-update')
+      .map(([, update]) => update as Record<string, unknown>)
+    expect(updates.length).toBe(1)
+    const persisted = String(updates[0].synopsis)
+    expect(persisted).toContain('第四章：边境异变')
+    expect(persisted).not.toContain('未完成')
+    // 合并后的正文不得出现两处「第二章：宗门封锁」
+    expect(persisted.split('第二章：宗门封锁').length - 1).toBe(1)
+    const partialWrites = (invoke.mock.calls as unknown as Array<[string, unknown, unknown]>)
+      .filter(([channel]) => channel === 'fs:write-json')
+      .map(([, , data]) => data as Record<string, unknown>)
+    expect(partialWrites[partialWrites.length - 1]).toEqual(expect.objectContaining({
+      synopsis_incomplete: false,
+    }))
+    expect(vi.mocked(callbacks.log)).toHaveBeenCalledWith(expect.stringContaining('从断点续写'))
+  })
+
+  it('填写本次生成章节数时：提示词注入分块指令，只详写前 N 章', async () => {
+    let observedUserPrompt = ''
+    useLLMStore.setState({
+      defaultModelId: 'model-1',
+      generateStream: vi.fn((
+        messages: Parameters<ReturnType<typeof useLLMStore.getState>['generateStream']>[0],
+        streamCallbacks: Parameters<ReturnType<typeof useLLMStore.getState>['generateStream']>[1],
+      ) => {
+        observedUserPrompt = messages.map(message => message.content).join('\n')
+        streamCallbacks.onDone?.('## 第一卷\n\n第一章……', undefined, 'stop')
+        return Promise.resolve('plot-scope-request')
+      }),
+    })
+    harnessWith()
+    const command = new GeneratePlotArchitectureCommand(
+      ['synopsis'], snapshot(), createWorkflowRuntimeDependencies(),
+      { synopsisChapters: 20 },
+    )
+
+    await command.execute({ step: {}, context, callbacks })
+
+    expect(observedUserPrompt).toContain('本次生成范围')
+    expect(observedUserPrompt).toContain('只对第 1–20 章输出完整详细的情节大纲')
+    expect(observedUserPrompt).toContain('第 21 章')
+    expect(vi.mocked(callbacks.log)).toHaveBeenCalledWith(expect.stringContaining('仅详细生成前 20 章'))
+  })
+
+  it('不传章节数时按全书生成（无分块指令）', async () => {
+    let observedUserPrompt = ''
+    useLLMStore.setState({
+      defaultModelId: 'model-1',
+      generateStream: vi.fn((
+        messages: Parameters<ReturnType<typeof useLLMStore.getState>['generateStream']>[0],
+        streamCallbacks: Parameters<ReturnType<typeof useLLMStore.getState>['generateStream']>[1],
+      ) => {
+        observedUserPrompt = messages.map(message => message.content).join('\n')
+        streamCallbacks.onDone?.('## 第一卷\n\n第一章……', undefined, 'stop')
+        return Promise.resolve('plot-full-request')
+      }),
+    })
+    harnessWith()
+    const command = new GeneratePlotArchitectureCommand(
+      ['synopsis'], snapshot(), createWorkflowRuntimeDependencies(),
+    )
+
+    await command.execute({ step: {}, context, callbacks })
+
+    expect(observedUserPrompt).not.toContain('本次生成范围')
+    expect(observedUserPrompt).toContain('100 章')
+  })
+})

--- a/src/services/workflows/commands/architecture.command.ts
+++ b/src/services/workflows/commands/architecture.command.ts
@@ -21,6 +21,7 @@ import {
 } from '../workflow-project-session'
 import { characterArchitecturePrompts, promptLanguageText } from '../../prompt-language'
 import { stripThinkingTags } from '../workflow-utils'
+import type { WorkflowContext } from '../../../stores/workflow-store'
 import type { NovelConfig, ProjectSessionContext } from '../../../shared/ipc-channels'
 import type { WritingLanguage } from '../../../shared/writing-language'
 import {
@@ -47,6 +48,67 @@ interface PartialArchData {
   character_state_result?: string
   world_building_result?: string
   synopsis_result?: string
+  /** 情节大纲在上一次生成中被输出长度中断；synopsis_result 为已完成部分。 */
+  synopsis_incomplete?: boolean
+}
+
+/**
+ * 情节大纲生成被输出长度中断、且已完成部分已自动保存时抛出的错误。
+ * errorCode 供前端识别并展示「继续生成情节大纲」断点续写按钮。
+ */
+export const PLOT_OUTLINE_RESUME_ERROR_CODE = 'architecture-synopsis-resume-available'
+
+export class PlotOutlineResumeAvailableError extends Error {
+  readonly code = PLOT_OUTLINE_RESUME_ERROR_CODE
+
+  constructor(message: string) {
+    super(message)
+    this.name = 'PlotOutlineResumeAvailableError'
+    Object.setPrototypeOf(this, new.target.prototype)
+  }
+}
+
+/** 少于该字符数视为无保存价值的零碎输出，不落盘、不提供续写。 */
+const MIN_SYNOPSIS_PARTIAL_PERSIST_CHARS = 120
+
+/** 落库时追加在未完成大纲末尾的可见标记（帮助用户识别与编辑器提示）。 */
+const SYNOPSIS_INCOMPLETE_MARKER_ZH = [
+  '',
+  '> ⚠️ **本大纲未完成**：生成被输出长度中断，以上为已自动保存的已完成部分。',
+  '> 可在「AI 输出」提示处点击「继续生成情节大纲」，从断点续写补齐剩余章节。',
+  '',
+].join('\n')
+
+const SYNOPSIS_INCOMPLETE_MARKER_EN = [
+  '',
+  '> ⚠ **This outline is incomplete**: generation stopped at the output length limit; the completed part above was saved automatically.',
+  '> Click “Continue plot outline” in the AI output notice to resume from this break point.',
+  '',
+].join('\n')
+
+/**
+ * 「本次只详写前 N 章」的分块指令：结构节点仍标全书区间，但具体展开
+ * 只到第 N 章；第 N+1 章起以一行占位句概览，避免单次输出超长。
+ */
+function synopsisScopeInstruction(
+  writingLanguage: WritingLanguage,
+  totalChapters: number,
+  scope: number,
+): string {
+  const next = scope + 1
+  return promptLanguageText(
+    writingLanguage,
+    `【本次生成范围（重要）】
+全书规划 ${totalChapters} 章。本次只对第 1–${scope} 章输出完整详细的情节大纲：
+1. 结构节点仍需标注全书章节区间，但“具体发生什么”只写到第 ${scope} 章为止。
+2. 第 ${next} 章及以后不展开细写：仅以一行占位句概览整段走向（不超过 300 字）。
+3. 大纲末尾单独一行注明：本批大纲仅细化至第 ${scope} 章，后续章节可继续分块生成。`,
+    `[Generation scope for this batch (important)]
+The book spans ${totalChapters} chapters, but this batch must detail only chapters 1–${scope}:
+1. Structure nodes may still cite full-book chapter ranges, but concrete "what happens" detail stops at chapter ${scope}.
+2. Chapters ${next}–${totalChapters} must not be expanded: collapse them into one short placeholder line (300 characters or fewer).
+3. End with a line noting that this batch details only up to chapter ${scope} and later chapters can be generated in further batches.`,
+  )
 }
 
 const PLOT_STRUCTURES = new Set<NovelConfig['plotStructure']>([
@@ -1209,6 +1271,12 @@ export class GeneratePlotArchitectureCommand extends BaseWorkflowCommand<string>
     private selectedSteps: string[],
     private snapshot: ArchitectureProjectSnapshot,
     generationDependencies?: WorkflowGenerationRuntimeDependencies,
+    private readonly options: {
+      /** 从上次中断点续写情节大纲（需检查点 synopsis_incomplete=true）。 */
+      resumeSynopsis?: boolean
+      /** 本次只详写前 N 章（0/空 = 全书）。 */
+      synopsisChapters?: number | null
+    } = {},
   ) {
     super(generationDependencies)
   }
@@ -1245,7 +1313,17 @@ export class GeneratePlotArchitectureCommand extends BaseWorkflowCommand<string>
       'Worldbuilding has not been generated.',
     ))
 
-    callbacks.log(text('生成情节大纲...', 'Generating plot outline...'))
+    // 进度日志保持先于模板解析/检查点读取，失败时用户也能看到步骤已启动
+    const resumeRequested = this.options.resumeSynopsis === true
+    callbacks.log(text(
+      resumeRequested
+        ? '正在读取情节大纲中断检查点...'
+        : '生成情节大纲...',
+      resumeRequested
+        ? 'Reading the interrupted plot-outline checkpoint...'
+        : 'Generating plot outline...',
+    ))
+
     const template = await resolvePromptTemplate('synopsis', projectSession, writingLanguage)
     if (!template) throw new Error(text(
       '模板丢失',
@@ -1272,19 +1350,115 @@ export class GeneratePlotArchitectureCommand extends BaseWorkflowCommand<string>
       .withGlobalGuidance(config.globalGuidance || promptLanguageText(writingLanguage, '（未填写）', '(not provided)'))
       .withStepGuidance(((context.data.stepGuidance as Record<string, string>) || {}).synopsis || '')
 
-    const result = await this.callLLMWithBuilder(
-      promptBuilder,
-      callbacks,
-      { purpose: 'generate-plot-architecture', reasoningStage: 'planning', writingSkillStage: 'planning' },
-      context,
-    )
-    if (context.cancelled) throw new Error(text('工作流已取消', 'Workflow was cancelled.'))
+    // ===== 断点续写：仅续写请求需要在生成前确认种子（普通生成保持原时序，
+    // 成功/中断落盘时才读取合并检查点文件，避免额外的启动 IPC） =====
+    const seedPartial = resumeRequested
+      ? (context.data.partial as PartialArchData) || await loadPartialData(expectedProjectPath, projectSession)
+      : (context.data.partial as PartialArchData | undefined)
+    if (seedPartial) context.data.partial = seedPartial
+    const existingSeed = ((seedPartial?.synopsis_result) || '').trim()
+    const resuming = resumeRequested
+      && seedPartial?.synopsis_incomplete === true
+      && existingSeed.length >= MIN_SYNOPSIS_PARTIAL_PERSIST_CHARS
 
+    // ===== 分块指令：本次只详写前 N 章（仅全新生成时生效） =====
+    const scope = resuming
+      ? 0
+      : Number.isSafeInteger(this.options.synopsisChapters) && (this.options.synopsisChapters as number) > 0
+        ? this.options.synopsisChapters as number
+        : 0
+    const scoped = !resuming && scope > 0 && scope < config.totalChapters
+    const taskPrompt = [
+      promptBuilder.build(),
+      scoped ? synopsisScopeInstruction(writingLanguage, config.totalChapters, scope) : '',
+    ].filter(Boolean).join('\n\n')
+
+    if (resuming) {
+      callbacks.log(text(
+        '检测到上次中断的情节大纲检查点，正在从断点续写...',
+        'An interrupted plot-outline checkpoint was found; resuming from the break point...',
+      ))
+    } else if (scoped) {
+      callbacks.log(text(
+        `本次仅详细生成前 ${scope} 章（全书 ${config.totalChapters} 章），其余章节以占位概览；后续可继续分块生成`,
+        `This batch details only the first ${scope} of ${config.totalChapters} chapters; the rest is a placeholder overview for later batches`,
+      ))
+    } else if (resumeRequested) {
+      callbacks.log(text(
+        '未找到可续写的中断检查点，将从头生成情节大纲',
+        'No resumable interrupted checkpoint was found; generating the plot outline from scratch.',
+      ))
+    }
+
+    // ===== 有界生成：自动续写至 stop；失败时把已完成部分交给 onPartialAvailable =====
+    let interruptedContent = ''
+    let merged = ''
+    try {
+      merged = await this.callLLMWithAppendContinuation({
+        taskPrompt,
+        systemPrompt: promptBuilder.getSystemRole(),
+        callbacks,
+        context,
+        llmOptions: {
+          purpose: resuming ? 'generate-plot-architecture-resume' : 'generate-plot-architecture',
+          reasoningStage: 'planning',
+          writingSkillStage: 'planning',
+        },
+        seedText: resuming ? existingSeed : '',
+        maxContinuations: 3,
+        onPartialAvailable: content => { interruptedContent = content },
+      })
+    } catch (error) {
+      // 只有「确实新增了内容后才中断」的失败才值得落盘并允许断点续写；
+      // 无净增（no-progress）、取消与网络错误保持原样失败。
+      const partialText = stripThinkingTags(interruptedContent).trim()
+      const seedTrimmed = stripThinkingTags(resuming ? existingSeed : '').trim()
+      const madeProgress = partialText !== seedTrimmed
+      if (
+        !context.cancelled
+        && madeProgress
+        && partialText.length >= MIN_SYNOPSIS_PARTIAL_PERSIST_CHARS
+      ) {
+        callbacks.log(text(
+          '情节大纲输出被模型长度上限中断，正在自动保存已完成部分...',
+          'Plot-outline output stopped at the model length limit; saving the completed part automatically...',
+        ))
+        this.assertNotCancelled(context)
+        assertArchitectureProjectSessionCurrent(projectSession, context)
+        try {
+          await this.persistInterruptedSynopsis(
+            projectSession,
+            expectedProjectPath,
+            context,
+            partialText,
+          )
+          callbacks.log(text(
+            `已完成部分（约 ${partialText.length} 字）已保存为不完整大纲，可点击「继续生成情节大纲」从断点续写`,
+            `The completed part (about ${partialText.length} characters) was saved as an incomplete outline. Click “Continue plot outline” to resume from the break point.`,
+          ))
+        } catch (persistError) {
+          // 检查点落盘失败时不得提供「继续生成」入口，避免续写时覆盖全文。
+          throw persistError
+        }
+        throw new PlotOutlineResumeAvailableError(text(
+          `情节大纲生成在完成前中断，AI 输出达到模型最大长度。已完成部分（约 ${partialText.length} 字）已自动保存为不完整大纲，没有白费。\n点击「继续生成情节大纲」可从断点续写；若整体内容仍偏长，也可在「AI 生成架构」中填写本次生成的章节数，分块生成。`,
+          `Plot-outline generation stopped before completion because the AI output reached the model maximum length. The finished part (about ${partialText.length} characters) was saved automatically as an incomplete outline.\nClick “Continue plot outline” to resume from the break point, or set a smaller per-batch chapter count in “Generate story architecture” to generate it in blocks.`,
+        ))
+      }
+      throw error
+    }
+
+    if (!merged.trim()) throw new Error(text(
+      '情节大纲生成失败，AI 返回空内容',
+      'Plot outline generation failed because the AI returned empty content.',
+    ))
     this.assertNotCancelled(context)
+    assertArchitectureProjectSessionCurrent(projectSession, context)
+
     const heading = promptLanguageText(writingLanguage, '情节大纲', 'Plot Outline')
     await writeArchToDb(
       'synopsis',
-      `# ${heading}\n\n${result}\n`,
+      `# ${heading}\n\n${merged.trim()}\n`,
       expectedProjectPath,
       context.runId,
       projectSession,
@@ -1292,9 +1466,28 @@ export class GeneratePlotArchitectureCommand extends BaseWorkflowCommand<string>
     )
     this.assertNotCancelled(context)
 
+    // 合并既有检查点文件：只更新 synopsis 字段，保留 premise 等其它步骤检查点
     const partial = (context.data.partial as PartialArchData) || await loadPartialData(expectedProjectPath, projectSession)
-    partial.synopsis_result = result
     context.data.partial = partial
+    partial.synopsis_result = merged.trim()
+    partial.synopsis_incomplete = false
+    try {
+      await savePartialData(
+        expectedProjectPath,
+        partial,
+        projectSession,
+        text('保存架构生成检查点', 'Save architecture-generation checkpoint'),
+        text('保存架构生成检查点失败', 'Failed to save the architecture-generation checkpoint.'),
+      )
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error)
+      callbacks.log(
+        text(
+          `[警告] 情节大纲已写入数据库，但检查点保存失败：${detail}。中断后将无法从此检查点续写。`,
+          `[Warning] The plot outline was saved to the database, but the checkpoint failed: ${detail}. It cannot resume from this checkpoint after an interruption.`,
+        ),
+      )
+    }
 
     if (this.selectedSteps.includes('premise') && this.selectedSteps.includes('characters') &&
       this.selectedSteps.includes('worldbuilding') && this.selectedSteps.includes('synopsis')) {
@@ -1313,9 +1506,45 @@ export class GeneratePlotArchitectureCommand extends BaseWorkflowCommand<string>
     }
 
     callbacks.log(text(
-      '情节大纲已生成并写入数据库',
-      'Plot outline generated and saved to the database.',
+      resuming ? '情节大纲续写完成并写入数据库' : '情节大纲已生成并写入数据库',
+      resuming ? 'Plot outline continuation completed and saved to the database.' : 'Plot outline generated and saved to the database.',
     ))
-    return result
+    return merged.trim()
+  }
+
+  /** 中断时落盘：DB 存带「未完成」标记的全文，partial 检查点保存纯内容供续写。 */
+  private async persistInterruptedSynopsis(
+    projectSession: ProjectSessionContext,
+    expectedProjectPath: string,
+    context: WorkflowContext,
+    partialText: string,
+  ): Promise<void> {
+    const writingLanguage = workflowWritingLanguage(context)
+    const text = (zhCNText: string, enUSText: string) => workflowUiText(context, zhCNText, enUSText)
+    const heading = promptLanguageText(writingLanguage, '情节大纲', 'Plot Outline')
+    const marker = promptLanguageText(
+      writingLanguage,
+      SYNOPSIS_INCOMPLETE_MARKER_ZH,
+      SYNOPSIS_INCOMPLETE_MARKER_EN,
+    )
+    await writeArchToDb(
+      'synopsis',
+      `# ${heading}\n\n${partialText}\n${marker}\n`,
+      expectedProjectPath,
+      context.runId,
+      projectSession,
+      text('故事架构写入数据库失败', 'Failed to write story architecture to the database.'),
+    )
+    const partial = (context.data.partial as PartialArchData) || await loadPartialData(expectedProjectPath, projectSession)
+    partial.synopsis_result = partialText
+    partial.synopsis_incomplete = true
+    context.data.partial = partial
+    await savePartialData(
+      expectedProjectPath,
+      partial,
+      projectSession,
+      text('保存中断的情节大纲检查点', 'Save the interrupted plot-outline checkpoint'),
+      text('保存中断的情节大纲检查点失败', 'Failed to save the interrupted plot-outline checkpoint.'),
+    )
   }
 }

--- a/src/services/workflows/commands/base-command.ts
+++ b/src/services/workflows/commands/base-command.ts
@@ -292,6 +292,93 @@ export abstract class BaseWorkflowCommand<TResult = string> {
   }
 
   /**
+   * 追加型文本续写助手：以 seedText（可为空）为基线，在单个模型租约内反复
+   * 请求直到 stop 或自动续写耗尽。seedText 非空时等价于「断点续写」——
+   * 不重发已有内容，只让模型从种子末尾自然追加。自动续写耗尽、无进展或
+   * 机械不完整等仍可能产出可见文本的失败，会在抛出前调用
+   * onPartialAvailable(mergedText)，供调用方把已完成部分落盘后让用户从
+   * 断点手动续写。
+   */
+  protected async callLLMWithAppendContinuation(
+    options: {
+      taskPrompt: string
+      systemPrompt: string
+      callbacks: StepCallbacks
+      context: WorkflowContext
+      llmOptions?: WorkflowLLMOptions
+      /** 已完成可见文本种子；为空时先发起一次全新请求。 */
+      seedText?: string
+      /** 自动续写轮数上限（0–7）。 */
+      maxContinuations: number
+      /** 部分结果回调：在失败抛出前携带当前合并文本。 */
+      onPartialAvailable?: (mergedText: string) => void
+      /** 进度日志用的任务描述。 */
+      taskLabel?: string
+    },
+  ): Promise<string> {
+    const uiText = (zhCNText: string, enUSText: string) => workflowUiText(options.context, zhCNText, enUSText)
+    const seed = options.seedText?.trim() || ''
+    let continuationCount = 0
+    let initial: { content: string; finishReason: LLMFinishReason }
+    let initialReceipt: LLMCompletion['receipt'] | undefined
+    if (seed) {
+      initial = { content: seed, finishReason: 'length' }
+    } else {
+      const first = await this.callLLMResult(
+        options.taskPrompt,
+        options.systemPrompt,
+        options.callbacks,
+        options.llmOptions,
+        options.context,
+      )
+      initial = first
+      initialReceipt = first.receipt
+    }
+    const prefix = options.taskLabel ? `${options.taskLabel} ` : ''
+    options.callbacks.log(uiText(
+      `  ${prefix}初始响应：finishReason=${initial.finishReason}`,
+      `  ${prefix}initial response: finishReason=${initial.finishReason}`,
+    ))
+    return completeBoundedCompletion({
+      initial,
+      mode: 'append-visible-text',
+      maxContinuations: options.maxContinuations,
+      originalPrompt: options.taskPrompt,
+      writingLanguage: workflowWritingLanguage(options.context),
+      uiLocale: options.context.uiLocale ?? 'zh-CN',
+      promptBudget: seed
+        ? undefined
+        : {
+            contextWindowTokens: initialReceipt?.capabilities?.contextWindowTokens,
+            maxOutputTokens: initialReceipt?.budget?.requestedOutputTokens,
+            systemPromptChars: options.systemPrompt.length,
+          },
+      isCancelled: () => options.context.cancelled,
+      redactVisibleText: redactedText => this.stripThinkingTags(redactedText),
+      requestContinuation: async continuationPrompt => {
+        continuationCount += 1
+        options.callbacks.log(uiText(
+          `  自动续写第 ${continuationCount} 轮请求已发起`,
+          `  Automatic continuation request ${continuationCount} started`,
+        ))
+        const next = await this.callLLMResult(
+          continuationPrompt,
+          options.systemPrompt,
+          options.callbacks,
+          options.llmOptions,
+          options.context,
+        )
+        options.callbacks.log(uiText(
+          `  自动续写第 ${continuationCount} 轮响应：finishReason=${next.finishReason}`,
+          `  Automatic continuation response ${continuationCount}: finishReason=${next.finishReason}`,
+        ))
+        return next
+      },
+      onInterrupted: mergedText => options.onPartialAvailable?.(mergedText),
+    })
+  }
+
+  /**
    * Returns partial text together with the provider end state. Commands that
    * have a bounded continuation policy (draft generation) may consume a
    * `length` result; all other workflow commands should use callLLM instead.

--- a/src/services/workflows/commands/review-chapter.command.ts
+++ b/src/services/workflows/commands/review-chapter.command.ts
@@ -274,8 +274,10 @@ export class ReviewChapterCommand extends BaseWorkflowCommand<string> {
 
     callbacks.log(text('调用 AI 审查员对本章进行多维度扫描...', 'Running the AI continuity review...'))
 
-    // 期望 JSON 格式返回
-    const reviewResultRaw = await this.callLLMWithBoundedCompletion(
+    // 期望 JSON 格式返回；bounded 模式会在 length 时自动重建一次。
+    // 部分模型/网关在输出上限截断时会把 finishReason 报成 stop，导致
+    // 坏 JSON 直接进入解析 → 这里在合同校验失败时再补一次完整替代输出。
+    let reviewResultRaw = await this.callLLMWithBoundedCompletion(
       reviewPrompt,
       promptBuilder.getSystemRole(),
       callbacks,
@@ -290,17 +292,76 @@ export class ReviewChapterCommand extends BaseWorkflowCommand<string> {
     )
     this.assertNotCancelled(context)
 
-    const reviewResultClean = this.stripThinkingTags(reviewResultRaw)
+    const parseAttempt = (): ReviewLike => parseReviewResult(this.stripThinkingTags(reviewResultRaw))
 
     let parsedResult: ReviewLike
     try {
-      parsedResult = parseReviewResult(reviewResultClean)
-    } catch {
-      throw new Error(text(
-        'AI 返回的审稿结果无效，因此未保存报告。',
-        'The AI review response was invalid, so no report was saved.',
+      parsedResult = parseAttempt()
+    } catch (parseError) {
+      const detail = parseError instanceof SyntaxError
+        ? promptLanguageText(
+          writingLanguage,
+          '输出不是完整 JSON（可能被模型输出上限截断）',
+          'the output is not complete JSON (it may be truncated by the model output limit)',
+        )
+        : promptLanguageText(
+          writingLanguage,
+          '输出不符合审稿报告合同（字段缺失、越界或多余）',
+          'the output does not match the review-report contract (missing, oversized, or extra fields)',
+        )
+      callbacks.log(text(
+        `审稿结果未通过校验（${detail}），正在请求一次完整替代输出...`,
+        `The review result failed validation (${detail}); requesting one complete replacement...`,
       ))
+      this.assertNotCancelled(context)
+      const rebuildInstruction = promptLanguageText(
+        writingLanguage,
+        '上一轮审稿输出未通过合同校验，已被丢弃，不得引用或续接。请重新完成原始审稿任务。',
+        'The previous review output failed contract validation and was discarded. Do not quote or continue it; complete the original review task again.',
+      )
+      const rebuildHeading = promptLanguageText(writingLanguage, '【原始审稿任务】', '[Original review task]')
+      const rebuildContract = promptLanguageText(
+        writingLanguage,
+        '【硬性要求】只重新输出一个完整审稿 JSON：summary 不超过 120 字符；items 为 1–10 条，每条含 category、severity(error|warning|pass)、description(≤200 字符)、可选 quote(≤160 字符)；不得输出额外字段、Markdown、解释或思考过程。',
+        '[Hard requirement] Output one complete review JSON only: summary within 120 characters; items 1–10 entries, each with category, severity(error|warning|pass), description(≤200 characters), optional quote(≤160 characters); no extra fields, Markdown, explanation, or reasoning.',
+      )
+      reviewResultRaw = await this.callLLMWithBoundedCompletion(
+        [rebuildInstruction, rebuildHeading, reviewPrompt, rebuildContract].join('\n\n'),
+        promptBuilder.getSystemRole(),
+        callbacks,
+        { mode: 'replace-structured-output', maxContinuations: 1 },
+        {
+          responseFormat: { type: 'json_object' },
+          purpose: 'review-chapter-rebuild',
+          reasoningStage: 'review',
+          writingSkillStage: 'review',
+        },
+        context,
+      )
+      this.assertNotCancelled(context)
+      try {
+        parsedResult = parseAttempt()
+      } catch (rebuildError) {
+        const rebuildDetail = rebuildError instanceof SyntaxError
+          ? promptLanguageText(
+            writingLanguage,
+            '替代输出仍不是完整 JSON',
+            'the replacement output is still not complete JSON',
+          )
+          : promptLanguageText(
+            writingLanguage,
+            '替代输出仍不符合审稿报告合同',
+            'the replacement output still does not match the review-report contract',
+          )
+        throw new Error(text(
+          `AI 返回的审稿结果两次均无效（${rebuildDetail}），因此未保存报告。`
+            + '若此问题反复出现，通常是审稿输出被模型最大长度截断：请提高模型的最大输出 Tokens 后重试。',
+          `The AI review response was invalid twice (${rebuildDetail}), so no report was saved. `
+            + 'If this keeps happening, the review output is usually truncated by the model maximum length: increase the model maximum output tokens and retry.',
+        ))
+      }
     }
+    this.assertNotCancelled(context)
 
     const blueprint = await ipc.invokeWithProjectSession(
       projectSession, 'db:blueprint-get', this.params.chapterNumber, context.projectPath,
@@ -380,7 +441,7 @@ export class ReviewChapterCommand extends BaseWorkflowCommand<string> {
       `审查完成，已生成审稿报告 r${revIndex}`,
       `Review complete; created review report r${revIndex}`,
     ))
-    return reviewResultClean
+    return this.stripThinkingTags(reviewResultRaw)
   }
 
   private async readCharacterStates(

--- a/src/services/workflows/creative-workflow-launcher.ts
+++ b/src/services/workflows/creative-workflow-launcher.ts
@@ -32,7 +32,15 @@ export type CreativeWorkflowName =
 
 export type CreativeIntent =
   | { workflow: 'generate_draft'; chapterNumber: number }
-  | { workflow: 'generate_architecture'; selectedSteps?: ArchitectureWorkflowParams['selectedSteps']; stepGuidance?: Record<string, string> }
+  | {
+      workflow: 'generate_architecture'
+      selectedSteps?: ArchitectureWorkflowParams['selectedSteps']
+      stepGuidance?: Record<string, string>
+      /** 情节大纲本次只详写前 N 章（0/空 = 全书）。 */
+      synopsisChapters?: ArchitectureWorkflowParams['synopsisChapters']
+      /** 从输出长度中断的检查点续写情节大纲。 */
+      resumeSynopsis?: ArchitectureWorkflowParams['resumeSynopsis']
+    }
   | { workflow: 'generate_blueprint'; params?: DirectoryWorkflowParams }
   | { workflow: 'review' | 'refine' | 'finalize'; chapterNumber: number }
 
@@ -115,6 +123,8 @@ async function definitionFor(
       projectSession,
       selectedSteps: intent.selectedSteps,
       stepGuidance: intent.stepGuidance,
+      synopsisChapters: intent.synopsisChapters ?? null,
+      resumeSynopsis: intent.resumeSynopsis,
     }, uiLocale)
   }
   if (intent.workflow === 'generate_blueprint') {

--- a/src/services/workflows/structured-batch-executor.ts
+++ b/src/services/workflows/structured-batch-executor.ts
@@ -351,19 +351,26 @@ export function createStructuredBatchExecutor<TInput, TOutput>(dependencies: {
           if (!Array.isArray(decoded)) throw new TypeError('decoder did not return an array')
         } catch (error) {
           const diagnostic = structuredContractDiagnostic(error)
-          if (diagnostic && items.length > 1) {
+          // JSON 无法解码通常意味着输出被模型输出上限截断（截断不总是携带
+          // 可提取的结构化诊断）。只要批次含多章就拆半重试：让每一半在更小
+          // 的输出预算内完整生成；拆到单章仍未通过时，再回退到紧凑单项重建。
+          if (items.length > 1) {
             const midpoint = Math.floor(items.length / 2)
             receipt.splitCount += 1
             await executeBatch(items.slice(0, midpoint))
             await executeBatch(items.slice(midpoint))
             return
           }
-          if (diagnostic && canUseCompactFallback) {
-            await runCompactFallback({
-              code: diagnostic.code,
-              path: diagnostic.path,
-              field: diagnostic.field,
-            })
+          if (canUseCompactFallback) {
+            await runCompactFallback(
+              diagnostic
+                ? {
+                    code: diagnostic.code,
+                    path: diagnostic.path,
+                    field: diagnostic.field,
+                  }
+                : undefined,
+            )
             return
           }
           throw new ExecutionFailure({
@@ -371,13 +378,13 @@ export function createStructuredBatchExecutor<TInput, TOutput>(dependencies: {
             reason: diagnostic
               ? 'invalid_item'
               : syntaxRepairApplied
-              ? 'malformed_output'
-              : 'invalid_item',
+                ? 'malformed_output'
+                : 'invalid_item',
             message: diagnostic
               ? diagnostic.message
               : syntaxRepairApplied
-              ? '结构化输出经一次语法修复后仍无法按合同解码'
-              : '结构化输出无法按合同解码',
+                ? '结构化输出经一次语法修复后仍无法按合同解码'
+                : '结构化输出无法按合同解码',
             ...(diagnostic
               ? {
                   diagnostic: {


### PR DESCRIPTION
## Problem

When a book has many chapters, single model calls cannot finish large outputs inside the fixed output-token budget, and many OpenAI-compatible gateways / local models report truncation as finishReason=stop instead of length, so half-written JSON is treated as complete:

- Plot outline (synopsis): a single call had no automatic continuation and no checkpoint. Early stops discarded the finished part - tokens wasted, nothing saved, no way to continue.
- Blueprint directory: batches whose JSON could not be decoded failed immediately when no structured diagnostic was extractable, so a truncated batch never fell back to smaller splits.
- AI review: a truncated review JSON reported as stop failed validation with no rebuild attempt.

## Changes (3 commits)

### 1) feat(workflows): bounded plot-outline continuation with checkpoint resume and per-batch chapter scoping
- `bounded-completion.ts`: optional `onInterrupted` callback hands the merged partial text to callers just before a non-cancelled failure.
- `base-command.ts`: `callLLMWithAppendContinuation` runs an append-mode bounded loop, optionally seeded from an existing partial document (break-point resume without re-sending prior content).
- `architecture.command.ts` `GeneratePlotArchitectureCommand`: synopsis generation auto-continues up to the bounded limit; on an early stop the completed part is automatically persisted to the story-architecture store (marked incomplete) and to the `.vela/partial_arch.json` checkpoint, then a machine-readable `architecture-synopsis-resume-available` error is raised. A resume workflow seeds the next run from that checkpoint and merges new content.
- Optional `synopsisChapters` param injects a per-batch scope instruction: detail only the first N chapters, collapse later chapters to one placeholder line, so a single pass stays inside the output budget and later batches/resume finish the rest.
- UI: the workflow failure notice gains a rounded **"Continue plot outline (resume)"** action; the story-architecture editor marks the outline card **incomplete** with the same resume action; the "Generate story architecture" dialog warns on large chapter counts and lets the author enter the number of chapters to detail in this batch.

### 2) fix(workflows): split structurally undecodable batches instead of failing immediately
- `structured-batch-executor.ts`: decode failures previously split / used compact fallback only when the error carried a structured diagnostic. Truncated JSON produces no diagnostic, so a whole directory batch failed after one syntax repair. Decode failures now **always split multi-item batches in half** and fall back to a compact single-item rebuild for single items, still bounded by the existing attempt budget.

### 3) fix(workflows): rebuild a review report once when contract validation fails
- `review-chapter.command.ts`: when the first review response fails contract validation, one complete replacement request is sent under the review-report contract before failing. The final error distinguishes truncated JSON from a contract violation and suggests raising the model maximum output tokens when truncation keeps recurring.

## Tests
- New `plot-outline-batch.command.test.ts` (6 tests): fresh/auto-continuation merge, exhausted-continuation auto-save + resume error code, checkpoint resume, per-batch scope instruction.
- `mutation-failure-boundary.test.ts`: review invalid-output cases updated to the new contract (one rebuild attempt then fail-closed, nothing persisted), plus a new case covering a `stop`-reported truncated review recovered via the replacement request.
- Verified on this branch: `tsc --noEmit` clean; 258 tests pass across bounded-completion, architecture.command, directory.command, structured-batch-executor, mutation-failure-boundary and refine-draft suites.