### PR TITLE
fix: 修复角色图谱保存无响应并支持粘贴导入角色卡

### DIFF
--- a/src/components/characters/CharacterCardImportButton.tsx
+++ b/src/components/characters/CharacterCardImportButton.tsx
@@ -17,6 +17,35 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, Di
 
 interface Props { projectKey: string; compact?: boolean; disabled?: boolean }
 
+interface ImportDraft {
+  source: string
+  files: PlanningMaterial[]
+}
+
+const importDrafts = new Map<string, ImportDraft>()
+let activeImportSessionKey: string | null = null
+
+function importSessionKey(session: ProjectSessionContext): string {
+  return `${session.projectId}:${session.leaseId}:${session.projectPath}`
+}
+
+function readImportDraft(session: ProjectSessionContext): ImportDraft {
+  const key = importSessionKey(session)
+  if (activeImportSessionKey !== key) {
+    importDrafts.clear()
+    activeImportSessionKey = key
+  }
+  return importDrafts.get(key) ?? { source: '', files: [] }
+}
+
+function writeImportDraft(session: ProjectSessionContext, draft: ImportDraft): void {
+  importDrafts.set(importSessionKey(session), draft)
+}
+
+function clearImportDraft(session: ProjectSessionContext): void {
+  importDrafts.delete(importSessionKey(session))
+}
+
 export function CharacterCardImportButton(props: Props) {
   const project = useProjectStore(state => state.currentProject)
   const session = captureProjectSession(project)
@@ -26,9 +55,10 @@ export function CharacterCardImportButton(props: Props) {
 
 function SessionImportButton({ session, compact, disabled }: Props & { session: ProjectSessionContext }) {
   const { locale, text } = useLocaleStore()
+  const [initialDraft] = useState(() => readImportDraft(session))
   const [open, setOpen] = useState(false)
-  const [source, setSource] = useState('')
-  const [files, setFiles] = useState<PlanningMaterial[]>([])
+  const [source, setSource] = useState(initialDraft.source)
+  const [files, setFiles] = useState<PlanningMaterial[]>(initialDraft.files)
   const [busy, setBusy] = useState(false)
   const label = text('粘贴 / 导入角色卡', 'Paste / import character cards')
 
@@ -36,7 +66,10 @@ function SessionImportButton({ session, compact, disabled }: Props & { session: 
     setBusy(true)
     try {
       const selected = await selectPlanningMaterials()
-      if (isProjectSessionCurrent(session) && selected.length) setFiles(selected)
+      if (isProjectSessionCurrent(session) && selected.length) {
+        writeImportDraft(session, { source, files: selected })
+        setFiles(selected)
+      }
     } catch (error) {
       if (isProjectSessionCurrent(session)) toast.error(appErrorMessage(locale, error))
     } finally {
@@ -85,6 +118,7 @@ function SessionImportButton({ session, compact, disabled }: Props & { session: 
       if (run?.status === 'completed') {
         setSource('')
         setFiles([])
+        clearImportDraft(session)
         toast.success(text('角色卡已导入角色名单', 'Character cards imported into the roster'))
       } else {
         setOpen(true)
@@ -111,9 +145,16 @@ function SessionImportButton({ session, compact, disabled }: Props & { session: 
           <DialogDescription>{text('粘贴完整角色卡，或选择资料文件。AI 提取后由你预览确认，不会自动保存。', 'Paste full character cards or choose files. Preview and confirm the AI extraction before saving.')}</DialogDescription>
         </DialogHeader>
         <div className="p-6 space-y-3">
-          <textarea aria-label={text('角色卡全文', 'Full character-card text')} value={source} onChange={event => setSource(event.target.value)} disabled={busy} rows={9} className="w-full rounded border border-[var(--color-border)] bg-[var(--color-bg)] p-2 text-sm" />
+          <textarea aria-label={text('角色卡全文', 'Full character-card text')} value={source} onChange={event => {
+            const nextSource = event.target.value
+            writeImportDraft(session, { source: nextSource, files })
+            setSource(nextSource)
+          }} disabled={busy} rows={9} className="w-full rounded border border-[var(--color-border)] bg-[var(--color-bg)] p-2 text-sm" />
           <Button variant="outline" size="sm" disabled={busy} onClick={() => void chooseFiles()}><FileUp size={14} />{text('选择文件', 'Choose files')}</Button>
-          {files.length > 0 && <div className="text-xs break-all">{files.map(file => file.fileName).join('、')} <Button variant="ghost" size="sm" disabled={busy} onClick={() => setFiles([])}>{text('清除文件', 'Clear files')}</Button></div>}
+          {files.length > 0 && <div className="text-xs break-all">{files.map(file => file.fileName).join('、')} <Button variant="ghost" size="sm" disabled={busy} onClick={() => {
+            writeImportDraft(session, { source, files: [] })
+            setFiles([])
+          }}>{text('清除文件', 'Clear files')}</Button></div>}
         </div>
         <DialogFooter>
           <Button variant="ghost" disabled={busy} onClick={() => setOpen(false)}>{text('暂不导入', 'Not now')}</Button>

--- a/src/components/characters/CharacterCardImportButton.tsx
+++ b/src/components/characters/CharacterCardImportButton.tsx
@@ -1,0 +1,125 @@
+import { useState } from 'react'
+import { ClipboardPaste, FileUp } from 'lucide-react'
+import { useProjectStore } from '../../stores/project-store'
+import { useLocaleStore } from '../../stores/locale-store'
+import { useLLMStore } from '../../stores/llm-store'
+import { useLayoutStore } from '../../stores/layout-store'
+import { useWorkflowStore, workflowResourceConflictMessage } from '../../stores/workflow-store'
+import { selectPlanningMaterials, type PlanningMaterial } from '../../services/knowledge-service'
+import { createPlanningMaterialCharacterExtractionWorkflow } from '../../services/workflows/planning-material-workflow'
+import type { ProjectSessionContext } from '../../shared/ipc-channels'
+import { appErrorMessage } from '../../i18n/app-errors'
+import { captureProjectSession, isProjectSessionCurrent, isProjectSessionPath } from '../project-session-gate'
+import { Button } from '../ui/Button'
+import { confirm } from '../ui/Confirm'
+import { toast } from '../ui/Toast'
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '../ui/Dialog'
+
+interface Props { projectKey: string; compact?: boolean; disabled?: boolean }
+
+export function CharacterCardImportButton(props: Props) {
+  const project = useProjectStore(state => state.currentProject)
+  const session = captureProjectSession(project)
+  if (!session || !isProjectSessionPath(session, props.projectKey)) return null
+  return <SessionImportButton key={JSON.stringify(session)} {...props} session={session} />
+}
+
+function SessionImportButton({ session, compact, disabled }: Props & { session: ProjectSessionContext }) {
+  const { locale, text } = useLocaleStore()
+  const [open, setOpen] = useState(false)
+  const [source, setSource] = useState('')
+  const [files, setFiles] = useState<PlanningMaterial[]>([])
+  const [busy, setBusy] = useState(false)
+  const label = text('粘贴 / 导入角色卡', 'Paste / import character cards')
+
+  async function chooseFiles() {
+    setBusy(true)
+    try {
+      const selected = await selectPlanningMaterials()
+      if (isProjectSessionCurrent(session) && selected.length) setFiles(selected)
+    } catch (error) {
+      if (isProjectSessionCurrent(session)) toast.error(appErrorMessage(locale, error))
+    } finally {
+      if (isProjectSessionCurrent(session)) setBusy(false)
+    }
+  }
+
+  async function extract() {
+    if (busy || !isProjectSessionCurrent(session)) return
+    const materials = [...files]
+    if (source.trim()) materials.push({ fileName: text('粘贴的角色卡.txt', 'Pasted character cards.txt'), text: source })
+    if (!materials.length) return
+    const llm = useLLMStore.getState()
+    const model = llm.models.find(candidate => candidate.id === llm.defaultModelId)
+    if (!model) {
+      toast.warning(text('请先到设置 → 模型配置，添加并选择默认生成模型；输入内容已保留。', 'Add and select a default generation model in Settings → Models first. Your input has been kept.'))
+      return
+    }
+    setBusy(true)
+    // The shared confirmation owns its own modal; release this focus trap first.
+    setOpen(false)
+    try {
+      const allowed = await confirm(text(
+        `本次粘贴及选中文件的全部文本将发送到以下模型端点，用于提取角色卡。提取后需预览并确认，才会写入角色名单；不会直接覆盖角色图谱。\n\n模型：${model.name} (${model.modelName})\n端点：${model.baseUrl}\n\n是否发送并提取？`,
+        `All pasted text and selected files will be sent to the following model endpoint to extract character cards. Preview and confirmation are required before saving to the roster; the character graph will not be overwritten directly.\n\nModel: ${model.name} (${model.modelName})\nEndpoint: ${model.baseUrl}\n\nSend and extract?`,
+      ), { title: text('AI 提取角色卡', 'AI character-card extraction'), confirmText: text('发送并提取', 'Send and extract') })
+      if (!isProjectSessionCurrent(session)) return
+      setOpen(true)
+      if (!allowed) return
+      const currentModel = useLLMStore.getState().models.find(candidate => candidate.id === model.id)
+      if (!currentModel || currentModel.baseUrl !== model.baseUrl || currentModel.modelName !== model.modelName) {
+        toast.warning(text('模型配置已改变，请重新确认后发送。', 'The model configuration changed. Confirm again before sending.'))
+        return
+      }
+      const workflow = createPlanningMaterialCharacterExtractionWorkflow({ projectSession: session, materials, generationModelId: model.id }, locale)
+      const conflict = useWorkflowStore.getState().getResourceConflict(workflow)
+      if (conflict) {
+        toast.warning(workflowResourceConflictMessage(locale, conflict.title))
+        return
+      }
+      setOpen(false)
+      useLayoutStore.getState().openBottomTab('tasks')
+      const runId = await useWorkflowStore.getState().startWorkflow(workflow, true)
+      if (!isProjectSessionCurrent(session)) return
+      const run = useWorkflowStore.getState().history.find(candidate => candidate.id === runId)
+      if (run?.status === 'completed') {
+        setSource('')
+        setFiles([])
+        toast.success(text('角色卡已导入角色名单', 'Character cards imported into the roster'))
+      } else {
+        setOpen(true)
+        toast.warning(text('导入未完成，输入内容已保留；请查看任务详情。', 'Import did not complete. Your input has been kept; check the task details.'))
+      }
+    } catch (error) {
+      if (isProjectSessionCurrent(session)) {
+        setOpen(true)
+        toast.error(appErrorMessage(locale, error))
+      }
+    } finally {
+      if (isProjectSessionCurrent(session)) setBusy(false)
+    }
+  }
+
+  return <>
+    <Button variant="ghost" size={compact ? 'icon' : 'sm'} className={compact ? 'h-6 w-6' : undefined} disabled={disabled || busy} title={label} aria-label={label} onClick={() => setOpen(true)}>
+      <ClipboardPaste size={14} />{!compact && label}
+    </Button>
+    <Dialog open={open} onOpenChange={value => { if (!busy) setOpen(value) }}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{label}</DialogTitle>
+          <DialogDescription>{text('粘贴完整角色卡，或选择资料文件。AI 提取后由你预览确认，不会自动保存。', 'Paste full character cards or choose files. Preview and confirm the AI extraction before saving.')}</DialogDescription>
+        </DialogHeader>
+        <div className="p-6 space-y-3">
+          <textarea aria-label={text('角色卡全文', 'Full character-card text')} value={source} onChange={event => setSource(event.target.value)} disabled={busy} rows={9} className="w-full rounded border border-[var(--color-border)] bg-[var(--color-bg)] p-2 text-sm" />
+          <Button variant="outline" size="sm" disabled={busy} onClick={() => void chooseFiles()}><FileUp size={14} />{text('选择文件', 'Choose files')}</Button>
+          {files.length > 0 && <div className="text-xs break-all">{files.map(file => file.fileName).join('、')} <Button variant="ghost" size="sm" disabled={busy} onClick={() => setFiles([])}>{text('清除文件', 'Clear files')}</Button></div>}
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" disabled={busy} onClick={() => setOpen(false)}>{text('暂不导入', 'Not now')}</Button>
+          <Button disabled={busy || (!source.trim() && !files.length)} onClick={() => void extract()}>{busy ? text('处理中…', 'Working…') : text('AI 提取并预览', 'Extract and preview with AI')}</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  </>
+}

--- a/src/components/characters/CharacterCardImportButton.tsx
+++ b/src/components/characters/CharacterCardImportButton.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useCallback, useEffect, useState, useSyncExternalStore } from 'react'
 import { ClipboardPaste, FileUp } from 'lucide-react'
 import { useProjectStore } from '../../stores/project-store'
 import { useLocaleStore } from '../../stores/locale-store'
@@ -22,28 +22,45 @@ interface ImportDraft {
   files: PlanningMaterial[]
 }
 
-const importDrafts = new Map<string, ImportDraft>()
+const importDraftListeners = new Set<() => void>()
+const EMPTY_IMPORT_DRAFT: ImportDraft = { source: '', files: [] }
 let activeImportSessionKey: string | null = null
+let activeImportDraft: ImportDraft = EMPTY_IMPORT_DRAFT
 
 function importSessionKey(session: ProjectSessionContext): string {
   return `${session.projectId}:${session.leaseId}:${session.projectPath}`
 }
 
-function readImportDraft(session: ProjectSessionContext): ImportDraft {
-  const key = importSessionKey(session)
-  if (activeImportSessionKey !== key) {
-    importDrafts.clear()
-    activeImportSessionKey = key
-  }
-  return importDrafts.get(key) ?? { source: '', files: [] }
+function notifyImportDraftListeners(): void {
+  for (const listener of importDraftListeners) listener()
 }
 
-function writeImportDraft(session: ProjectSessionContext, draft: ImportDraft): void {
-  importDrafts.set(importSessionKey(session), draft)
+function readImportDraft(key: string): ImportDraft {
+  return activeImportSessionKey === key ? activeImportDraft : EMPTY_IMPORT_DRAFT
 }
 
-function clearImportDraft(session: ProjectSessionContext): void {
-  importDrafts.delete(importSessionKey(session))
+function activateImportSession(key: string): void {
+  if (activeImportSessionKey === key) return
+  activeImportSessionKey = key
+  activeImportDraft = EMPTY_IMPORT_DRAFT
+  notifyImportDraftListeners()
+}
+
+function writeImportDraft(key: string, draft: ImportDraft): void {
+  if (activeImportSessionKey !== key) return
+  activeImportDraft = draft
+  notifyImportDraftListeners()
+}
+
+function clearImportDraftIfCurrent(key: string, expectedDraft: ImportDraft): void {
+  if (activeImportSessionKey !== key || activeImportDraft !== expectedDraft) return
+  activeImportDraft = EMPTY_IMPORT_DRAFT
+  notifyImportDraftListeners()
+}
+
+function subscribeImportDraft(listener: () => void): () => void {
+  importDraftListeners.add(listener)
+  return () => importDraftListeners.delete(listener)
 }
 
 export function CharacterCardImportButton(props: Props) {
@@ -55,20 +72,25 @@ export function CharacterCardImportButton(props: Props) {
 
 function SessionImportButton({ session, compact, disabled }: Props & { session: ProjectSessionContext }) {
   const { locale, text } = useLocaleStore()
-  const [initialDraft] = useState(() => readImportDraft(session))
+  const sessionKey = importSessionKey(session)
+  const draft = useSyncExternalStore(
+    subscribeImportDraft,
+    useCallback(() => readImportDraft(sessionKey), [sessionKey]),
+  )
+  useEffect(() => {
+    activateImportSession(sessionKey)
+  }, [sessionKey])
   const [open, setOpen] = useState(false)
-  const [source, setSource] = useState(initialDraft.source)
-  const [files, setFiles] = useState<PlanningMaterial[]>(initialDraft.files)
   const [busy, setBusy] = useState(false)
   const label = text('粘贴 / 导入角色卡', 'Paste / import character cards')
 
   async function chooseFiles() {
+    const draftWhenSelected = draft
     setBusy(true)
     try {
       const selected = await selectPlanningMaterials()
-      if (isProjectSessionCurrent(session) && selected.length) {
-        writeImportDraft(session, { source, files: selected })
-        setFiles(selected)
+      if (isProjectSessionCurrent(session) && selected.length && readImportDraft(sessionKey) === draftWhenSelected) {
+        writeImportDraft(sessionKey, { source: draftWhenSelected.source, files: selected })
       }
     } catch (error) {
       if (isProjectSessionCurrent(session)) toast.error(appErrorMessage(locale, error))
@@ -79,8 +101,9 @@ function SessionImportButton({ session, compact, disabled }: Props & { session: 
 
   async function extract() {
     if (busy || !isProjectSessionCurrent(session)) return
-    const materials = [...files]
-    if (source.trim()) materials.push({ fileName: text('粘贴的角色卡.txt', 'Pasted character cards.txt'), text: source })
+    const submittedDraft = draft
+    const materials = [...submittedDraft.files]
+    if (submittedDraft.source.trim()) materials.push({ fileName: text('粘贴的角色卡.txt', 'Pasted character cards.txt'), text: submittedDraft.source })
     if (!materials.length) return
     const llm = useLLMStore.getState()
     const model = llm.models.find(candidate => candidate.id === llm.defaultModelId)
@@ -116,9 +139,7 @@ function SessionImportButton({ session, compact, disabled }: Props & { session: 
       if (!isProjectSessionCurrent(session)) return
       const run = useWorkflowStore.getState().history.find(candidate => candidate.id === runId)
       if (run?.status === 'completed') {
-        setSource('')
-        setFiles([])
-        clearImportDraft(session)
+        clearImportDraftIfCurrent(sessionKey, submittedDraft)
         toast.success(text('角色卡已导入角色名单', 'Character cards imported into the roster'))
       } else {
         setOpen(true)
@@ -145,20 +166,18 @@ function SessionImportButton({ session, compact, disabled }: Props & { session: 
           <DialogDescription>{text('粘贴完整角色卡，或选择资料文件。AI 提取后由你预览确认，不会自动保存。', 'Paste full character cards or choose files. Preview and confirm the AI extraction before saving.')}</DialogDescription>
         </DialogHeader>
         <div className="p-6 space-y-3">
-          <textarea aria-label={text('角色卡全文', 'Full character-card text')} value={source} onChange={event => {
+          <textarea aria-label={text('角色卡全文', 'Full character-card text')} value={draft.source} onChange={event => {
             const nextSource = event.target.value
-            writeImportDraft(session, { source: nextSource, files })
-            setSource(nextSource)
+            writeImportDraft(sessionKey, { source: nextSource, files: draft.files })
           }} disabled={busy} rows={9} className="w-full rounded border border-[var(--color-border)] bg-[var(--color-bg)] p-2 text-sm" />
           <Button variant="outline" size="sm" disabled={busy} onClick={() => void chooseFiles()}><FileUp size={14} />{text('选择文件', 'Choose files')}</Button>
-          {files.length > 0 && <div className="text-xs break-all">{files.map(file => file.fileName).join('、')} <Button variant="ghost" size="sm" disabled={busy} onClick={() => {
-            writeImportDraft(session, { source, files: [] })
-            setFiles([])
+          {draft.files.length > 0 && <div className="text-xs break-all">{draft.files.map(file => file.fileName).join('、')} <Button variant="ghost" size="sm" disabled={busy} onClick={() => {
+            writeImportDraft(sessionKey, { source: draft.source, files: [] })
           }}>{text('清除文件', 'Clear files')}</Button></div>}
         </div>
         <DialogFooter>
           <Button variant="ghost" disabled={busy} onClick={() => setOpen(false)}>{text('暂不导入', 'Not now')}</Button>
-          <Button disabled={busy || (!source.trim() && !files.length)} onClick={() => void extract()}>{busy ? text('处理中…', 'Working…') : text('AI 提取并预览', 'Extract and preview with AI')}</Button>
+          <Button disabled={busy || (!draft.source.trim() && !draft.files.length)} onClick={() => void extract()}>{busy ? text('处理中…', 'Working…') : text('AI 提取并预览', 'Extract and preview with AI')}</Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/components/characters/__tests__/CharacterCardImportButton.browser.tsx
+++ b/src/components/characters/__tests__/CharacterCardImportButton.browser.tsx
@@ -1,0 +1,130 @@
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { page } from 'vitest/browser'
+import { CharacterCardImportButton } from '../CharacterCardImportButton'
+import { useProjectStore } from '../../../stores/project-store'
+import { useLocaleStore } from '../../../stores/locale-store'
+import { useLLMStore } from '../../../stores/llm-store'
+import { useWorkflowStore } from '../../../stores/workflow-store'
+import { setActiveProjectSessionContext } from '../../../shared/project-session-context'
+import type { ProjectData } from '../../../shared/ipc-channels'
+
+const project = { id: 'paste', path: 'C:\\novels\\paste', sessionLease: 'lease-1' } as ProjectData
+const model = { id: 'model', name: 'Test model', modelName: 'test', baseUrl: 'https://example.invalid' } as ReturnType<typeof useLLMStore.getState>['models'][number]
+;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+const originals = { project: useProjectStore.getState(), locale: useLocaleStore.getState(), llm: useLLMStore.getState(), workflow: useWorkflowStore.getState() }
+let root: Root
+let container: HTMLDivElement
+let start: ReturnType<typeof vi.fn<ReturnType<typeof useWorkflowStore.getState>['startWorkflow']>>
+let invoke: ReturnType<typeof vi.fn>
+
+function button(label: string) {
+  const result = [...document.querySelectorAll('button')].find(node => node.textContent === label || node.getAttribute('aria-label') === label)
+  expect(result, label).toBeTruthy()
+  return result!
+}
+async function click(label: string) {
+  await act(async () => button(label).click())
+  // Existing confirmation dialogs resolve after their 200 ms exit animation.
+  await act(async () => { await new Promise(resolve => setTimeout(resolve, 250)) })
+}
+async function paste(value: string) {
+  await act(async () => page.getByRole('textbox', { name: '角色卡全文' }).fill(value))
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks()
+  invoke = vi.fn().mockResolvedValue(null)
+  Object.defineProperty(window, 'velaAPI', { configurable: true, value: { invoke, on: vi.fn(() => () => {}), once: vi.fn(), send: vi.fn() } })
+  start = vi.fn<ReturnType<typeof useWorkflowStore.getState>['startWorkflow']>().mockResolvedValue('failed-run')
+  useLocaleStore.setState({ locale: 'zh-CN', initialized: true })
+  useProjectStore.setState({ currentProject: project })
+  setActiveProjectSessionContext({ projectId: project.id, projectPath: project.path, leaseId: project.sessionLease! })
+  useLLMStore.setState({ models: [model], defaultModelId: model.id })
+  useWorkflowStore.setState({ startWorkflow: start, history: [], getResourceConflict: () => null })
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+  await act(async () => root.render(<CharacterCardImportButton projectKey={project.path} />))
+  await click('粘贴 / 导入角色卡')
+})
+
+afterEach(async () => {
+  await act(async () => root.unmount())
+  container.remove()
+  Reflect.deleteProperty(window, 'velaAPI')
+  setActiveProjectSessionContext(null)
+  useProjectStore.setState(originals.project)
+  useLocaleStore.setState(originals.locale)
+  useLLMStore.setState(originals.llm)
+  useWorkflowStore.setState(originals.workflow)
+})
+
+describe('角色卡导入入口', () => {
+  it('发送前需同意，取消同意后保留全文且不启动工作流', async () => {
+    await paste('姓名：林舟\n背景：旧港调查员')
+    await click('AI 提取并预览')
+    expect(document.body.textContent).toContain(model.baseUrl)
+    await click('取消')
+    expect(start).not.toHaveBeenCalled()
+    expect(document.querySelector('textarea')?.value).toContain('旧港调查员')
+  })
+
+  it('使用已有提取工作流与逐步确认，失败不丢失粘贴内容', async () => {
+    await paste('姓名：林舟')
+    await click('AI 提取并预览')
+    await click('发送并提取')
+    expect(start).toHaveBeenCalledWith(expect.objectContaining({
+      generationModelId: model.id,
+      projectSession: { projectId: project.id, projectPath: project.path, leaseId: project.sessionLease },
+      steps: [expect.objectContaining({ name: '生成待确认角色卡' }), expect.objectContaining({ name: '确认并导入角色卡' })],
+    }), true)
+    expect(document.querySelector('textarea')?.value).toBe('姓名：林舟')
+  })
+
+  it('没有模型时给出设置指引并保留输入', async () => {
+    useLLMStore.setState({ models: [], defaultModelId: null })
+    await paste('姓名：林舟')
+    await click('AI 提取并预览')
+    expect(document.body.textContent).toContain('模型配置')
+    expect(start).not.toHaveBeenCalled()
+    expect(document.querySelector('textarea')?.value).toBe('姓名：林舟')
+  })
+
+  it('文件读取期间同路径项目重新打开，不将旧文件带入新会话', async () => {
+    let resolve!: (result: { success: true; content: string }) => void
+    invoke.mockImplementation((channel: string) => channel === 'dialog:select-knowledge-files'
+      ? Promise.resolve([{ grantId: 'grant', displayName: '旧项目私有角色.txt' }])
+      : new Promise(done => { resolve = done }))
+    await click('选择文件')
+    await act(async () => {
+      setActiveProjectSessionContext({ projectId: project.id, projectPath: project.path, leaseId: 'lease-2' })
+      useProjectStore.setState({ currentProject: { ...project, sessionLease: 'lease-2' } })
+      resolve({ success: true, content: '旧项目内容' })
+    })
+    await click('粘贴 / 导入角色卡')
+    expect(document.body.textContent).not.toContain('旧项目私有角色.txt')
+    expect(document.querySelector('textarea')?.value).toBe('')
+    expect(start).not.toHaveBeenCalled()
+  })
+
+  it('文件选择只读取授权文件，不自动发送；提取成功后清空临时输入', async () => {
+    invoke.mockImplementation((channel: string) => Promise.resolve(channel === 'dialog:select-knowledge-files'
+      ? [{ grantId: 'grant', displayName: '角色.txt' }]
+      : { success: true, content: '姓名：林舟' }))
+    await click('选择文件')
+    expect(document.body.textContent).toContain('角色.txt')
+    expect(start).not.toHaveBeenCalled()
+    start.mockImplementation(async () => {
+      useWorkflowStore.setState({ history: [{ id: 'ok', status: 'completed' } as ReturnType<typeof useWorkflowStore.getState>['history'][number]] })
+      return 'ok'
+    })
+    await click('AI 提取并预览')
+    await click('发送并提取')
+    expect(start).toHaveBeenCalledOnce()
+    await click('粘贴 / 导入角色卡')
+    expect(document.body.textContent).not.toContain('角色.txt')
+    expect(document.querySelector('textarea')?.value).toBe('')
+  })
+})

--- a/src/components/characters/__tests__/CharacterCardImportButton.browser.tsx
+++ b/src/components/characters/__tests__/CharacterCardImportButton.browser.tsx
@@ -112,13 +112,15 @@ describe('角色卡导入入口', () => {
 
   it('文件读取期间同路径项目重新打开，不将旧文件带入新会话', async () => {
     let resolve!: (result: { success: true; content: string }) => void
+    const reopenedLease = `${project.sessionLease}-reopened`
     invoke.mockImplementation((channel: string) => channel === 'dialog:select-knowledge-files'
       ? Promise.resolve([{ grantId: 'grant', displayName: '旧项目私有角色.txt' }])
       : new Promise(done => { resolve = done }))
+    await paste('姓名：旧项目角色')
     await click('选择文件')
     await act(async () => {
-      setActiveProjectSessionContext({ projectId: project.id, projectPath: project.path, leaseId: 'lease-2' })
-      useProjectStore.setState({ currentProject: { ...project, sessionLease: 'lease-2' } })
+      setActiveProjectSessionContext({ projectId: project.id, projectPath: project.path, leaseId: reopenedLease })
+      useProjectStore.setState({ currentProject: { ...project, sessionLease: reopenedLease } })
       resolve({ success: true, content: '旧项目内容' })
     })
     await click('粘贴 / 导入角色卡')
@@ -131,6 +133,7 @@ describe('角色卡导入入口', () => {
     invoke.mockImplementation((channel: string) => Promise.resolve(channel === 'dialog:select-knowledge-files'
       ? [{ grantId: 'grant', displayName: '角色.txt' }]
       : { success: true, content: '姓名：林舟' }))
+    await paste('姓名：林舟')
     await click('选择文件')
     expect(document.body.textContent).toContain('角色.txt')
     expect(start).not.toHaveBeenCalled()
@@ -147,5 +150,29 @@ describe('角色卡导入入口', () => {
     await click('粘贴 / 导入角色卡')
     expect(document.body.textContent).not.toContain('角色.txt')
     expect(document.querySelector('textarea')?.value).toBe('')
+  })
+
+  it('旧任务完成时不会清空重挂载后编辑的新草稿', async () => {
+    let resolveRun!: (runId: string) => void
+    start.mockImplementation(() => new Promise(resolve => { resolveRun = resolve }))
+    invoke.mockImplementation((channel: string) => Promise.resolve(channel === 'dialog:select-knowledge-files'
+      ? [{ grantId: 'grant', displayName: '新角色.txt' }]
+      : { success: true, content: '姓名：林舟' }))
+    await paste('姓名：旧角色')
+    await click('AI 提取并预览')
+    await click('发送并提取')
+    expect(start).toHaveBeenCalledOnce()
+
+    await act(async () => root.unmount())
+    root = createRoot(container)
+    await act(async () => root.render(<CharacterCardImportButton projectKey={project.path} />))
+    await click('粘贴 / 导入角色卡')
+    await paste('姓名：新角色')
+    await click('选择文件')
+
+    useWorkflowStore.setState({ history: [{ id: 'completed-run', status: 'completed' } as ReturnType<typeof useWorkflowStore.getState>['history'][number]] })
+    await act(async () => resolveRun('completed-run'))
+    await vi.waitFor(() => expect(document.querySelector('textarea')?.value).toBe('姓名：新角色'))
+    expect(document.body.textContent).toContain('新角色.txt')
   })
 })

--- a/src/components/characters/__tests__/CharacterCardImportButton.browser.tsx
+++ b/src/components/characters/__tests__/CharacterCardImportButton.browser.tsx
@@ -18,6 +18,7 @@ let root: Root
 let container: HTMLDivElement
 let start: ReturnType<typeof vi.fn<ReturnType<typeof useWorkflowStore.getState>['startWorkflow']>>
 let invoke: ReturnType<typeof vi.fn>
+let testLease = 0
 
 function button(label: string) {
   const result = [...document.querySelectorAll('button')].find(node => node.textContent === label || node.getAttribute('aria-label') === label)
@@ -35,6 +36,7 @@ async function paste(value: string) {
 
 beforeEach(async () => {
   vi.clearAllMocks()
+  project.sessionLease = `lease-${++testLease}`
   invoke = vi.fn().mockResolvedValue(null)
   Object.defineProperty(window, 'velaAPI', { configurable: true, value: { invoke, on: vi.fn(() => () => {}), once: vi.fn(), send: vi.fn() } })
   start = vi.fn<ReturnType<typeof useWorkflowStore.getState>['startWorkflow']>().mockResolvedValue('failed-run')
@@ -92,6 +94,22 @@ describe('角色卡导入入口', () => {
     expect(document.querySelector('textarea')?.value).toBe('姓名：林舟')
   })
 
+  it('导航离开后确认取消，仍恢复粘贴内容和已选文件', async () => {
+    invoke.mockImplementation((channel: string) => Promise.resolve(channel === 'dialog:select-knowledge-files'
+      ? [{ grantId: 'grant', displayName: '角色.txt' }]
+      : { success: true, content: '姓名：林舟' }))
+    await paste('姓名：江澜')
+    await click('选择文件')
+    await click('AI 提取并预览')
+    await act(async () => root.unmount())
+    await click('取消')
+    root = createRoot(container)
+    await act(async () => root.render(<CharacterCardImportButton projectKey={project.path} />))
+    await click('粘贴 / 导入角色卡')
+    expect(document.querySelector('textarea')?.value).toBe('姓名：江澜')
+    expect(document.body.textContent).toContain('角色.txt')
+  })
+
   it('文件读取期间同路径项目重新打开，不将旧文件带入新会话', async () => {
     let resolve!: (result: { success: true; content: string }) => void
     invoke.mockImplementation((channel: string) => channel === 'dialog:select-knowledge-files'
@@ -123,6 +141,9 @@ describe('角色卡导入入口', () => {
     await click('AI 提取并预览')
     await click('发送并提取')
     expect(start).toHaveBeenCalledOnce()
+    await act(async () => root.unmount())
+    root = createRoot(container)
+    await act(async () => root.render(<CharacterCardImportButton projectKey={project.path} />))
     await click('粘贴 / 导入角色卡')
     expect(document.body.textContent).not.toContain('角色.txt')
     expect(document.querySelector('textarea')?.value).toBe('')

--- a/src/components/editor/ArchFileViewer.tsx
+++ b/src/components/editor/ArchFileViewer.tsx
@@ -7,7 +7,10 @@ import ArchitectureConfirmDialog from '../dialogs/ArchitectureConfirmDialog'
 import { Button } from '../ui/Button'
 import { ipc } from '../../services/ipc-client'
 import { requireIpcSuccess } from '../../services/ipc-result'
-import { parseCoreField } from '../../services/vela-protocol'
+import { CORE_FIELD_MAP, parseCoreField } from '../../services/vela-protocol'
+import { appErrorMessage } from '../../i18n/app-errors'
+import { toast } from '../ui/Toast'
+import { CharacterCardImportButton } from '../characters/CharacterCardImportButton'
 import CodeMirrorEditor from './CodeMirrorEditor'
 import { useProjectStore } from '../../stores/project-store'
 import { useLocaleStore } from '../../stores/locale-store'
@@ -50,6 +53,9 @@ const ARCH_META: Record<ArchStepKey, { iconName: string; label: string; labelEn:
 
 /** 从文件路径推断出 ArchStepKey */
 function detectStepKey(filePath: string): ArchStepKey | null {
+  const field = parseCoreField(filePath)
+  const coreKey = Object.keys(CORE_FIELD_MAP).find(key => CORE_FIELD_MAP[key] === field)
+  if (coreKey) return coreKey as ArchStepKey
   if (filePath.endsWith('premise.md')) return 'premise'
   if (filePath.endsWith('characters.md')) return 'characters'
   if (filePath.endsWith('worldbuilding.md')) return 'worldbuilding'
@@ -175,7 +181,7 @@ function ArchFileViewerSession({
   }, [isCharacterProjection, tabId])
 
   /** 保存（统一走 vela://core/ DB 路径） */
-  const handleSave = useCallback(async (md: string) => {
+  const handleSave = useCallback(async (md: string, propagateFailure = false) => {
     if (isCharacterProjection) return
     const projectSession = captureProjectSession(useProjectStore.getState().currentProject)
     if (!projectSession || !isProjectSessionPath(projectSession, projectKey)) {
@@ -221,6 +227,12 @@ function ArchFileViewerSession({
           useEditorStore.getState().updateTabContent(tabId, currentContentRef.current)
         }
       }
+    } catch (error) {
+      if (isProjectSessionCurrent(projectSession)) {
+        toast.error(appErrorMessage(useLocaleStore.getState().locale, error))
+      }
+      // Exit-save must reject so the caller cannot close an unsaved document.
+      if (propagateFailure) throw error
     } finally {
       if (isProjectSessionCurrent(projectSession)) setSaving(false)
     }
@@ -228,11 +240,11 @@ function ArchFileViewerSession({
 
   useEffect(() => {
     if (isCharacterProjection) return
-    registerEditorExitSaveHandler({
+    return registerEditorExitSaveHandler({
       tabId,
       type: 'arch-file',
       projectKey,
-      save: () => handleSave(currentContentRef.current),
+      save: () => handleSave(currentContentRef.current, true),
     })
   }, [handleSave, isCharacterProjection, projectKey, tabId])
 
@@ -444,6 +456,9 @@ function ArchFileViewerSession({
 
         {/* 右侧：字数 + 状态 + 操作按钮 */}
         <div className="flex items-center gap-2 flex-shrink-0">
+          {isCharacterProjection && (
+            <CharacterCardImportButton projectKey={projectKey} disabled={!projectMatches} />
+          )}
 
           {/* 字数 */}
           {charCount > 0 && (

--- a/src/components/editor/ArchFileViewer.tsx
+++ b/src/components/editor/ArchFileViewer.tsx
@@ -240,7 +240,10 @@ function ArchFileViewerSession({
 
   useEffect(() => {
     if (isCharacterProjection) return
-    return registerEditorExitSaveHandler({
+    // EditorArea unmounts the inactive tab. The store removes this handler only
+    // when the tab itself closes, so an inactive dirty document can still save
+    // during application exit.
+    registerEditorExitSaveHandler({
       tabId,
       type: 'arch-file',
       projectKey,

--- a/src/components/editor/CodeMirrorEditor.tsx
+++ b/src/components/editor/CodeMirrorEditor.tsx
@@ -241,6 +241,7 @@ export default function CodeMirrorEditor({
         {
           key: 'Tab',
           run: (target) => {
+            if (target.state.readOnly) return false
             // 插入两个 em 空格（U+2003）= 2em = 标准中文首行缩进两字符宽
             // 使用 \u2003 而非 \u3000（全角空格），因为 em 空格在任何 Unicode 字体下
             // 都精确等于 1em，不依赖 CJK 字体加载
@@ -437,6 +438,7 @@ export default function CodeMirrorEditor({
             theme={cmTheme}
             extensions={extensions}
             readOnly={!editable}
+            editable={editable}
             basicSetup={cmBasicSetup}
             onUpdate={handleUpdate}
           />
@@ -444,7 +446,7 @@ export default function CodeMirrorEditor({
       </div>
 
       {/* Bubble Menu */}
-      {bubbleOpen && bubblePos.top !== 0 && (
+      {bubbleOpen && (editable || aiResult !== null) && bubblePos.top !== 0 && (
         <div
           className="fixed z-50 flex items-center gap-0.5 p-1 rounded-xl border select-none shadow-xl transform -translate-x-1/2 -translate-y-full"
           style={{

--- a/src/components/editor/__tests__/ArchFileViewer.locale.browser.tsx
+++ b/src/components/editor/__tests__/ArchFileViewer.locale.browser.tsx
@@ -129,6 +129,23 @@ describe('ArchFileViewer locale', () => {
     expect(useEditorStore.getState().tabs[0].dirty).toBe(true)
   })
 
+  it('keeps its exit-save handler while an inactive tab is unmounted', async () => {
+    useEditorStore.setState({ tabs: [{
+      id: 'arch-inactive', name: '故事前提', type: 'arch-file',
+      projectKey: PROJECT_PATH, filePath: 'vela://core/premise',
+      content: '待保存内容', savedContent: '', dirty: true,
+    }], draftLedgers: {} })
+    await act(async () => root.render(
+      <ArchFileViewer tabId="arch-inactive" filePath="vela://core/premise"
+        projectKey={PROJECT_PATH} content="待保存内容" savedContent="" />,
+    ))
+
+    await act(async () => root.unmount())
+    await expect(saveDirtyEditorChangesForExit(PROJECT_PATH)).resolves.toBeUndefined()
+    expect(useEditorStore.getState().tabs[0]).toMatchObject({ dirty: false, savedContent: '待保存内容' })
+    root = createRoot(container)
+  })
+
   it('renders document controls and empty guidance in English', async () => {
     const generatedContent = 'A'.repeat(60)
     await act(async () => root.render(

--- a/src/components/editor/__tests__/ArchFileViewer.locale.browser.tsx
+++ b/src/components/editor/__tests__/ArchFileViewer.locale.browser.tsx
@@ -1,4 +1,5 @@
 import { act } from 'react'
+import { EditorView } from '@codemirror/view'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -6,6 +7,8 @@ import { setActiveProjectSessionContext } from '../../../shared/project-session-
 import type { ProjectData } from '../../../shared/ipc-channels'
 import { useLocaleStore } from '../../../stores/locale-store'
 import { useProjectStore } from '../../../stores/project-store'
+import { saveDirtyEditorChangesForExit, useEditorStore } from '../../../stores/editor-store'
+import { toast } from '../../ui/Toast'
 import ArchFileViewer from '../ArchFileViewer'
 
 const PROJECT_PATH = 'C:\\novels\\arch-locale'
@@ -29,6 +32,7 @@ let root: Root
 let invoke: ReturnType<typeof vi.fn>
 const originalLocaleState = useLocaleStore.getState()
 const originalProjectState = useProjectStore.getState()
+const originalEditorState = useEditorStore.getState()
 
 ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -62,10 +66,69 @@ afterEach(async () => {
   setActiveProjectSessionContext(null)
   useLocaleStore.setState(originalLocaleState)
   useProjectStore.setState(originalProjectState)
+  useEditorStore.setState(originalEditorState)
   vi.restoreAllMocks()
 })
 
 describe('ArchFileViewer locale', () => {
+  it.each([
+    ['premise', '故事前提'],
+    ['characters', '角色图谱'],
+    ['worldbuilding', '世界观'],
+    ['synopsis', '情节大纲'],
+  ])('recognizes the actual core protocol %s and restores generation controls', async (key, label) => {
+    useLocaleStore.setState({ locale: 'zh-CN' })
+    await act(async () => root.render(
+      <ArchFileViewer tabId={`arch-${key}`} filePath={`vela://core/${key}`}
+        projectKey={PROJECT_PATH} content="" savedContent="" />,
+    ))
+    expect(container.textContent).toContain(label)
+    expect(container.querySelector(`[title="AI 生成「${label}」"]`)).not.toBeNull()
+    if (key === 'characters') {
+      expect(container.textContent).toContain('角色图谱由角色名单自动生成，只读展示')
+      expect(container.querySelector('.cm-content')?.getAttribute('contenteditable')).toBe('false')
+      const editor = container.querySelector('.cm-editor') as HTMLElement
+      const view = EditorView.findFromDOM(editor)!
+      expect(view.state.readOnly).toBe(true)
+      await act(async () => view.contentDOM.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Tab', code: 'Tab', bubbles: true, cancelable: true,
+      })))
+      expect(view.state.doc.toString()).toBe('')
+      expect(container.querySelector('[title="保存（Cmd+S）"]')).toBeNull()
+    } else if (key === 'premise') {
+      const view = EditorView.findFromDOM(container.querySelector('.cm-editor') as HTMLElement)!
+      expect(view.state.readOnly).toBe(false)
+      await act(async () => view.contentDOM.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Tab', code: 'Tab', bubbles: true, cancelable: true,
+      })))
+      expect(view.state.doc.toString()).toBe('  ')
+    }
+  })
+
+  it('reports a rejected save without clearing the draft and rejects exit-save', async () => {
+    useLocaleStore.setState({ locale: 'zh-CN' })
+    const errorToast = vi.spyOn(toast, 'error').mockImplementation(() => {})
+    invoke.mockResolvedValue({ success: false, error: '磁盘已满' })
+    useEditorStore.setState({ tabs: [{
+      id: 'arch-save-error', name: '故事前提', type: 'arch-file',
+      projectKey: PROJECT_PATH, filePath: 'vela://core/premise',
+      content: '未保存的故事前提', savedContent: '', dirty: true,
+    }], draftLedgers: {} })
+    await act(async () => root.render(
+      <ArchFileViewer tabId="arch-save-error" filePath="vela://core/premise"
+        projectKey={PROJECT_PATH} content="未保存的故事前提" savedContent="" />,
+    ))
+    await act(async () => (container.querySelector('[title="保存（Cmd+S）"]') as HTMLButtonElement).click())
+    expect(errorToast).toHaveBeenCalledWith(expect.stringContaining('磁盘已满'))
+    expect(container.textContent).toContain('未保存的故事前提')
+    expect(container.querySelector('[title="有未保存的修改"]')).not.toBeNull()
+    expect(useEditorStore.getState().tabs[0]).toMatchObject({ dirty: true, savedContent: '' })
+    await act(async () => {
+      await expect(saveDirtyEditorChangesForExit(PROJECT_PATH)).rejects.toThrow('磁盘已满')
+    })
+    expect(useEditorStore.getState().tabs[0].dirty).toBe(true)
+  })
+
   it('renders document controls and empty guidance in English', async () => {
     const generatedContent = 'A'.repeat(60)
     await act(async () => root.render(

--- a/src/components/panels/sidebar/CharactersView.tsx
+++ b/src/components/panels/sidebar/CharactersView.tsx
@@ -12,6 +12,7 @@ import { EmptyState } from '../../ui/EmptyState'
 import { cn } from '../../../lib/utils'
 import { useLocaleStore } from '../../../stores/locale-store'
 import { getCharacterRoleLabels } from '../../../shared/character-role'
+import { CharacterCardImportButton } from '../../characters/CharacterCardImportButton'
 
 export default function CharactersView() {
   const [searchQuery, setSearchQuery] = useState('')
@@ -64,6 +65,7 @@ export default function CharactersView() {
           {text(`角色列表（${visibleCharacters.length}）`, `Characters (${visibleCharacters.length})`)}
         </span>
         <div className="flex items-center gap-0.5">
+          <CharacterCardImportButton projectKey={currentProject.path} compact disabled={identityBusy || !dataReady} />
           <Button variant="ghost" size="icon" className="h-6 w-6" onClick={() => load(currentProject.path)} disabled={identityBusy || loadingProjectKey !== null} title={text('刷新列表', 'Refresh list')}>
             <RefreshCw size={14} strokeWidth={2} />
           </Button>


### PR DESCRIPTION
## 问题与范围

关联 #211；关联 #185 的角色卡导入使用场景，但不关闭或宣称完成 #185 的全部范围。

官方 1.1.0 程序中已复现角色图谱可输入却无法保存、界面无错误提示。原因是文档类型只识别旧 Markdown 路径，遗漏真实 `vela://core/characters` 入口，错误开放了只读投影的编辑。

## 修改

- 使用统一协议映射恢复四类架构文档识别、生成控件及角色图谱只读说明。
- 保存失败显示错误并保留未保存内容；退出保存仍传播失败，避免关闭时误判成功。
- 角色管理与角色图谱提供粘贴全文／选择文件入口，复用现有模型提取、候选预览确认和原子角色名单合并流程。
- 发送前明确模型与端点；取消、失败保留输入；项目会话变化隔离旧资料。
- 补齐 CodeMirror 的 editable/readOnly 透传和只读 Tab/编辑工具限制。

没有新增解析器、请求重试或生成预算，没有直接覆盖角色图谱，没有改 DSH、发布配置或依赖。

## 验证

- `pnpm run test:browser`：47 文件，291 项通过。
- 四个针对性浏览器文件：14 项通过，覆盖真实协议入口、只读、保存失败与退出保存、导入确认、文件选择、模型缺失及会话变化。
- `pnpm exec vitest run src/services/__tests__/vela-protocol-character-roster.test.ts src/services/workflows/commands/__tests__/planning-material.command.test.ts src/services/workflows/__tests__/character-card-normalizer.test.ts src/stores/__tests__/character-project-context.test.ts`：55 项通过。
- `pnpm run typecheck`、六个变更文件 ESLint、`pnpm run check:i18n`、`pnpm run build`、`git diff --check`：通过。
- 本地生产构建真实 Electron + 真实 IPC/数据库，隔离合成项目复测：角色图谱不可编辑且无错误保存入口；粘贴窗口可打开；缺模型提示保留输入；故事前提正常保存后数据库回读一致。
- 固定 `7ff7180...c81fd94` 独立 Standards / Spec 审查分别 0 项阻塞发现。

## 验证边界

新增导入界面测试 mock 现有工作流启动边界；本轮没有调用真实模型做全文提取，不将模型语义质量或真实候选确认全链路标为通过。没有重跑全部单元套件、Windows/macOS 安装包构建或升级资格；本 PR 不发布版本。完整界面回归仍有既有 React act 与工具链 warning，但测试退出成功。

仅提交六个源码／测试文件；不包含截图、私有证据、小说、API Key 或本机路径。保持 Draft，待维护者审阅后决定合并。
