### PR TITLE
fix(workflows): split structurally undecodable batches instead of failing immediately

### DIFF
--- a/src/services/workflows/__tests__/structured-batch-executor.test.ts
+++ b/src/services/workflows/__tests__/structured-batch-executor.test.ts
@@ -1199,7 +1199,9 @@ describe('StructuredBatchExecutor seam', () => {
     diagnostic.mockRestore()
   })
 
-  it('allows at most one syntax repair across all batches in one executor run', async () => {
+  it('keeps one global syntax repair and recovers a later truncated batch via compact rebuild', async () => {
+    // 修复额度全局只有一次：批[1] 截断走语法修复；批[2] 再次截断时不重复修复，
+    // 而是按预算回退到紧凑单项重建（作者 #202 评审点：修复用尽后仍应能恢复）。
     let attempt = 0
     const complete = vi.fn<GenerationSession['complete']>(async (task) => {
       attempt += 1
@@ -1209,6 +1211,14 @@ describe('StructuredBatchExecutor seam', () => {
           content: blueprintJson([1]),
           finishReason: 'stop',
           receipt: attemptReceipt(2, 100, 200, 'stop'),
+        }
+      }
+      if (task.purpose.endsWith(':compact-single')) {
+        return {
+          status: 'completed',
+          content: blueprintJson([2]),
+          finishReason: 'stop',
+          receipt: attemptReceipt(attempt, 100, attempt * 100, 'stop'),
         }
       }
       expect(task.purpose).toBe('chapter-blueprints')
@@ -1223,15 +1233,16 @@ describe('StructuredBatchExecutor seam', () => {
     })
     const executor = createStructuredBatchExecutor({ contract: blueprintContract, session: { complete } })
 
-    const result = await executor.execute({ items: [1, 2], limits: { maxBatchItems: 1 } })
+    const result = await executor.execute({
+      items: [1, 2],
+      limits: { maxBatchItems: 1, maxCompactSingleFallbacks: 1 },
+    })
 
     expect(result).toMatchObject({
-      ok: false,
-      failure: { code: 'invalid_output', reason: 'malformed_output' },
-      receipt: { calls: 3, requestedTokens: 300 },
+      ok: true,
+      items: [{ chapterNumber: 1 }, { chapterNumber: 2 }],
+      receipt: { calls: 4, compactSingleFallbackCount: 1, requestedTokens: 400 },
     })
-    expect(result).not.toHaveProperty('items')
-    expect(complete).toHaveBeenCalledTimes(3)
   })
 
   it('lets the contract decode a complete fenced JSON envelope without spending the syntax repair', async () => {
@@ -1595,5 +1606,98 @@ describe('StructuredBatchExecutor seam', () => {
       receipt: { calls: 4, requestedTokens: 400, compactSingleFallbackCount: 2 },
     })
     expect(complete).toHaveBeenCalledTimes(4)
+  })
+
+  it('recovers chapters missing after a syntax repair by splitting the batch instead of failing', async () => {
+    // 作者 probe：截断被报成 stop，语法修复只补闭合括号 → 得到合法但仅含
+    // 第一章的 JSON（修复不能补造尚未生成的章节）→ 执行器应拆半并请求小批次。
+    let attempt = 0
+    const complete = vi.fn<GenerationSession['complete']>(async (task) => {
+      attempt += 1
+      if (attempt === 1) {
+        return {
+          status: 'completed',
+          content: '{"blueprints":[{"chapterNumber":1,"title":"一"}',
+          finishReason: 'stop',
+          receipt: attemptReceipt(attempt, 100, attempt * 100, 'stop'),
+        }
+      }
+      if (task.purpose.endsWith(':structured-syntax-repair')) {
+        // 修复只闭合结构，不得改动候选中的非结构证据（保留 title 原值）
+        return {
+          status: 'completed',
+          content: '{"blueprints":[{"chapterNumber":1,"title":"一"}]}',
+          finishReason: 'stop',
+          receipt: attemptReceipt(attempt, 100, attempt * 100, 'stop'),
+        }
+      }
+      const items = taskPayload(task).items
+      return {
+        status: 'completed',
+        content: blueprintJson(items),
+        finishReason: 'stop',
+        receipt: attemptReceipt(attempt, 100, attempt * 100, 'stop'),
+      }
+    })
+    const executor = createStructuredBatchExecutor({ contract: blueprintContract, session: { complete } })
+
+    const result = await executor.execute({ items: [1, 2, 3], limits: { maxBatchItems: 3 } })
+
+    expect(result).toMatchObject({
+      ok: true,
+      items: [{ chapterNumber: 1 }, { chapterNumber: 2 }, { chapterNumber: 3 }],
+      receipt: { calls: 4, splitCount: 1, requestedTokens: 400 },
+    })
+  })
+
+  it('keeps splitting when a truncated half-batch arrives after the one syntax repair was used', async () => {
+    // 作者 probe：一次执行已消耗唯一一次语法修复后，[2,3] 子批再次 stop 截断；
+    // 不应在解码前退出，而应按预算继续拆半到单项完成。
+    let attempt = 0
+    const complete = vi.fn<GenerationSession['complete']>(async (task) => {
+      attempt += 1
+      if (attempt === 1) {
+        return {
+          status: 'completed',
+          content: '{"blueprints":[{"chapterNumber":1,"title":"一"}',
+          finishReason: 'stop',
+          receipt: attemptReceipt(attempt, 100, attempt * 100, 'stop'),
+        }
+      }
+      if (task.purpose.endsWith(':structured-syntax-repair')) {
+        // 修复只闭合结构，不得改动候选中的非结构证据（保留 title 原值）
+        return {
+          status: 'completed',
+          content: '{"blueprints":[{"chapterNumber":1,"title":"一"}]}',
+          finishReason: 'stop',
+          receipt: attemptReceipt(attempt, 100, attempt * 100, 'stop'),
+        }
+      }
+      const items = taskPayload(task).items
+      if (attempt === 4) {
+        // [2,3] 子批再次被截断（语法修复已用尽，不得再次 repair）
+        return {
+          status: 'completed',
+          content: '{"blueprints":[{"chapterNumber":2,"title":"二"}',
+          finishReason: 'stop',
+          receipt: attemptReceipt(attempt, 100, attempt * 100, 'stop'),
+        }
+      }
+      return {
+        status: 'completed',
+        content: blueprintJson(items),
+        finishReason: 'stop',
+        receipt: attemptReceipt(attempt, 100, attempt * 100, 'stop'),
+      }
+    })
+    const executor = createStructuredBatchExecutor({ contract: blueprintContract, session: { complete } })
+
+    const result = await executor.execute({ items: [1, 2, 3], limits: { maxBatchItems: 3 } })
+
+    expect(result).toMatchObject({
+      ok: true,
+      items: [{ chapterNumber: 1 }, { chapterNumber: 2 }, { chapterNumber: 3 }],
+      receipt: { calls: 6, splitCount: 2, requestedTokens: 600 },
+    })
   })
 })

--- a/src/services/workflows/structured-batch-executor.ts
+++ b/src/services/workflows/structured-batch-executor.ts
@@ -285,65 +285,63 @@ export function createStructuredBatchExecutor<TInput, TOutput>(dependencies: {
               message: '结构化语法修复合同构建失败',
             })
           }
-          if (repairUsed) {
-            throw new ExecutionFailure({
-              code: 'invalid_output',
-              reason: 'malformed_output',
-              message: '结构化输出无法按合同解码，且本次执行已使用过唯一一次语法修复',
-            })
-          }
-          repairUsed = true
-          syntaxRepairApplied = true
-          const repaired = await session.complete(
-            buildStructuredSyntaxRepairTask(task, repairContract, outcome.content, writingLanguage),
-            { signal: input.signal },
-          )
-          recordAttempt(repaired.receipt)
-          if (input.signal?.aborted || repaired.finishReason === 'cancelled') {
-            throw new ExecutionFailure({
-              code: 'cancelled',
-              reason: 'cancelled',
-              message: '结构化语法修复已取消',
-            })
-          }
-          if (repaired.status === 'incomplete') {
-            if (repaired.finishReason === 'length') {
-              if (items.length > 1) {
-                const midpoint = Math.floor(items.length / 2)
-                receipt.splitCount += 1
-                await executeBatch(items.slice(0, midpoint))
-                await executeBatch(items.slice(midpoint))
-                return
-              }
-              if (canUseCompactFallback) {
-                await runCompactFallback()
-                return
-              }
+          if (!repairUsed) {
+            repairUsed = true
+            syntaxRepairApplied = true
+            const repaired = await session.complete(
+              buildStructuredSyntaxRepairTask(task, repairContract, outcome.content, writingLanguage),
+              { signal: input.signal },
+            )
+            recordAttempt(repaired.receipt)
+            if (input.signal?.aborted || repaired.finishReason === 'cancelled') {
               throw new ExecutionFailure({
-                code: 'limit_exceeded',
-                reason: 'output_limit',
-                message: '结构化语法修复达到模型输出上限',
+                code: 'cancelled',
+                reason: 'cancelled',
+                message: '结构化语法修复已取消',
               })
             }
-            const repairReason: StructuredGenerationFailureReason = repaired.finishReason === 'content_filter'
-              ? 'safety'
-              : repaired.finishReason === 'error'
-                ? 'server_error'
-                : 'unknown'
-            throw new ExecutionFailure({
-              code: 'generation_failed',
-              reason: repairReason,
-              message: `结构化语法修复未正常完成：${repaired.finishReason}`,
-            })
+            if (repaired.status === 'incomplete') {
+              if (repaired.finishReason === 'length') {
+                if (items.length > 1) {
+                  const midpoint = Math.floor(items.length / 2)
+                  receipt.splitCount += 1
+                  await executeBatch(items.slice(0, midpoint))
+                  await executeBatch(items.slice(midpoint))
+                  return
+                }
+                if (canUseCompactFallback) {
+                  await runCompactFallback()
+                  return
+                }
+                throw new ExecutionFailure({
+                  code: 'limit_exceeded',
+                  reason: 'output_limit',
+                  message: '结构化语法修复达到模型输出上限',
+                })
+              }
+              const repairReason: StructuredGenerationFailureReason = repaired.finishReason === 'content_filter'
+                ? 'safety'
+                : repaired.finishReason === 'error'
+                  ? 'server_error'
+                  : 'unknown'
+              throw new ExecutionFailure({
+                code: 'generation_failed',
+                reason: repairReason,
+                message: `结构化语法修复未正常完成：${repaired.finishReason}`,
+              })
+            }
+            if (!preservesStructuredJsonEvidence(candidateContent, repaired.content)) {
+              throw new ExecutionFailure({
+                code: 'invalid_output',
+                reason: 'malformed_output',
+                message: '结构化语法修复改变了候选中的非结构证据，已拒绝补造或改写事实',
+              })
+            }
+            candidateContent = repaired.content
           }
-          if (!preservesStructuredJsonEvidence(candidateContent, repaired.content)) {
-            throw new ExecutionFailure({
-              code: 'invalid_output',
-              reason: 'malformed_output',
-              message: '结构化语法修复改变了候选中的非结构证据，已拒绝补造或改写事实',
-            })
-          }
-          candidateContent = repaired.content
+          // 本次执行已使用过唯一一次语法修复：再次语法损坏时不再重复修复，
+          // 让坏文本直接进入下方解码；解码失败路径会在预算内拆半或回退
+          // 紧凑单项重建，而不是在解码前整体终止。
         }
         let decoded: readonly TOutput[]
         try {
@@ -444,6 +442,21 @@ export function createStructuredBatchExecutor<TInput, TOutput>(dependencies: {
         const missingKeys = expectedKeys
           .filter(key => !outputKeys.has(key))
         if (missingKeys.length > 0) {
+          // 输出合法但缺少目标项。只有本批经历过语法修复（截断证据）时才值得
+          // 继续语义重试：语法修复只能闭合已写内容、不能补造尚未生成的章节，
+          // 因此在预算内把本批拆半或回退紧凑单项重建。普通漏写（模型 stop 且
+          // 无截断证据）保持 fail-closed，避免对偷懒输出无限重试。
+          if (syntaxRepairApplied && items.length > 1) {
+            const midpoint = Math.floor(items.length / 2)
+            receipt.splitCount += 1
+            await executeBatch(items.slice(0, midpoint))
+            await executeBatch(items.slice(midpoint))
+            return
+          }
+          if (syntaxRepairApplied && canUseCompactFallback) {
+            await runCompactFallback()
+            return
+          }
           throw new ExecutionFailure({
             code: 'invalid_output',
             reason: syntaxRepairApplied ? 'malformed_output' : 'missing_item',

--- a/src/services/workflows/structured-batch-executor.ts
+++ b/src/services/workflows/structured-batch-executor.ts
@@ -351,19 +351,26 @@ export function createStructuredBatchExecutor<TInput, TOutput>(dependencies: {
           if (!Array.isArray(decoded)) throw new TypeError('decoder did not return an array')
         } catch (error) {
           const diagnostic = structuredContractDiagnostic(error)
-          if (diagnostic && items.length > 1) {
+          // JSON 无法解码通常意味着输出被模型输出上限截断（截断不总是携带
+          // 可提取的结构化诊断）。只要批次含多章就拆半重试：让每一半在更小
+          // 的输出预算内完整生成；拆到单章仍未通过时，再回退到紧凑单项重建。
+          if (items.length > 1) {
             const midpoint = Math.floor(items.length / 2)
             receipt.splitCount += 1
             await executeBatch(items.slice(0, midpoint))
             await executeBatch(items.slice(midpoint))
             return
           }
-          if (diagnostic && canUseCompactFallback) {
-            await runCompactFallback({
-              code: diagnostic.code,
-              path: diagnostic.path,
-              field: diagnostic.field,
-            })
+          if (canUseCompactFallback) {
+            await runCompactFallback(
+              diagnostic
+                ? {
+                    code: diagnostic.code,
+                    path: diagnostic.path,
+                    field: diagnostic.field,
+                  }
+                : undefined,
+            )
             return
           }
           throw new ExecutionFailure({
@@ -371,13 +378,13 @@ export function createStructuredBatchExecutor<TInput, TOutput>(dependencies: {
             reason: diagnostic
               ? 'invalid_item'
               : syntaxRepairApplied
-              ? 'malformed_output'
-              : 'invalid_item',
+                ? 'malformed_output'
+                : 'invalid_item',
             message: diagnostic
               ? diagnostic.message
               : syntaxRepairApplied
-              ? '结构化输出经一次语法修复后仍无法按合同解码'
-              : '结构化输出无法按合同解码',
+                ? '结构化输出经一次语法修复后仍无法按合同解码'
+                : '结构化输出无法按合同解码',
             ...(diagnostic
               ? {
                   diagnostic: {


### PR DESCRIPTION
## Summary
`structured-batch-executor.ts` decode failures previously only split multi-item batches or used the compact single-item fallback when the error carried a structured diagnostic (`diagnostic && items.length > 1`). Truncated JSON — frequently reported as `finishReason=stop` by OpenAI-compatible gateways/local models — produces **no** diagnostic, so an entire blueprint directory batch failed right after the single syntax repair, wasting the run.

## Change
Decode failures now **always split multi-item batches in half** (recursive) and fall back to the compact single-item rebuild for single items, still bounded by the existing attempt/token budget. This makes large-chapter directory generation recover from output-limit truncation automatically.

## Verification
- `tsc --noEmit` clean; 76 tests pass (structured-batch-executor 48 + directory.command 28). Suggested by review on PR #198 to keep the plot-outline change reviewable.