### PR TITLE
fix(workflows): rebuild a review report once when contract validation fails

### DIFF
--- a/src/services/workflows/commands/__tests__/mutation-failure-boundary.test.ts
+++ b/src/services/workflows/commands/__tests__/mutation-failure-boundary.test.ts
@@ -1276,7 +1276,7 @@ describe('workflow mutation failure boundaries', () => {
       step: {},
       context: { ...context(), uiLocale: 'en-US', writingLanguage: 'en-US' },
       callbacks: callbacks(),
-    })).rejects.toThrow('The AI review response was invalid, so no report was saved.')
+    })).rejects.toThrow('The AI review response was invalid twice')
 
     expect(invoke.mock.calls.map(([channel]) => channel)).not.toContain('db:review-create')
     expect(useEditorStore.getState().tabs).toEqual([])
@@ -1327,6 +1327,61 @@ describe('workflow mutation failure boundaries', () => {
 
     expect(generateStream).toHaveBeenCalledTimes(2)
     expect(generateStream.mock.calls[1]?.[0][1]?.content).toContain('上一轮结构化输出因长度限制而中断')
+    expect(invoke.mock.calls.filter(([channel]) => channel === 'db:review-create')).toHaveLength(1)
+  })
+
+  it('recovers a stop-reported truncated review with one complete replacement before persistence', async () => {
+    // 模型/网关在输出上限截断时把 finishReason 报成 stop（而非 length）：
+    // 坏 JSON 直接进入解析 → 命令应自动补一次完整替代输出并成功保存。
+    const completeReview = JSON.stringify({
+      items: [{ category: '剧情连贯性', severity: 'pass', description: '未发现矛盾' }],
+      summary: '审稿完成',
+    })
+    const invoke = vi.fn(async (channel: string) => {
+      if (channel === 'kb:search') return []
+      if (channel === 'db:character-get-all') return []
+      if (channel === 'db:project-core-get') return {}
+      if (channel === 'db:draft-get-meta') {
+        return { id: 1, chapterNumber: 1, version: 1, status: 'draft', source: 'write' }
+      }
+      if (channel === 'db:review-next-index') return 1
+      if (channel === 'db:review-create') return { success: true, id: 10 }
+      if (channel === 'db:blueprint-get') return null
+      throw new Error(`unexpected IPC: ${channel}`)
+    })
+    stubVelaIpc(invoke)
+    const rebuildPrompts: string[] = []
+    const generateStream = vi.fn(async (
+      messages: Parameters<ReturnType<typeof useLLMStore.getState>['generateStream']>[0],
+      streamCallbacks: Parameters<ReturnType<typeof useLLMStore.getState>['generateStream']>[1],
+    ) => {
+      const firstAttempt = generateStream.mock.calls.length === 1
+      if (!firstAttempt) {
+        rebuildPrompts.push(messages.map(message => message.content).join('\n'))
+      }
+      streamCallbacks.onDone?.(
+        firstAttempt ? '{"summary":"审稿","items":[' : completeReview,
+        undefined,
+        'stop',
+      )
+      return `review-request-${generateStream.mock.calls.length}`
+    })
+    useLLMStore.setState({ defaultModelId: 'model', generateStream })
+    const command = new ReviewChapterCommand({
+      draftPath: 'vela://draft/1',
+      draftContent: '待审正文',
+      chapterNumber: 1,
+    })
+
+    await expect(command.execute({
+      step: {},
+      context: context(),
+      callbacks: callbacks(),
+    })).resolves.toBe(completeReview)
+
+    expect(generateStream).toHaveBeenCalledTimes(2)
+    expect(rebuildPrompts[0]).toContain('上一轮审稿输出未通过合同校验')
+    expect(rebuildPrompts[0]).toContain('完整审稿 JSON')
     expect(invoke.mock.calls.filter(([channel]) => channel === 'db:review-create')).toHaveLength(1)
   })
 

--- a/src/services/workflows/commands/__tests__/mutation-failure-boundary.test.ts
+++ b/src/services/workflows/commands/__tests__/mutation-failure-boundary.test.ts
@@ -1282,6 +1282,61 @@ describe('workflow mutation failure boundaries', () => {
     expect(useEditorStore.getState().tabs).toEqual([])
   })
 
+  it.each([
+    {
+      name: 'English UI with Chinese writing',
+      uiLocale: 'en-US' as const,
+      writingLanguage: 'zh-CN' as const,
+      response: 'not-json',
+      expectedLog: 'The review result failed validation (the output is not complete JSON (it may be truncated by the model output limit)); requesting one complete replacement...',
+      expectedError: 'The AI review response was invalid twice (the replacement output is still not complete JSON)',
+      expectedPrompt: '上一轮审稿输出未通过合同校验',
+    },
+    {
+      name: 'Chinese UI with English writing',
+      uiLocale: 'zh-CN' as const,
+      writingLanguage: 'en-US' as const,
+      response: '{}',
+      expectedLog: '审稿结果未通过校验（输出不符合审稿报告合同（字段缺失、越界或多余）），正在请求一次完整替代输出...',
+      expectedError: 'AI 返回的审稿结果两次均无效（替代输出仍不符合审稿报告合同）',
+      expectedPrompt: 'The previous review output failed contract validation',
+    },
+  ])('keeps $name diagnostics in the UI language while rebuilding in the writing language', async ({
+    uiLocale,
+    writingLanguage,
+    response,
+    expectedLog,
+    expectedError,
+    expectedPrompt,
+  }) => {
+    const invoke = vi.fn(async (channel: string) => {
+      if (channel === 'kb:search') return []
+      if (channel === 'db:character-get-all') return []
+      if (channel === 'db:project-core-get') return {}
+      throw new Error(`unexpected IPC: ${channel}`)
+    })
+    stubVelaIpc(invoke)
+    const command = new ReviewChapterCommand({
+      draftPath: 'vela://draft/1',
+      draftContent: writingLanguage === 'en-US' ? 'Draft awaiting review.' : '待审正文',
+      chapterNumber: 1,
+    })
+    const llm = vi.spyOn(command as unknown as {
+      callLLMWithBoundedCompletion: (...args: unknown[]) => Promise<string>
+    }, 'callLLMWithBoundedCompletion').mockResolvedValue(response)
+    const stepCallbacks = callbacks()
+
+    await expect(command.execute({
+      step: {},
+      context: { ...context(), uiLocale, writingLanguage },
+      callbacks: stepCallbacks,
+    })).rejects.toThrow(expectedError)
+
+    expect(stepCallbacks.log).toHaveBeenCalledWith(expectedLog)
+    expect(llm.mock.calls[1]?.[0]).toContain(expectedPrompt)
+    expect(invoke.mock.calls.map(([channel]) => channel)).not.toContain('db:review-create')
+  })
+
   it('replaces one length-truncated review with complete JSON before persistence', async () => {
     const completeReview = JSON.stringify({
       items: [{ category: '剧情连贯性', severity: 'pass', description: '未发现矛盾' }],

--- a/src/services/workflows/commands/review-chapter.command.ts
+++ b/src/services/workflows/commands/review-chapter.command.ts
@@ -299,13 +299,11 @@ export class ReviewChapterCommand extends BaseWorkflowCommand<string> {
       parsedResult = parseAttempt()
     } catch (parseError) {
       const detail = parseError instanceof SyntaxError
-        ? promptLanguageText(
-          writingLanguage,
+        ? text(
           '输出不是完整 JSON（可能被模型输出上限截断）',
           'the output is not complete JSON (it may be truncated by the model output limit)',
         )
-        : promptLanguageText(
-          writingLanguage,
+        : text(
           '输出不符合审稿报告合同（字段缺失、越界或多余）',
           'the output does not match the review-report contract (missing, oversized, or extra fields)',
         )
@@ -343,13 +341,11 @@ export class ReviewChapterCommand extends BaseWorkflowCommand<string> {
         parsedResult = parseAttempt()
       } catch (rebuildError) {
         const rebuildDetail = rebuildError instanceof SyntaxError
-          ? promptLanguageText(
-            writingLanguage,
+          ? text(
             '替代输出仍不是完整 JSON',
             'the replacement output is still not complete JSON',
           )
-          : promptLanguageText(
-            writingLanguage,
+          : text(
             '替代输出仍不符合审稿报告合同',
             'the replacement output still does not match the review-report contract',
           )

--- a/src/services/workflows/commands/review-chapter.command.ts
+++ b/src/services/workflows/commands/review-chapter.command.ts
@@ -274,8 +274,10 @@ export class ReviewChapterCommand extends BaseWorkflowCommand<string> {
 
     callbacks.log(text('调用 AI 审查员对本章进行多维度扫描...', 'Running the AI continuity review...'))
 
-    // 期望 JSON 格式返回
-    const reviewResultRaw = await this.callLLMWithBoundedCompletion(
+    // 期望 JSON 格式返回；bounded 模式会在 length 时自动重建一次。
+    // 部分模型/网关在输出上限截断时会把 finishReason 报成 stop，导致
+    // 坏 JSON 直接进入解析 → 这里在合同校验失败时再补一次完整替代输出。
+    let reviewResultRaw = await this.callLLMWithBoundedCompletion(
       reviewPrompt,
       promptBuilder.getSystemRole(),
       callbacks,
@@ -290,17 +292,76 @@ export class ReviewChapterCommand extends BaseWorkflowCommand<string> {
     )
     this.assertNotCancelled(context)
 
-    const reviewResultClean = this.stripThinkingTags(reviewResultRaw)
+    const parseAttempt = (): ReviewLike => parseReviewResult(this.stripThinkingTags(reviewResultRaw))
 
     let parsedResult: ReviewLike
     try {
-      parsedResult = parseReviewResult(reviewResultClean)
-    } catch {
-      throw new Error(text(
-        'AI 返回的审稿结果无效，因此未保存报告。',
-        'The AI review response was invalid, so no report was saved.',
+      parsedResult = parseAttempt()
+    } catch (parseError) {
+      const detail = parseError instanceof SyntaxError
+        ? promptLanguageText(
+          writingLanguage,
+          '输出不是完整 JSON（可能被模型输出上限截断）',
+          'the output is not complete JSON (it may be truncated by the model output limit)',
+        )
+        : promptLanguageText(
+          writingLanguage,
+          '输出不符合审稿报告合同（字段缺失、越界或多余）',
+          'the output does not match the review-report contract (missing, oversized, or extra fields)',
+        )
+      callbacks.log(text(
+        `审稿结果未通过校验（${detail}），正在请求一次完整替代输出...`,
+        `The review result failed validation (${detail}); requesting one complete replacement...`,
       ))
+      this.assertNotCancelled(context)
+      const rebuildInstruction = promptLanguageText(
+        writingLanguage,
+        '上一轮审稿输出未通过合同校验，已被丢弃，不得引用或续接。请重新完成原始审稿任务。',
+        'The previous review output failed contract validation and was discarded. Do not quote or continue it; complete the original review task again.',
+      )
+      const rebuildHeading = promptLanguageText(writingLanguage, '【原始审稿任务】', '[Original review task]')
+      const rebuildContract = promptLanguageText(
+        writingLanguage,
+        '【硬性要求】只重新输出一个完整审稿 JSON：summary 不超过 120 字符；items 为 1–10 条，每条含 category、severity(error|warning|pass)、description(≤200 字符)、可选 quote(≤160 字符)；不得输出额外字段、Markdown、解释或思考过程。',
+        '[Hard requirement] Output one complete review JSON only: summary within 120 characters; items 1–10 entries, each with category, severity(error|warning|pass), description(≤200 characters), optional quote(≤160 characters); no extra fields, Markdown, explanation, or reasoning.',
+      )
+      reviewResultRaw = await this.callLLMWithBoundedCompletion(
+        [rebuildInstruction, rebuildHeading, reviewPrompt, rebuildContract].join('\n\n'),
+        promptBuilder.getSystemRole(),
+        callbacks,
+        { mode: 'replace-structured-output', maxContinuations: 1 },
+        {
+          responseFormat: { type: 'json_object' },
+          purpose: 'review-chapter-rebuild',
+          reasoningStage: 'review',
+          writingSkillStage: 'review',
+        },
+        context,
+      )
+      this.assertNotCancelled(context)
+      try {
+        parsedResult = parseAttempt()
+      } catch (rebuildError) {
+        const rebuildDetail = rebuildError instanceof SyntaxError
+          ? promptLanguageText(
+            writingLanguage,
+            '替代输出仍不是完整 JSON',
+            'the replacement output is still not complete JSON',
+          )
+          : promptLanguageText(
+            writingLanguage,
+            '替代输出仍不符合审稿报告合同',
+            'the replacement output still does not match the review-report contract',
+          )
+        throw new Error(text(
+          `AI 返回的审稿结果两次均无效（${rebuildDetail}），因此未保存报告。`
+            + '若此问题反复出现，通常是审稿输出被模型最大长度截断：请提高模型的最大输出 Tokens 后重试。',
+          `The AI review response was invalid twice (${rebuildDetail}), so no report was saved. `
+            + 'If this keeps happening, the review output is usually truncated by the model maximum length: increase the model maximum output tokens and retry.',
+        ))
+      }
     }
+    this.assertNotCancelled(context)
 
     const blueprint = await ipc.invokeWithProjectSession(
       projectSession, 'db:blueprint-get', this.params.chapterNumber, context.projectPath,
@@ -380,7 +441,7 @@ export class ReviewChapterCommand extends BaseWorkflowCommand<string> {
       `审查完成，已生成审稿报告 r${revIndex}`,
       `Review complete; created review report r${revIndex}`,
     ))
-    return reviewResultClean
+    return this.stripThinkingTags(reviewResultRaw)
   }
 
   private async readCharacterStates(

--- a/src/services/workflows/commands/review-chapter.command.ts
+++ b/src/services/workflows/commands/review-chapter.command.ts
@@ -322,8 +322,8 @@ export class ReviewChapterCommand extends BaseWorkflowCommand<string> {
       const rebuildHeading = promptLanguageText(writingLanguage, '【原始审稿任务】', '[Original review task]')
       const rebuildContract = promptLanguageText(
         writingLanguage,
-        '【硬性要求】只重新输出一个完整审稿 JSON：summary 不超过 120 字符；items 为 1–10 条，每条含 category、severity(error|warning|pass)、description(≤200 字符)、可选 quote(≤160 字符)；不得输出额外字段、Markdown、解释或思考过程。',
-        '[Hard requirement] Output one complete review JSON only: summary within 120 characters; items 1–10 entries, each with category, severity(error|warning|pass), description(≤200 characters), optional quote(≤160 characters); no extra fields, Markdown, explanation, or reasoning.',
+        '【硬性要求】只重新输出一个完整审稿 JSON：summary 不超过 120 字符；items 为 1–10 条，每条含 category、severity(error|warning|pass)、description(≤200 字符)；quote 仅 pass 可省略，error/warning 必须提供且不超过 160 字符；不得输出额外字段、Markdown、解释或思考过程。',
+        '[Hard requirement] Output one complete review JSON only: summary within 120 characters; items 1–10 entries, each with category, severity(error|warning|pass), description(≤200 characters); quote is optional only for pass items and required (≤160 characters) for error/warning items; no extra fields, Markdown, explanation, or reasoning.',
       )
       reviewResultRaw = await this.callLLMWithBoundedCompletion(
         [rebuildInstruction, rebuildHeading, reviewPrompt, rebuildContract].join('\n\n'),


### PR DESCRIPTION
## Summary
When the first review response fails contract validation (truncated JSON reported as `finishReason=stop`, prose around JSON, contract violations), `review-chapter.command.ts` now sends **one complete replacement request** under the review-report contract before failing. Previously a `stop`-reported truncated JSON failed immediately with no rebuild attempt and no diagnostic.

The final error now distinguishes "output is not complete JSON (possibly truncated)" from "output violates the review-report contract", and suggests raising the model maximum output tokens when truncation recurs.

## Tests
- `mutation-failure-boundary.test.ts` updated: invalid-output cases assert the one-rebuild-then-fail-closed contract with nothing persisted, plus a new case covering a `stop`-reported truncated review recovered via the replacement request. Verified: `tsc` clean, 86 tests pass (mutation-failure-boundary 50 incl. new case, refine-draft 37). Suggested by review on PR #198 to keep this fix as its own PR.