### PR TITLE
ci: add automatic desktop PR checks

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,0 +1,78 @@
+name: PR CI
+
+on:
+  pull_request:
+    branches: [master]
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+
+# Test untrusted PR code without repository write access or model credentials.
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  desktop:
+    name: Desktop PR CI (Windows)
+    runs-on: windows-2022
+    timeout-minutes: 45
+    defaults:
+      run:
+        shell: pwsh
+    env:
+      CI: 'true'
+
+    steps:
+      # Default PR checkout tests the proposed merge, not an unrelated branch.
+      - name: Check out source
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
+
+      # Keep the toolchain aligned with the existing Windows release workflow.
+      - name: Set up pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
+        with:
+          version: 11.11.0
+
+      - name: Set up Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 22.23.1
+
+      - name: Record tested commit
+        run: git rev-parse HEAD
+
+      - name: Install locked dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type-check
+        run: pnpm run typecheck
+
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Check translation coverage
+        run: pnpm run check:i18n
+
+      - name: Prepare and verify Node native modules
+        run: pnpm run prepare:native-node
+
+      - name: Run complete desktop unit test suite
+        run: pnpm test
+
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install chromium
+
+      - name: Run renderer browser tests
+        run: pnpm run test:browser
+
+      # Compile only: do not rebuild for Electron, package installers, or publish.
+      - name: Compile renderer and Electron sources
+        run: pnpm run build
+
+      # Intentionally no artifact uploads or dependency cache: keep this daily
+      # gate separate from retained, release-qualified Windows/macOS packages.

--- a/scripts/__tests__/release-version.test.ts
+++ b/scripts/__tests__/release-version.test.ts
@@ -77,53 +77,38 @@ describe('v1.1.0 release metadata', () => {
     for (const line of [...zhRetained, ...enRetained]) expect(notes).toContain(line)
   })
 
-  it('documents the bilingual v0.9.0 feature set, platform coverage, and security disclosure', () => {
+  it('documents current desktop downloads and signing disclosures in both READMEs', () => {
     const chineseReadme = readFileSync('README.md', 'utf8')
     const englishReadme = readFileSync('README_en.md', 'utf8')
 
-    for (const expected of [
-      'v0.9.0',
-      '长篇一致性上下文继承',
-      '伏笔与叙事线索系统',
-      'EPUB 导入',
-      '缩放、平移和一键清空',
-      '章节模型与字数控制',
-      '人工审稿闭环',
-      '差异对比',
-      '模型高级设置',
-      '获取模型列表',
-      '重复任务',
-      '更准确的失败提示',
-      'macOS Apple Silicon',
-      'macOS Intel',
-      '七项资产',
-      '未代码签名',
-      '未公证',
-    ]) {
-      expect(chineseReadme).toContain(expected)
+    // Current release metadata is checked above; README wording can evolve.
+    for (const readme of [chineseReadme, englishReadme]) {
+      for (const expected of [
+        'Windows x64',
+        'Apple Silicon',
+        'Intel',
+        'https://github.com/EthanYoQ/AI-Novel-Writer/releases/latest',
+      ]) expect(readme).toContain(expected)
+
+      for (const installer of [
+        /ai-novel-writer-setup-<[^>\r\n]+>\.exe/u,
+        /ai-novel-writer-mac-arm64-<[^>\r\n]+>-installer\.dmg/u,
+        /ai-novel-writer-mac-x64-<[^>\r\n]+>-installer\.dmg/u,
+      ]) expect(readme).toMatch(installer)
     }
 
     for (const expected of [
-      'v0.9.0',
-      'Long-form continuity context',
-      'Foreshadowing and narrative threads',
-      'EPUB import',
-      'zoom, pan, or clear',
-      'Per-chapter model and length control',
-      'Human-confirmed review loop',
-      'inspect the diff',
-      'Advanced model settings',
-      'fetch the model list',
-      'Duplicate jobs',
-      'More precise failure messages',
-      'macOS Apple Silicon',
-      'macOS Intel',
-      'seven-asset',
+      '尚未进行代码签名',
+      'ad-hoc 签名',
+      '未使用 Developer ID 签名或公证',
+    ]) expect(chineseReadme).toContain(expected)
+
+    for (const expected of [
       'not code-signed',
+      'ad-hoc signed',
+      'no Developer ID signature',
       'not notarized',
-    ]) {
-      expect(englishReadme).toContain(expected)
-    }
+    ]) expect(englishReadme).toContain(expected)
   })
 
   it('keeps stale Mythpen branding out of release metadata', () => {


### PR DESCRIPTION
## Purpose
Add the missing automatic desktop PR CI requested by the maintainer. This is deterministic test/build CI, not another AI code-review integration.

## Scope
Two files only: `.github/workflows/pr-ci.yml` and `scripts/__tests__/release-version.test.ts`. Application code, README content, DSH plugin CI, release qualification/publishing, and model configuration are unchanged.

- Runs for PRs targeting `master` on opened, synchronize, reopened, and ready_for_review; also supports manual dispatch once available on the default branch.
- Uses the existing pinned Actions and Windows toolchain: `windows-2022`, Node `22.23.1`, pnpm `11.11.0`.
- Installs locked dependencies; runs typecheck, lint, i18n coverage, explicit Node/SQLite ABI preparation, the complete desktop unit suite, Playwright Chromium browser tests, and `pnpm run build` (compile only).
- Fails on a required command failure. New pushes cancel stale runs on the same PR. Timeout: 45 minutes.
- Read-only repository token, checkout credentials not persisted, no model credentials, no `pull_request_target`, no installer builds, no artifact uploads, no dependency cache.
- Leaves release-platform qualification separate; this Windows PR gate is not macOS or packaged-app acceptance.

## Maintainer-approved test repair
Commit `aeb6f293225eba3fbc5eafa4c8c5bf1547babd6f` replaces the obsolete README requirement for v0.9.0 promotional wording with checks for current bilingual desktop downloads and signing disclosures. The existing current-version, exact seven-asset, release-note, branding, and executable checks remain unchanged. No tests were skipped and no timeouts or pass criteria were loosened. The maintainer approved repairing the test and validating CI only, not merging or publishing.

## Validation
**Latest real CI result: PASS**, [run 34202814156, attempt 2, job 101989522480](https://github.com/EthanYoQ/AI-Novel-Writer/actions/runs/34202814156/job/101989522480), HEAD `aeb6f293225eba3fbc5eafa4c8c5bf1547babd6f`. Completed 2026-09-08 08:27:51 UTC. Typecheck, lint, i18n coverage, native-module preparation, complete desktop unit-test suite, Playwright Chromium installation, renderer browser tests, and compilation all succeeded. This was one unchanged-job rerun, not another code change.

Run history is retained rather than hiding the earlier failures:
- Original run [34194254617](https://github.com/EthanYoQ/AI-Novel-Writer/actions/runs/34194254617): 2720 tests passed, 1 failed, 9 skipped. The failure was the obsolete README assertion.
- Repair run 34202814156, attempt 1: all 6 release-version tests passed, confirming the approved repair, but separate tests timed out: `locale-shell.interaction.test.ts` beforeAll (30 seconds), `update-section.interaction.test.ts` beforeAll (30 seconds), and `recovery-candidate-migration.test.ts` legacy identity test (5 seconds). Summary: 290 test files passed, 3 failed; 2703 tests passed, 1 failed, 26 skipped, including cases skipped after setup failures. Dedicated browser and compile steps did not execute in that attempt.
- Attempt 2 passed without modifying code, test timeouts, or assertions. The earlier timeout failures did not reproduce, but this does not establish that timing sensitivity is permanently fixed. No unrelated repair was made.
- Local validation covered syntax, the changed assertions against retrieved README installation excerpts, and 12 removal checks for critical disclosures; it was not a full local repository test run.

## Enablement
This PR remains open and unmerged. After review, merging it to `master` makes the workflow available to future PRs. The stable check name to add to an existing branch rule is **Desktop PR CI (Windows)**. No branch protection or required-check settings have been modified. This task does not authorize merge, auto-merge, or release.