### PR TITLE
fix: 保留截断世界观并精简章节大纲上下文

### DIFF
--- a/src/components/editor/WorldBuildingEditor.tsx
+++ b/src/components/editor/WorldBuildingEditor.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { Sparkles, CheckCircle2, Circle, RefreshCw, FileText, BookOpen, AlertTriangle, FolderTree } from 'lucide-react'
+import { Sparkles, CheckCircle2, Circle, RefreshCw, FileText, BookOpen, AlertTriangle, FolderTree, Eye, Copy } from 'lucide-react'
 import { useProjectStore } from '../../stores/project-store'
+import { useWorkflowStore } from '../../stores/workflow-store'
 import { useLocaleStore } from '../../stores/locale-store'
 import { renderIcon } from '../panels/sidebar/sidebar-icons'
 
@@ -34,6 +35,7 @@ import {
   hasVisiblePartialSynopsisMarker,
   isRecoverableSynopsisCheckpoint,
   isUsableSynopsisCheckpoint,
+  recoverableWorldBuildingCandidate,
 } from '../../services/workflows/commands/architecture.command'
 
 type ArchStepKey = 'premise' | 'characters' | 'worldbuilding' | 'synopsis'
@@ -62,6 +64,9 @@ export default function WorldBuildingEditor({ projectKey }: { projectKey: string
   const currentProject = useProjectStore(s => s.currentProject)
   const text = useLocaleStore(s => s.text)
   const projectMatches = currentProject?.path === projectKey
+  const latestArchitectureTerminalRunId = useWorkflowStore(state => (
+    state.history.find(run => run.type === 'architecture_generation' && run.projectPath === projectKey)?.id ?? null
+  ))
   const [archStatus, setArchStatus] = useState<Record<string, boolean>>({})
   const [wordCounts, setWordCounts] = useState<Record<string, number>>({})
   const [synopsisIncomplete, setSynopsisIncomplete] = useState(false)
@@ -69,6 +74,9 @@ export default function WorldBuildingEditor({ projectKey }: { projectKey: string
   const [synopsisCoveredTo, setSynopsisCoveredTo] = useState<number>(0)
   const [synopsisTotalChapters, setSynopsisTotalChapters] = useState<number>(0)
   const [synopsisBusy, setSynopsisBusy] = useState(false)
+  const [worldBuildingCandidate, setWorldBuildingCandidate] = useState('')
+  const [worldBuildingBusy, setWorldBuildingBusy] = useState(false)
+  const [showWorldBuildingCandidate, setShowWorldBuildingCandidate] = useState(false)
   const [pendingSynopsisRange, setPendingSynopsisRange] = useState<{ from: number; to: number } | null>(null)
   const [loading, setLoading] = useState(true)
   const [showArchDialog, setShowArchDialog] = useState(false)
@@ -94,6 +102,8 @@ export default function WorldBuildingEditor({ projectKey }: { projectKey: string
       setSynopsisRecoveryFailed(false)
       setSynopsisCoveredTo(0)
       setSynopsisTotalChapters(0)
+      setWorldBuildingCandidate('')
+      setShowWorldBuildingCandidate(false)
       setLoading(false)
       return
     }
@@ -109,6 +119,7 @@ export default function WorldBuildingEditor({ projectKey }: { projectKey: string
     let interrupted = false
     let recoveryFailed = false
     let coveredTo = 0
+    let recoveredWorldBuildingCandidate = ''
     const dbSynopsis = core?.synopsis || ''
     const totalChapters = Number(core?.totalChapters ?? currentProject?.novelConfig?.totalChapters) || 0
     const writingLanguage = (core?.writingLanguage ?? currentProject?.novelConfig?.writingLanguage) === 'en-US'
@@ -125,6 +136,7 @@ export default function WorldBuildingEditor({ projectKey }: { projectKey: string
       const partial = partialResult?.success === true
         ? (partialResult as { data?: Record<string, unknown> }).data
         : undefined
+      recoveredWorldBuildingCandidate = recoverableWorldBuildingCandidate(partial)
       const checkpointUsable = isUsableSynopsisCheckpoint(
         partial,
         dbSynopsis,
@@ -145,6 +157,7 @@ export default function WorldBuildingEditor({ projectKey }: { projectKey: string
       interrupted = false
       recoveryFailed = visiblyPartial
       coveredTo = 0
+      recoveredWorldBuildingCandidate = ''
     }
     const status: Record<string, boolean> = {
       premise: (core?.premise?.length ?? 0) > 50,
@@ -168,6 +181,8 @@ export default function WorldBuildingEditor({ projectKey }: { projectKey: string
     setSynopsisRecoveryFailed(recoveryFailed && Boolean(status.synopsis))
     setSynopsisCoveredTo(coveredTo)
     setSynopsisTotalChapters(totalChapters)
+    setWorldBuildingCandidate(recoveredWorldBuildingCandidate)
+    if (!recoveredWorldBuildingCandidate) setShowWorldBuildingCandidate(false)
     setLoading(false)
     // ✅ 只依赖 path 字符串，避免 novelConfig 等变化导致 loadStatus 重建
   }, [currentProject, projectKey, projectMatches, rosterSnapshot])
@@ -175,7 +190,7 @@ export default function WorldBuildingEditor({ projectKey }: { projectKey: string
   useEffect(() => {
     const timer = setTimeout(() => { void loadStatus() }, 0)
     return () => clearTimeout(timer)
-  }, [loadStatus])
+  }, [latestArchitectureTerminalRunId, loadStatus])
 
   // 监听 EventBus 事件，刷新后处理状态面板
   useEffect(() => {
@@ -300,6 +315,46 @@ export default function WorldBuildingEditor({ projectKey }: { projectKey: string
     }
   }
 
+  /** 从本项目保存的未完成候选继续生成世界观。 */
+  const handleResumeWorldBuilding = async () => {
+    const projectSession = captureProjectSession(currentProject)
+    if (!projectMatches || !projectSession || !isProjectSessionPath(projectSession, projectKey)) return
+    if (!isProjectSessionCurrent(projectSession) || worldBuildingBusy || !worldBuildingCandidate) return
+    setWorldBuildingBusy(true)
+    try {
+      await launchCreativeWorkflow({
+        workflow: 'generate_architecture',
+        selectedSteps: ['worldbuilding'],
+        resumeWorldBuilding: true,
+      }, projectSession)
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error)
+      const { toast } = await import('../ui/Toast')
+      toast.error(text(`续写启动失败：${detail}`, `Failed to start the continuation: ${detail}`))
+    } finally {
+      setWorldBuildingBusy(false)
+    }
+  }
+
+  const copyWorldBuildingCandidate = async () => {
+    const projectSession = captureProjectSession(currentProject)
+    if (!projectMatches
+      || !projectSession
+      || !isProjectSessionPath(projectSession, projectKey)
+      || !isProjectSessionCurrent(projectSession)
+      || !worldBuildingCandidate
+    ) return
+    try {
+      await navigator.clipboard.writeText(worldBuildingCandidate)
+      const { toast } = await import('../ui/Toast')
+      toast.success(text('世界观未完成候选已复制', 'Incomplete worldbuilding candidate copied.'))
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error)
+      const { toast } = await import('../ui/Toast')
+      toast.error(text(`复制失败：${detail}`, `Copy failed: ${detail}`))
+    }
+  }
+
   /** 续批入口：打开生成弹窗并预填下一批范围（从 coveredTo+1 起，默认带本批上限，
    * 上限可在弹窗内调整）。避免一次请求剩余全部章节再次触发超长输出。 */
   const handleContinueOutlineBatch = async () => {
@@ -399,6 +454,7 @@ export default function WorldBuildingEditor({ projectKey }: { projectKey: string
           const synopsisNeedsRecovery = f.key === 'synopsis' && synopsisRecoveryFailed
           const words = wordCounts[f.key] ?? 0
           const isCharacters = f.key === 'characters'
+          const isWorldBuildingCandidate = f.key === 'worldbuilding' && Boolean(worldBuildingCandidate)
           const rosterNeedsAttention = isCharacters && rosterPresentation
             && rosterPresentation.kind !== 'ready'
             && rosterPresentation.kind !== 'empty'
@@ -408,11 +464,13 @@ export default function WorldBuildingEditor({ projectKey }: { projectKey: string
             ? 'var(--color-error, #ef4444)'
             : rosterNeedsAttention
               ? 'var(--color-warning)'
-            : synopsisNeedsRecovery
-              ? 'var(--color-warning)'
-              : generated
-              ? 'var(--color-success)'
-              : 'var(--color-border)'
+              : synopsisNeedsRecovery
+                ? 'var(--color-warning)'
+                : isWorldBuildingCandidate
+                  ? 'var(--color-warning)'
+               : generated
+                    ? 'var(--color-success)'
+                    : 'var(--color-border)'
           return (
             <div key={f.key} className="space-y-2">
               <div
@@ -431,11 +489,11 @@ export default function WorldBuildingEditor({ projectKey }: { projectKey: string
                 title={`${text('点击查看', 'Open')} — ${text(f.descZh, f.descEn)}`}
               >
                 {/* 状态图标 */}
-                {generated
-                  ? synopsisNeedsRecovery
-                    ? <AlertTriangle size={18} style={{ flexShrink: 0, color: 'var(--color-warning)' }} />
-                    : <CheckCircle2 size={18} style={{ flexShrink: 0, color: 'var(--color-success)' }} />
-                  : <Circle size={18} style={{ flexShrink: 0, color: 'var(--color-text-muted)' }} />
+                {isWorldBuildingCandidate || synopsisNeedsRecovery
+                  ? <AlertTriangle size={18} style={{ flexShrink: 0, color: 'var(--color-warning)' }} />
+                  : generated
+                    ? <CheckCircle2 size={18} style={{ flexShrink: 0, color: 'var(--color-success)' }} />
+                    : <Circle size={18} style={{ flexShrink: 0, color: 'var(--color-text-muted)' }} />
                 }
 
                 {/* 图标 */}
@@ -486,6 +544,56 @@ export default function WorldBuildingEditor({ projectKey }: { projectKey: string
                           {words.toLocaleString()} {text('字符', 'characters')}
                         </span>
                       )}
+                    </>
+                  ) : isWorldBuildingCandidate ? (
+                    <>
+                      <span className="text-[0.7rem] px-1.5 py-0.5 rounded font-medium bg-yellow-500/15 text-[var(--color-warning-text)]">
+                        {text(
+                          generated ? '正式内容保留 · 有未完成候选' : '未完成候选 · 未写入正式内容',
+                          generated ? 'Formal content kept · incomplete candidate' : 'Incomplete candidate · not formal content',
+                        )}
+                      </span>
+                      {generated && (
+                        <span className="text-xs" style={{ color: 'var(--color-text-muted)' }}>
+                          {words.toLocaleString()} {text('字符（正式内容）', 'characters (formal)')}
+                        </span>
+                      )}
+                      <div className="flex flex-wrap justify-end gap-1 mt-0.5">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            setShowWorldBuildingCandidate(value => !value)
+                          }}
+                        >
+                          <Eye size={12} />
+                          {showWorldBuildingCandidate ? text('收起候选', 'Hide candidate') : text('查看候选', 'View candidate')}
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            void copyWorldBuildingCandidate()
+                          }}
+                        >
+                          <Copy size={12} />
+                          {text('复制', 'Copy')}
+                        </Button>
+                        <Button
+                          size="sm"
+                          disabled={worldBuildingBusy}
+                          className="gap-1.5 bg-gradient-to-r from-amber-500 to-orange-500 text-white border-none"
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            void handleResumeWorldBuilding()
+                          }}
+                        >
+                          <RefreshCw size={12} className={worldBuildingBusy ? 'animate-spin' : ''} />
+                          {worldBuildingBusy ? text('续写中...', 'Resuming...') : text('断点续写', 'Resume')}
+                        </Button>
+                      </div>
                     </>
                   ) : generated ? (
                     <>
@@ -592,6 +700,20 @@ export default function WorldBuildingEditor({ projectKey }: { projectKey: string
                   )}
                 </div>
               </div>
+              {isWorldBuildingCandidate && showWorldBuildingCandidate && (
+                <div
+                  role="status"
+                  className="rounded-lg border p-3"
+                  style={{ borderColor: 'var(--color-warning)', backgroundColor: 'var(--color-panel)' }}
+                >
+                  <div className="text-xs font-medium mb-2" style={{ color: 'var(--color-warning-text)' }}>
+                    {text('世界观未完成候选（不会自动写入正式世界观）', 'Incomplete worldbuilding candidate (not written to formal worldbuilding)')}
+                  </div>
+                  <pre className="text-xs whitespace-pre-wrap max-h-64 overflow-y-auto" style={{ color: 'var(--color-text-secondary)' }}>
+                    {worldBuildingCandidate}
+                  </pre>
+                </div>
+              )}
             </div>
           )
         })}

--- a/src/components/editor/__tests__/world-building-recovery.browser.tsx
+++ b/src/components/editor/__tests__/world-building-recovery.browser.tsx
@@ -1,0 +1,136 @@
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { setActiveProjectSessionContext } from '../../../shared/project-session-context'
+import { useLocaleStore } from '../../../stores/locale-store'
+import { useProjectStore } from '../../../stores/project-store'
+import { useWorkflowStore } from '../../../stores/workflow-store'
+import WorldBuildingEditor from '../WorldBuildingEditor'
+
+const projectPath = 'C:\\novels\\世界观候选界面测试'
+const projectSession = {
+  projectId: 'world-ui-test',
+  leaseId: 'world-ui-test-lease',
+  projectPath,
+}
+const originalLocaleState = useLocaleStore.getState()
+const originalProjectState = useProjectStore.getState()
+const originalWorkflowState = useWorkflowStore.getState()
+
+let container: HTMLDivElement
+let root: Root
+let partialFile: Record<string, unknown>
+
+;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+beforeEach(() => {
+  partialFile = {}
+  useLocaleStore.setState({ locale: 'zh-CN', initialized: true })
+  useProjectStore.setState({
+    currentProject: {
+      id: projectSession.projectId,
+      sessionLease: projectSession.leaseId,
+      name: '世界观候选界面测试',
+      path: projectPath,
+      novelConfig: {
+        writingLanguage: 'zh-CN',
+        genre: '东方奇幻',
+        subGenre: '',
+        targetAudience: '成年读者',
+        totalChapters: 20,
+        wordsPerChapter: 3000,
+        plotStructure: 'three_act',
+        narrativePOV: 'third_limited',
+        coreOutline: '倒悬古城的记忆税危机。',
+        worldSetting: '',
+        goldenFinger: '',
+        protagonistProfile: '',
+        globalGuidance: '',
+      },
+    } as never,
+  })
+  useWorkflowStore.setState({ activeRuns: [], history: [] })
+  setActiveProjectSessionContext(projectSession)
+
+  Object.defineProperty(window, 'velaAPI', {
+    configurable: true,
+    value: {
+      invoke: vi.fn(async (channel: string) => {
+        if (channel === 'db:project-core-get') {
+          return { premise: '故事前提'.repeat(20), worldbuilding: '', synopsis: '', totalChapters: 20 }
+        }
+        if (channel === 'fs:read-json') return { success: true, data: structuredClone(partialFile) }
+        if (channel === 'db:character-roster-read') {
+          return { status: 'empty', revision: 0, entries: [], renderedMarkdown: '' }
+        }
+        throw new Error(`未预期的 IPC 通道：${channel}`)
+      }),
+      on: vi.fn(() => () => {}),
+      once: vi.fn(),
+      send: vi.fn(),
+      setZoomLevel: vi.fn(),
+      setZoomFactor: vi.fn(),
+      getZoomLevel: vi.fn(),
+    },
+  })
+
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+})
+
+afterEach(async () => {
+  await act(async () => root.unmount())
+  container.remove()
+  Reflect.deleteProperty(window, 'velaAPI')
+  setActiveProjectSessionContext(null)
+  useLocaleStore.setState(originalLocaleState)
+  useProjectStore.setState(originalProjectState)
+  useWorkflowStore.setState(originalWorkflowState)
+  vi.restoreAllMocks()
+})
+
+describe('WorldBuildingEditor 世界观恢复候选', () => {
+  it('已打开页面会在架构工作流失败终态后刷新并显示候选入口', async () => {
+    await act(async () => root.render(<WorldBuildingEditor projectKey={projectPath} />))
+    await act(async () => {
+      await vi.waitFor(() => expect(container.textContent).toContain('世界观'))
+    })
+    expect(container.textContent).not.toContain('未完成候选 · 未写入正式内容')
+
+    partialFile = {
+      world_building_partial_result: '倒悬古城依靠记忆结晶运转，王庭通过税令控制流通。',
+      world_building_incomplete: true,
+      world_building_facts_fingerprint: 'facts',
+      world_building_db_hash: 'db',
+      world_building_step_guidance: '',
+    }
+    await act(async () => useWorkflowStore.setState({
+      history: [{
+        id: 'failed-world-run',
+        type: 'architecture_generation',
+        title: '生成故事架构',
+        projectPath,
+        projectSession,
+        status: 'failed',
+        steps: [],
+        currentStepIndex: 0,
+        logs: [],
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        uiLocale: 'zh-CN',
+      } as never],
+    }))
+
+    await act(async () => {
+      await vi.waitFor(() => expect(container.textContent).toContain('未完成候选 · 未写入正式内容'))
+    })
+    const viewButton = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent?.includes('查看候选'))
+    expect(viewButton).toBeTruthy()
+    await act(async () => viewButton?.click())
+    expect(container.textContent).toContain('不会自动写入正式世界观')
+    expect(container.textContent).toContain('倒悬古城依靠记忆结晶运转')
+  })
+})

--- a/src/services/workflows/__tests__/bounded-completion.test.ts
+++ b/src/services/workflows/__tests__/bounded-completion.test.ts
@@ -4,6 +4,7 @@ import {
   appendVisibleTextContinuation,
   BoundedCompletionFailure,
   completeBoundedCompletion,
+  createBoundedCompletionError,
   redactVisibleCompletionText,
 } from '../bounded-completion'
 
@@ -84,16 +85,31 @@ describe('bounded completion', () => {
   it('fails closed after the configured structured continuation limit', async () => {
     const requestContinuation = vi.fn().mockResolvedValue({ content: '{"half":', finishReason: 'length' })
 
-    await expect(completeBoundedCompletion({
+    const completion = completeBoundedCompletion({
       initial: { content: '{"half":', finishReason: 'length' },
       mode: 'replace-structured-output',
       maxContinuations: 2,
       originalPrompt: '返回 JSON',
       writingLanguage: 'zh-CN',
       requestContinuation,
-    })).rejects.toThrow('已自动续写 2 次仍未完成')
+    })
+
+    await expect(completion).rejects.toThrow(
+      'AI 输出连续达到本次请求长度限制，已自动续写 2 次，尚未完整生成。',
+    )
+    await expect(completion).rejects.not.toThrow(/模型最大长度|结果未被保存/)
 
     expect(requestContinuation).toHaveBeenCalledTimes(2)
+  })
+
+  it('describes provider length as this request limit and retains the failure code', () => {
+    const error = createBoundedCompletionError('length')
+
+    expect(error).toMatchObject({
+      failureCode: 'length',
+      message: 'AI 输出达到本次请求长度限制，尚未完整生成。请缩短本次任务或拆分为更小批次后重试。',
+    })
+    expect(error.message).not.toMatch(/模型最大长度|结果未被保存/)
   })
 
   it('localizes terminal errors by UI locale without changing the writing-language prompt', async () => {
@@ -110,7 +126,9 @@ describe('bounded completion', () => {
       writingLanguage: 'zh-CN',
       uiLocale: 'en-US',
       requestContinuation,
-    })).rejects.toThrow('Automatic continuation ran 1 time but the output is still incomplete')
+    })).rejects.toThrow(
+      'Automatic continuation ran 1 time, but the output is not yet complete',
+    )
 
     expect(requestContinuation).toHaveBeenCalledOnce()
     expect(requestContinuation.mock.calls[0]?.[0]).toContain('上一轮结构化输出因长度限制而中断')

--- a/src/services/workflows/__tests__/legacy-character-roster-repair.test.ts
+++ b/src/services/workflows/__tests__/legacy-character-roster-repair.test.ts
@@ -259,7 +259,7 @@ describe('legacy character roster repair public workflow seam', () => {
     })
     installVela(invoke)
 
-    await expect(migrateLegacyCharacterRoster(projectPath)).rejects.toThrow('已自动续写 2 次仍未完成')
+    await expect(migrateLegacyCharacterRoster(projectPath)).rejects.toThrow('已自动续写 2 次，尚未完整生成')
     expect(generateStream).toHaveBeenCalledTimes(3)
     expect(invoke.mock.calls.map(([channel]) => channel).filter(channel => channel.startsWith('db:character-roster'))).toEqual(['db:character-roster-read'])
   })

--- a/src/services/workflows/architecture-workflow.ts
+++ b/src/services/workflows/architecture-workflow.ts
@@ -25,6 +25,11 @@ export interface PartialArchData {
   character_dynamics_result?: string
   character_state_result?: string
   world_building_result?: string
+  world_building_partial_result?: string
+  world_building_incomplete?: boolean
+  world_building_facts_fingerprint?: string
+  world_building_db_hash?: string
+  world_building_step_guidance?: string
   synopsis_result?: string
   /** 情节大纲在上一次生成中被输出长度中断；synopsis_result 为已完成部分。 */
   synopsis_incomplete?: boolean
@@ -42,6 +47,8 @@ export interface ArchitectureWorkflowParams {
   synopsisRange?: { from: number; to: number } | null
   /** 从上次输出长度中断的检查点续写情节大纲（工作流只包含 synopsis 一步）。 */
   resumeSynopsis?: boolean
+  /** 从上次输出长度中断的候选续写世界观（工作流只包含 worldbuilding 一步）。 */
+  resumeWorldBuilding?: boolean
 }
 
 export interface ConfigGenerationWorkflowParams {
@@ -64,9 +71,15 @@ export function createArchitectureWorkflow(
 ): WorkflowDefinition {
   const text = (zhCNText: string, enUSText: string) => localize(uiLocale, zhCNText, enUSText)
   const resumingSynopsis = params.resumeSynopsis === true
+  const resumingWorldBuilding = params.resumeWorldBuilding === true
+  if (resumingSynopsis && resumingWorldBuilding) {
+    throw new Error(text('一次只能恢复一个故事架构步骤', 'Only one story-architecture step can be resumed at a time.'))
+  }
   const sel = resumingSynopsis
     ? ['synopsis' as const]
-    : params.selectedSteps ?? ['premise', 'characters', 'worldbuilding', 'synopsis']
+    : resumingWorldBuilding
+      ? ['worldbuilding' as const]
+      : params.selectedSteps ?? ['premise', 'characters', 'worldbuilding', 'synopsis']
   const expectedProjectPath = params.projectPath
   const project = useProjectStore.getState().currentProject
   const currentProjectSession = projectSessionContextFromProject(project)
@@ -114,11 +127,15 @@ export function createArchitectureWorkflow(
     {
       name: text('世界观', 'World building'),
       key: 'worldbuilding',
-      description: stepDesc('worldbuilding', '构建自带冲突引擎的世界观矩阵', 'Build a world matrix with its own conflict engine'),
+      description: resumingWorldBuilding
+        ? text('从已保存的未完成候选继续生成世界观', 'Resume worldbuilding from the saved incomplete candidate')
+        : stepDesc('worldbuilding', '构建自带冲突引擎的世界观矩阵', 'Build a world matrix with its own conflict engine'),
       executor: async (step: unknown, context: WorkflowContext, callbacks: StepCallbacks) => {
         context.data.stepGuidance = guidance
         const { GenerateWorldBuildingCommand } = await import('./commands/architecture.command')
-        return new GenerateWorldBuildingCommand(projectSnapshot).execute({ step, context, callbacks })
+        return new GenerateWorldBuildingCommand(projectSnapshot, undefined, {
+          resumeWorldBuilding: params.resumeWorldBuilding,
+        }).execute({ step, context, callbacks })
       },
     },
     {
@@ -144,7 +161,9 @@ export function createArchitectureWorkflow(
     type: 'architecture_generation',
     title: resumingSynopsis
       ? text('继续生成情节大纲（断点续写）', 'Continue plot outline (resume)')
-      : text('生成故事架构', 'Generate story architecture'),
+      : resumingWorldBuilding
+        ? text('继续生成世界观（断点续写）', 'Continue worldbuilding (resume)')
+        : text('生成故事架构', 'Generate story architecture'),
     projectPath: expectedProjectPath,
     projectSession,
     uiLocale,

--- a/src/services/workflows/bounded-completion.ts
+++ b/src/services/workflows/bounded-completion.ts
@@ -215,8 +215,8 @@ function incompleteCompletionError(
         failureCode,
         localize(
           uiLocale,
-          'AI 输出达到模型最大长度，结果不完整。请提高模型最大输出 Tokens 或缩短本次任务后重试。',
-          'AI output reached the model maximum length and is incomplete. Increase the maximum output tokens or shorten the task, then try again.',
+          'AI 输出达到本次请求长度限制，尚未完整生成。请缩短本次任务或拆分为更小批次后重试。',
+          'AI output reached this request length limit and is not yet complete. Shorten the task or split it into smaller batches, then try again.',
         ),
       )
     case 'content_filter':
@@ -251,11 +251,11 @@ function continuationLimitExceededError(maxContinuations: number, uiLocale: Loca
   return new Error(
     localize(
       uiLocale,
-      `AI 输出连续达到模型最大长度，已自动续写 ${maxContinuations} 次仍未完成，结果未被保存。` +
-        '请提高模型最大输出 Tokens、缩短本次任务，或拆分为更小批次后重试。',
-      `AI output repeatedly reached the model maximum length. Automatic continuation ran ${maxContinuations} ` +
-        `${maxContinuations === 1 ? 'time' : 'times'} but the output is still incomplete, so it was not saved. ` +
-        'Increase the maximum output tokens, shorten the task, or split it into smaller batches and try again.',
+      `AI 输出连续达到本次请求长度限制，已自动续写 ${maxContinuations} 次，尚未完整生成。` +
+        '请缩短本次任务，或拆分为更小批次后重试。',
+      `AI output repeatedly reached this request length limit. Automatic continuation ran ${maxContinuations} ` +
+        `${maxContinuations === 1 ? 'time' : 'times'}, but the output is not yet complete. ` +
+        'Shorten the task or split it into smaller batches, then try again.',
     ),
   )
 }

--- a/src/services/workflows/commands/__tests__/base-command.completion.test.ts
+++ b/src/services/workflows/commands/__tests__/base-command.completion.test.ts
@@ -203,7 +203,7 @@ describe('BaseWorkflowCommand completion boundary', () => {
       step: { kind: 'single' } satisfies ProbeStep,
       context,
       callbacks,
-    })).rejects.toThrow('AI 输出达到模型最大长度，结果不完整')
+    })).rejects.toThrow('AI 输出达到本次请求长度限制，尚未完整生成')
 
     expect(completeWithLease).toHaveBeenCalledOnce()
     expect(completeWithLease.mock.calls[0]?.[0].plan.maxOutputTokens).toBe(2048)
@@ -244,7 +244,7 @@ describe('BaseWorkflowCommand completion boundary', () => {
       step: { kind: 'single' } satisfies ProbeStep,
       context: { ...context, uiLocale: 'en-US', writingLanguage: 'zh-CN' },
       callbacks,
-    })).rejects.toThrow('AI output reached the model maximum length and is incomplete')
+    })).rejects.toThrow('AI output reached this request length limit and is not yet complete')
   })
 
   it('shares one frozen lease and budget across a structured continuation after the default changes', async () => {

--- a/src/services/workflows/commands/__tests__/generate-draft.command.test.ts
+++ b/src/services/workflows/commands/__tests__/generate-draft.command.test.ts
@@ -28,10 +28,59 @@ import {
   countDraftUnits,
   previousChapterEnding,
   sanitizeDraftText,
+  synopsisForDraftChapter,
   type GenerateDraftCommandDependencies,
 } from '../generate-draft.command'
 
 describe('generate draft command text cleanup', () => {
+  it.each(['```', '~~~'])('keeps quoted chapter examples inside %s fences verbatim', (fence) => {
+    const synopsis = `全局说明\n${fence}text\n## 第1章：示例\n作者不可丢事实甲\n## 第2章：示例\n作者不可丢事实乙\n${fence}\n全局尾部`
+    expect(synopsisForDraftChapter(synopsis, 2)).toBe(synopsis)
+  })
+
+  it('keeps global sections and the exact current chapter from an explicit Chinese chapter outline', () => {
+    const synopsis = `# 全书总纲
+潮门只能由守钟人开启。
+
+## 第1章：失钟
+顾舟遗失潮汐钟。
+
+## 第2章：回港
+顾舟在退潮前回到月桂港。
+
+## 第3章：潮门
+顾舟找到潮门。
+
+## 全局禁则
+潮门真相只能在终章揭晓。`
+
+    const projected = synopsisForDraftChapter(synopsis, 2)
+
+    expect(projected).toContain('潮门只能由守钟人开启')
+    expect(projected).toContain('## 第2章：回港')
+    expect(projected).toContain('潮门真相只能在终章揭晓')
+    expect(projected).not.toContain('顾舟遗失潮汐钟')
+    expect(projected).not.toContain('顾舟找到潮门')
+  })
+
+  it('keeps an ambiguous chapter outline verbatim instead of guessing which facts to drop', () => {
+    const synopsis = `## 第1章：甲
+事实甲。
+
+### 第2章：乙
+事实乙。`
+
+    expect(synopsisForDraftChapter(synopsis, 2)).toBe(synopsis)
+  })
+
+  it('does not treat ordinary prose mentioning a later chapter as a chapter heading', () => {
+    const synopsis = `全局说明：第2章发生的事将在未来改变潮门归属。
+
+普通正文仍属于全局大纲，不含 Markdown 章节标题。`
+
+    expect(synopsisForDraftChapter(synopsis, 2)).toBe(synopsis)
+  })
+
   it('removes thinking residue and continue UI prompts from draft text', () => {
     const text = sanitizeDraftText(`<think>分析过程</think>
 
@@ -265,6 +314,8 @@ describe('GenerateDraftCommand generation runtime boundary', () => {
     wordsTarget?: number
     premise?: string
     charactersArch?: string
+    worldbuilding?: string
+    synopsis?: string
     blueprints?: Array<{ chapterNumber: number; title: string; keyEvents: string }>
     userGuidance?: string
     globalGuidance?: string
@@ -321,8 +372,8 @@ describe('GenerateDraftCommand generation runtime boundary', () => {
         return {
           premise: options.premise ?? '故事前提',
           charactersArch: options.charactersArch ?? '',
-          worldbuilding: '',
-          synopsis: '',
+          worldbuilding: options.worldbuilding ?? '',
+          synopsis: options.synopsis ?? '',
         }
       }
       if (channel === 'db:blueprint-get-all') return options.blueprints ?? []
@@ -1491,6 +1542,58 @@ describe('GenerateDraftCommand generation runtime boundary', () => {
     expect(completePrompt).toContain(coreOutline)
   })
 
+  it.each(['## ', ''])('bounds an explicit long chapter outline with heading prefix %j while retaining author facts', async (headingPrefix) => {
+    const worldbuilding = [
+      '世界规则开始：月桂港每天只有一次退潮。',
+      '港务规则必须服从潮汐钟。'.repeat(1_000),
+      '世界观尾部关键事实：顾舟不会游泳。',
+    ].join('\n')
+    const synopsis = (outsideChapterSize: number) => `# 全书总纲
+全局关键事实：潮门真相只能在终章揭晓。
+
+${headingPrefix}第1章：失钟
+第一章非当前内容开始。${'旧案延展。'.repeat(outsideChapterSize)}第一章非当前内容结束。
+
+${headingPrefix}第2章：回港
+当前章关键事实：顾舟必须在退潮前拿回潮汐钟。
+
+${headingPrefix}第3章：潮门
+第三章非当前内容开始。${'后续延展。'.repeat(outsideChapterSize)}第三章非当前内容结束。
+
+## 全局禁则
+全局尾部关键事实：任何人不得提前知道潮门来源。`
+    const run = async (outline: string) => {
+      const runtime = fakeOutcomes(outcome(`${'正文'.repeat(250)}。`, 'stop'))
+      const { context, callbacks, command } = setup({
+        runtime,
+        chapterNumber: 2,
+        wordsTarget: 500,
+        previousFinalizedContent: '第一章定稿原文。',
+        worldbuilding,
+        worldSetting: worldbuilding,
+        coreOutline: '作者核心事实：顾舟必须查清潮门来源。',
+        synopsis: outline,
+      })
+
+      await command.execute({ step: {}, context, callbacks })
+      return runtime.complete.mock.calls[0]?.[0].messages
+        .find(message => message.role === 'user')?.content ?? ''
+    }
+
+    const shortPrompt = await run(synopsis(2))
+    const longPrompt = await run(synopsis(4_000))
+
+    expect(longPrompt).toContain('全局关键事实：潮门真相只能在终章揭晓')
+    expect(longPrompt).toContain('当前章关键事实：顾舟必须在退潮前拿回潮汐钟')
+    expect(longPrompt).toContain('全局尾部关键事实：任何人不得提前知道潮门来源')
+    expect(longPrompt).toContain('世界观尾部关键事实：顾舟不会游泳')
+    expect(longPrompt).toContain('作者核心事实：顾舟必须查清潮门来源')
+    expect(longPrompt).not.toContain('第一章非当前内容开始')
+    expect(longPrompt).not.toContain('第三章非当前内容开始')
+    expect(longPrompt.length).toBe(shortPrompt.length)
+    expect(longPrompt.match(/世界观尾部关键事实：顾舟不会游泳/gu)).toHaveLength(1)
+  })
+
   it.each([
     ['zh-CN', '文风仅用于选择表达方式', '作者明确事实与指导、实际前文、本章关键因果和本章篇幅优先'],
     ['en-US', 'Writing style selects expression only', 'actual prior prose'],
@@ -2515,7 +2618,7 @@ describe('GenerateDraftCommand generation runtime boundary', () => {
     })
 
     await expect(command.execute({ step: {}, context, callbacks }))
-      .rejects.toThrow('AI 输出达到模型最大长度，结果不完整')
+      .rejects.toThrow('AI 输出达到本次请求长度限制，尚未完整生成')
     expect(runtime.complete).toHaveBeenCalledTimes(8)
     expectNoDraftPersistence(invoke)
   })

--- a/src/services/workflows/commands/__tests__/import-novel.command.test.ts
+++ b/src/services/workflows/commands/__tests__/import-novel.command.test.ts
@@ -685,7 +685,7 @@ describe('InferGlobalSettingsCommand', () => {
     useLLMStore.setState({ defaultModelId: 'model-a', generateStream })
 
     await expect(new InferGlobalSettingsCommand().execute({ step: {}, context: createContext(), callbacks }))
-      .rejects.toThrow(/最大长度/)
+      .rejects.toThrow(/本次请求长度限制/)
     expect(generateStream).toHaveBeenCalledTimes(2)
     expect(invoke.mock.calls.map(([channel]) => channel)).toEqual([
       'kb:search', 'kb:search', 'kb:search', 'kb:search',

--- a/src/services/workflows/commands/__tests__/mutation-failure-boundary.test.ts
+++ b/src/services/workflows/commands/__tests__/mutation-failure-boundary.test.ts
@@ -642,7 +642,7 @@ describe('workflow mutation failure boundaries', () => {
       'db:post-process-mark-step-failed',
       'run-1',
       'chapter_notes',
-      expect.stringContaining('输出达到模型最大长度'),
+      expect.stringContaining('输出达到本次请求长度限制'),
       PROJECT_PATH,
       workflowContext.projectSession,
     )
@@ -696,7 +696,7 @@ describe('workflow mutation failure boundaries', () => {
     expect(step).toBeDefined()
 
     await expect(step!.executor(callbacks(), context()))
-      .rejects.toThrow('AI 输出达到模型最大长度')
+      .rejects.toThrow('AI 输出达到本次请求长度限制')
     expect(invoke.mock.calls.map(([channel]) => channel)).toEqual(['db:character-roster-read'])
   })
 
@@ -1639,7 +1639,7 @@ describe('workflow mutation failure boundaries', () => {
       step: {},
       context: { ...context(), uiLocale: 'en-US' },
       callbacks: callbacks(),
-    })).rejects.toThrow('Automatic continuation ran 1 time but the output is still incomplete')
+    })).rejects.toThrow('Automatic continuation ran 1 time, but the output is not yet complete')
 
     expect(generateStream).toHaveBeenCalledTimes(2)
     expect(invoke.mock.calls.map(([channel]) => channel)).not.toContain('db:review-create')

--- a/src/services/workflows/commands/__tests__/refine-draft.command.test.ts
+++ b/src/services/workflows/commands/__tests__/refine-draft.command.test.ts
@@ -520,7 +520,7 @@ describe('RefineDraftCommand bounded visible completion', () => {
       step: {},
       context: workflowContext(),
       callbacks: callbacks(),
-    })).rejects.toThrow('已自动续写 3 次仍未完成')
+    })).rejects.toThrow('已自动续写 3 次，尚未完整生成')
 
     expect(completeWithLease).toHaveBeenCalledTimes(4)
     expect(invoke).not.toHaveBeenCalled()

--- a/src/services/workflows/commands/__tests__/world-building-recovery.command.test.ts
+++ b/src/services/workflows/commands/__tests__/world-building-recovery.command.test.ts
@@ -92,6 +92,7 @@ function installResponses(items: readonly ResponseItem[], writesAtRequestStart: 
 }
 
 let partialFile: Record<string, unknown>
+let currentPremise: string
 let formalWorldbuilding: string
 let formalWrites: string[]
 let partialWriteCount: number
@@ -103,7 +104,7 @@ function installIpc(): void {
         if (channel === 'prompt:load-global') return { templates: [], diagnostics: [] }
         if (channel === 'fs:check-exists') return false
         if (channel === 'db:project-core-get') {
-          return { premise, worldbuilding: formalWorldbuilding }
+          return { premise: currentPremise, worldbuilding: formalWorldbuilding }
         }
         if (channel === 'fs:read-json') {
           return { success: true, data: structuredClone(partialFile) }
@@ -136,6 +137,7 @@ function installIpc(): void {
 beforeEach(() => {
   vi.clearAllMocks()
   partialFile = {}
+  currentPremise = premise
   formalWorldbuilding = '# 世界观\n\n作者已经确认的完整世界观。'
   formalWrites = []
   partialWriteCount = 0
@@ -272,6 +274,35 @@ describe('GenerateWorldBuildingCommand 截断恢复', () => {
     expect(formalWorldbuilding).toBe(authorEdit)
     expect(formalWrites).toHaveLength(0)
     expect(recoverableWorldBuildingCandidate(partialFile)).toBe('模型生成的完整世界观候选。')
+  })
+
+  it('模型响应前故事前提与小说配置变化时只保留候选，不写正式世界观', async () => {
+    const original = formalWorldbuilding
+    installResponses([{
+      content: '基于旧前提与旧配置生成的世界观。',
+      finishReason: 'stop',
+      beforeResponse: () => {
+        currentPremise = '作者在生成期间改写后的故事前提。'.repeat(4)
+        const currentProject = useProjectStore.getState().currentProject!
+        useProjectStore.setState({
+          currentProject: {
+            ...currentProject,
+            novelConfig: {
+              ...currentProject.novelConfig,
+              worldSetting: '作者在生成期间修改后的世界底层规则。',
+            },
+          },
+        })
+      },
+    }])
+
+    await expect(new GenerateWorldBuildingCommand(snapshot, createWorkflowRuntimeDependencies())
+      .execute({ step: {}, context: context(), callbacks: callbacks() }))
+      .rejects.toThrow('故事前提、小说配置或模板已变化')
+
+    expect(formalWorldbuilding).toBe(original)
+    expect(formalWrites).toHaveLength(0)
+    expect(recoverableWorldBuildingCandidate(partialFile)).toBe('基于旧前提与旧配置生成的世界观。')
   })
 
   it('重新打开后源事实变化会拒绝续写，并保留候选供查看复制', async () => {

--- a/src/services/workflows/commands/__tests__/world-building-recovery.command.test.ts
+++ b/src/services/workflows/commands/__tests__/world-building-recovery.command.test.ts
@@ -1,0 +1,336 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useLLMStore } from '../../../../stores/llm-store'
+import { useProjectStore } from '../../../../stores/project-store'
+import type { StepCallbacks, WorkflowContext } from '../../../../stores/workflow-store'
+import {
+  GenerateWorldBuildingCommand,
+  WorldBuildingResumeAvailableError,
+  recoverableWorldBuildingCandidate,
+  type ArchitectureProjectSnapshot,
+} from '../architecture.command'
+import { createWorkflowRuntimeDependencies } from './workflow-generation-runtime.fixture'
+import { clearProjectCustomPrompts } from '../../../prompt-templates'
+
+const projectPath = 'C:\\novels\\世界观恢复测试'
+const otherProjectPath = 'C:\\novels\\另一本书'
+const projectSession = Object.freeze({
+  projectId: 'world-recovery',
+  leaseId: 'lease-world-recovery',
+  projectPath,
+})
+const premise = '群山围绕的盆地每逢冬至会浮现倒悬古城，年轻测绘师必须查明记忆税令的真相，同时保护沿岸聚落。'.repeat(2)
+const novelConfig: ArchitectureProjectSnapshot['novelConfig'] = {
+  writingLanguage: 'zh-CN',
+  genre: '东方奇幻',
+  subGenre: '',
+  targetAudience: '成年读者',
+  totalChapters: 36,
+  wordsPerChapter: 3000,
+  plotStructure: 'three_act',
+  narrativePOV: 'third_limited',
+  coreOutline: premise,
+  worldSetting: '记忆可以被固化、征税和走私。',
+  goldenFinger: '主角能看见记忆实体的原始归属，但会付出代价。',
+  protagonistProfile: '主角谨慎、善于测绘，坚持不牺牲无辜者。',
+  globalGuidance: '保持规则、资源和权力结构之间的因果闭环。',
+}
+const snapshot: ArchitectureProjectSnapshot = {
+  expectedProjectPath: projectPath,
+  novelConfig,
+}
+const originalGenerateStream = useLLMStore.getState().generateStream
+const originalDefaultModelId = useLLMStore.getState().defaultModelId
+
+interface ResponseItem {
+  content?: string
+  finishReason?: 'stop' | 'length'
+  error?: string
+  beforeResponse?: () => void
+}
+
+function context(): WorkflowContext {
+  return {
+    runId: 'world-recovery-run',
+    projectPath,
+    projectSession,
+    generationModelId: 'world-recovery-model',
+    writingLanguage: 'zh-CN',
+    uiLocale: 'zh-CN',
+    data: { stepGuidance: { worldbuilding: '只写世界观正文，保持因果闭环。' } },
+    cancelled: false,
+  }
+}
+
+function callbacks(): StepCallbacks {
+  return {
+    log: vi.fn(),
+    setProgress: vi.fn(),
+    appendText: vi.fn(),
+    setPromptBudgetReport: vi.fn(),
+  }
+}
+
+function installResponses(items: readonly ResponseItem[], writesAtRequestStart: number[] = []) {
+  let index = 0
+  const generateStream = vi.fn(async (_messages, streamCallbacks) => {
+    writesAtRequestStart.push(partialWriteCount)
+    const item = items[index++]
+    if (!item) throw new Error(`出现未计划的第 ${index} 次模型请求`)
+    item.beforeResponse?.()
+    if (item.error) {
+      streamCallbacks.onError?.(item.error)
+    } else {
+      const content = item.content ?? ''
+      streamCallbacks.onChunk?.(content)
+      streamCallbacks.onDone?.(content, undefined, item.finishReason ?? 'stop')
+    }
+    return `世界观请求-${index}`
+  })
+  useLLMStore.setState({ defaultModelId: 'world-recovery-model', generateStream })
+  return generateStream
+}
+
+let partialFile: Record<string, unknown>
+let formalWorldbuilding: string
+let formalWrites: string[]
+let partialWriteCount: number
+
+function installIpc(): void {
+  vi.stubGlobal('window', {
+    velaAPI: {
+      invoke: vi.fn(async (channel: string, ...args: unknown[]) => {
+        if (channel === 'prompt:load-global') return { templates: [], diagnostics: [] }
+        if (channel === 'fs:check-exists') return false
+        if (channel === 'db:project-core-get') {
+          return { premise, worldbuilding: formalWorldbuilding }
+        }
+        if (channel === 'fs:read-json') {
+          return { success: true, data: structuredClone(partialFile) }
+        }
+        if (channel === 'fs:write-json') {
+          partialWriteCount += 1
+          partialFile = structuredClone(args[1] as Record<string, unknown>)
+          return { success: true }
+        }
+        if (channel === 'db:project-core-update') {
+          const update = args[0] as { worldbuilding?: string }
+          if (typeof update.worldbuilding === 'string') {
+            formalWorldbuilding = update.worldbuilding
+            formalWrites.push(update.worldbuilding)
+          }
+          return { success: true }
+        }
+        throw new Error(`未预期的 IPC 通道：${channel}`)
+      }),
+      on: vi.fn(),
+      once: vi.fn(),
+      send: vi.fn(),
+      setZoomLevel: vi.fn(),
+      setZoomFactor: vi.fn(),
+      getZoomLevel: vi.fn(),
+    },
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  partialFile = {}
+  formalWorldbuilding = '# 世界观\n\n作者已经确认的完整世界观。'
+  formalWrites = []
+  partialWriteCount = 0
+  useProjectStore.setState({
+    currentProject: {
+      id: projectSession.projectId,
+      name: '世界观恢复测试',
+      path: projectPath,
+      sessionLease: projectSession.leaseId,
+      novelConfig,
+    } as never,
+  })
+  installIpc()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+  useLLMStore.setState({
+    defaultModelId: originalDefaultModelId,
+    generateStream: originalGenerateStream,
+  })
+  useProjectStore.setState({ currentProject: null })
+  clearProjectCustomPrompts()
+})
+
+describe('GenerateWorldBuildingCommand 截断恢复', () => {
+  it('正常 stop 只请求一次并直接保存正式世界观', async () => {
+    const generateStream = installResponses([{ content: '新世界遵循明确的资源与权力规则。', finishReason: 'stop' }])
+
+    await expect(new GenerateWorldBuildingCommand(snapshot, createWorkflowRuntimeDependencies())
+      .execute({ step: {}, context: context(), callbacks: callbacks() }))
+      .resolves.toBe('新世界遵循明确的资源与权力规则。')
+
+    expect(generateStream).toHaveBeenCalledTimes(1)
+    expect(formalWrites).toEqual(['# 世界观\n\n新世界遵循明确的资源与权力规则。'])
+    expect(recoverableWorldBuildingCandidate(partialFile)).toBe('')
+  })
+
+  it('length 后先保存候选，再自动续写一次并在 stop 后提交完整结果', async () => {
+    const requestStartWrites: number[] = []
+    const generateStream = installResponses([
+      { content: '古城以记忆作为税收与燃料，', finishReason: 'length' },
+      { content: '王庭与行会因此形成相互制衡的权力结构。', finishReason: 'stop' },
+    ], requestStartWrites)
+
+    const result = await new GenerateWorldBuildingCommand(snapshot, createWorkflowRuntimeDependencies())
+      .execute({ step: {}, context: context(), callbacks: callbacks() })
+
+    expect(generateStream).toHaveBeenCalledTimes(2)
+    expect(requestStartWrites).toEqual([0, 1])
+    expect(result).toContain('古城以记忆作为税收与燃料')
+    expect(result).toContain('王庭与行会因此形成相互制衡')
+    expect(formalWrites).toHaveLength(1)
+    expect(recoverableWorldBuildingCandidate(partialFile)).toBe('')
+  })
+
+  it('连续两次 length 只请求两次，保存合并候选且不覆盖正式世界观', async () => {
+    const original = formalWorldbuilding
+    const generateStream = installResponses([
+      { content: '第一部分建立记忆税的来源与代价。', finishReason: 'length' },
+      { content: '第二部分建立行会、王庭与港口之间的冲突。', finishReason: 'length' },
+    ])
+
+    await expect(new GenerateWorldBuildingCommand(snapshot, createWorkflowRuntimeDependencies())
+      .execute({ step: {}, context: context(), callbacks: callbacks() }))
+      .rejects.toBeInstanceOf(WorldBuildingResumeAvailableError)
+
+    expect(generateStream).toHaveBeenCalledTimes(2)
+    expect(formalWrites).toHaveLength(0)
+    expect(formalWorldbuilding).toBe(original)
+    expect(recoverableWorldBuildingCandidate(partialFile)).toContain('第一部分建立记忆税')
+    expect(recoverableWorldBuildingCandidate(partialFile)).toContain('第二部分建立行会')
+  })
+
+  it('续写请求网络失败时，首段候选已先保存且正式世界观不变', async () => {
+    const requestStartWrites: number[] = []
+    const original = formalWorldbuilding
+    installResponses([
+      { content: '已收到的世界观首段。', finishReason: 'length' },
+      { error: '网络连接中断' },
+    ], requestStartWrites)
+
+    await expect(new GenerateWorldBuildingCommand(snapshot, createWorkflowRuntimeDependencies())
+      .execute({ step: {}, context: context(), callbacks: callbacks() }))
+      .rejects.toThrow('模型请求失败')
+
+    expect(requestStartWrites).toEqual([0, 1])
+    expect(recoverableWorldBuildingCandidate(partialFile)).toBe('已收到的世界观首段。')
+    expect(formalWorldbuilding).toBe(original)
+    expect(formalWrites).toHaveLength(0)
+  })
+
+  it('新工作流上下文可从持久化候选恢复并在成功后清除候选', async () => {
+    installResponses([
+      { content: '倒悬古城以记忆结晶维持运转。', finishReason: 'length' },
+      { content: '港口行会控制结晶流通。', finishReason: 'length' },
+    ])
+    await expect(new GenerateWorldBuildingCommand(snapshot, createWorkflowRuntimeDependencies())
+      .execute({ step: {}, context: context(), callbacks: callbacks() }))
+      .rejects.toBeInstanceOf(WorldBuildingResumeAvailableError)
+
+    const persistedCandidate = recoverableWorldBuildingCandidate(partialFile)
+    const resumeCalls = installResponses([
+      { content: '王庭通过税令制衡行会，冲突由此持续升级。', finishReason: 'stop' },
+    ])
+    const reopenedContext = context()
+    reopenedContext.data = {}
+    const result = await new GenerateWorldBuildingCommand(
+      snapshot,
+      createWorkflowRuntimeDependencies(),
+      { resumeWorldBuilding: true },
+    ).execute({ step: {}, context: reopenedContext, callbacks: callbacks() })
+
+    expect(resumeCalls).toHaveBeenCalledTimes(1)
+    expect(result).toContain(persistedCandidate)
+    expect(result).toContain('王庭通过税令制衡行会')
+    expect(formalWrites).toHaveLength(1)
+    expect(recoverableWorldBuildingCandidate(partialFile)).toBe('')
+  })
+
+  it('正式写入前发现作者修改时不覆盖新内容，并保留本次生成候选', async () => {
+    const authorEdit = '# 世界观\n\n作者在生成期间补充的新规则。'
+    installResponses([{
+      content: '模型生成的完整世界观候选。',
+      finishReason: 'stop',
+      beforeResponse: () => { formalWorldbuilding = authorEdit },
+    }])
+
+    await expect(new GenerateWorldBuildingCommand(snapshot, createWorkflowRuntimeDependencies())
+      .execute({ step: {}, context: context(), callbacks: callbacks() }))
+      .rejects.toBeInstanceOf(WorldBuildingResumeAvailableError)
+
+    expect(formalWorldbuilding).toBe(authorEdit)
+    expect(formalWrites).toHaveLength(0)
+    expect(recoverableWorldBuildingCandidate(partialFile)).toBe('模型生成的完整世界观候选。')
+  })
+
+  it('重新打开后源事实变化会拒绝续写，并保留候选供查看复制', async () => {
+    installResponses([
+      { content: '旧规则下的世界观首段。', finishReason: 'length' },
+      { content: '旧规则下的世界观续段。', finishReason: 'length' },
+    ])
+    await expect(new GenerateWorldBuildingCommand(snapshot, createWorkflowRuntimeDependencies())
+      .execute({ step: {}, context: context(), callbacks: callbacks() }))
+      .rejects.toBeInstanceOf(WorldBuildingResumeAvailableError)
+    const savedCandidate = recoverableWorldBuildingCandidate(partialFile)
+
+    const resumeCalls = installResponses([{ content: '不应发出的续写。', finishReason: 'stop' }])
+    const changedSnapshot: ArchitectureProjectSnapshot = {
+      ...snapshot,
+      novelConfig: { ...novelConfig, worldSetting: '作者已经改变世界底层规则。' },
+    }
+    await expect(new GenerateWorldBuildingCommand(
+      changedSnapshot,
+      createWorkflowRuntimeDependencies(),
+      { resumeWorldBuilding: true },
+    ).execute({ step: {}, context: { ...context(), data: {} }, callbacks: callbacks() }))
+      .rejects.toThrow('旧候选不能续到新上下文')
+
+    expect(resumeCalls).not.toHaveBeenCalled()
+    expect(recoverableWorldBuildingCandidate(partialFile)).toBe(savedCandidate)
+    expect(formalWrites).toHaveLength(0)
+  })
+
+  it('取消或项目切换时不保存候选，也不写正式世界观', async () => {
+    const cancelledContext = context()
+    installResponses([{
+      content: '取消后的输出不得保存。',
+      finishReason: 'length',
+      beforeResponse: () => { cancelledContext.cancelled = true },
+    }])
+    await expect(new GenerateWorldBuildingCommand(snapshot, createWorkflowRuntimeDependencies())
+      .execute({ step: {}, context: cancelledContext, callbacks: callbacks() }))
+      .rejects.toThrow('工作流已取消')
+    expect(partialWriteCount).toBe(0)
+    expect(formalWrites).toHaveLength(0)
+
+    installResponses([{
+      content: '项目切换后的输出不得保存。',
+      finishReason: 'length',
+      beforeResponse: () => useProjectStore.setState({
+        currentProject: {
+          id: 'other',
+          name: '另一本书',
+          path: otherProjectPath,
+          sessionLease: 'lease-other',
+          novelConfig,
+        } as never,
+      }),
+    }])
+    await expect(new GenerateWorldBuildingCommand(snapshot, createWorkflowRuntimeDependencies())
+      .execute({ step: {}, context: context(), callbacks: callbacks() }))
+      .rejects.toThrow('当前项目已切换')
+    expect(partialWriteCount).toBe(0)
+    expect(formalWrites).toHaveLength(0)
+  })
+})

--- a/src/services/workflows/commands/architecture.command.ts
+++ b/src/services/workflows/commands/architecture.command.ts
@@ -48,6 +48,15 @@ interface PartialArchData {
   character_dynamics_result?: string
   character_state_result?: string
   world_building_result?: string
+  /** 世界观输出达到长度上限时保存的未完成候选；不写入正式 worldbuilding。 */
+  world_building_partial_result?: string
+  world_building_incomplete?: boolean
+  /** 候选赖以生成的输入指纹；项目事实变化后禁止自动续写。 */
+  world_building_facts_fingerprint?: string
+  /** 候选创建时正式世界观的指纹；避免恢复时覆盖后来编辑的完整成果。 */
+  world_building_db_hash?: string
+  /** 候选实际使用的作者步骤指导；恢复时沿用，不读取新输入。 */
+  world_building_step_guidance?: string
   /** 情节大纲：已确认覆盖至 synopsis_covered_to 的纯正文（不含批次进度行）。 */
   synopsis_result?: string
   /** 上一次生成在本批范围内被输出长度中断；synopsis_result 为已完成部分。 */
@@ -117,6 +126,28 @@ export class PlotOutlineResumeAvailableError extends Error {
     this.name = 'PlotOutlineResumeAvailableError'
     Object.setPrototypeOf(this, new.target.prototype)
   }
+}
+
+export const WORLD_BUILDING_RESUME_ERROR_CODE = 'architecture-world-building-resume-available'
+
+export class WorldBuildingResumeAvailableError extends Error {
+  readonly code = WORLD_BUILDING_RESUME_ERROR_CODE
+
+  constructor(message: string) {
+    super(message)
+    this.name = 'WorldBuildingResumeAvailableError'
+    Object.setPrototypeOf(this, new.target.prototype)
+  }
+}
+
+/** 返回可供查看、复制或续写的世界观候选；候选不是正式世界观。 */
+export function recoverableWorldBuildingCandidate(value: unknown): string {
+  if (!value || typeof value !== 'object') return ''
+  const partial = value as PartialArchData
+  if (partial.world_building_incomplete !== true) return ''
+  return typeof partial.world_building_partial_result === 'string'
+    ? partial.world_building_partial_result.trim()
+    : ''
 }
 
 /** 少于该字符数视为无保存价值的零碎输出，不落盘、不提供续写。 */
@@ -1620,6 +1651,7 @@ export class GenerateWorldBuildingCommand extends BaseWorkflowCommand<string> {
   constructor(
     private snapshot: ArchitectureProjectSnapshot,
     generationDependencies?: WorkflowGenerationRuntimeDependencies,
+    private readonly options: { resumeWorldBuilding?: boolean } = {},
   ) {
     super(generationDependencies)
   }
@@ -1648,7 +1680,11 @@ export class GenerateWorldBuildingCommand extends BaseWorkflowCommand<string> {
       ))
     }
 
-    callbacks.log(text('生成世界观...', 'Generating worldbuilding...'))
+    const resumeRequested = this.options.resumeWorldBuilding === true
+    callbacks.log(text(
+      resumeRequested ? '正在读取世界观未完成候选...' : '生成世界观...',
+      resumeRequested ? 'Reading the incomplete worldbuilding candidate...' : 'Generating worldbuilding...',
+    ))
     const template = await resolvePromptTemplate('world_building', projectSession, writingLanguage)
     if (!template) throw new Error(text(
       '模板丢失',
@@ -1656,6 +1692,48 @@ export class GenerateWorldBuildingCommand extends BaseWorkflowCommand<string> {
     ))
 
     const missingValue = promptLanguageText(writingLanguage, '（未填写）', '(not provided)')
+    const requestedStepGuidance = ((context.data.stepGuidance as Record<string, string>) || {}).worldbuilding || ''
+    const partial = (context.data.partial as PartialArchData) || await loadPartialData(expectedProjectPath, projectSession)
+    context.data.partial = partial
+    let stepGuidance = requestedStepGuidance
+    let seedText = ''
+    let expectedDbHash = synopsisFactsFingerprint([core?.worldbuilding || ''])
+
+    if (resumeRequested) {
+      seedText = recoverableWorldBuildingCandidate(partial)
+      if (!seedText
+        || partial.world_building_step_guidance === undefined
+        || !partial.world_building_facts_fingerprint
+        || !partial.world_building_db_hash
+      ) {
+        throw new Error(text(
+          '未找到可恢复的世界观候选；正式世界观保持不变，请重新生成。',
+          'No recoverable worldbuilding candidate was found. The formal worldbuilding remains unchanged; regenerate instead.',
+        ))
+      }
+      stepGuidance = partial.world_building_step_guidance
+      expectedDbHash = partial.world_building_db_hash
+      if (synopsisFactsFingerprint([core?.worldbuilding || '']) !== expectedDbHash) {
+        throw new Error(text(
+          '正式世界观自候选保存后已变化，旧候选不能自动覆盖新内容；候选仍可查看或复制。',
+          'The formal worldbuilding changed after the candidate was saved, so the old candidate cannot overwrite it. The candidate remains available to view or copy.',
+        ))
+      }
+    }
+
+    const factsFingerprint = synopsisFactsFingerprint([
+      premise_result,
+      JSON.stringify(config),
+      stepGuidance,
+      JSON.stringify(template),
+    ])
+    if (resumeRequested && partial.world_building_facts_fingerprint !== factsFingerprint) {
+      throw new Error(text(
+        '故事前提、小说配置或世界观模板自候选保存后已变化，旧候选不能续到新上下文；候选仍可查看或复制。',
+        'The premise, novel configuration, or worldbuilding template changed after the candidate was saved, so the old candidate cannot be continued into the new context. The candidate remains available to view or copy.',
+      ))
+    }
+
     const promptBuilder = new ArchitecturePromptBuilder(template, writingLanguage)
       .withCoreSeed(premise_result)
       .withGenre(modelFacts.genre)
@@ -1663,17 +1741,110 @@ export class GenerateWorldBuildingCommand extends BaseWorkflowCommand<string> {
       .withGoldenFinger(config.goldenFinger || missingValue)
       .withProtagonistProfile(config.protagonistProfile || missingValue)
       .withGlobalGuidance(config.globalGuidance || missingValue)
-      .withStepGuidance(((context.data.stepGuidance as Record<string, string>) || {}).worldbuilding || '')
-
-    const result = await this.callLLMWithBuilder(
-      promptBuilder,
-      callbacks,
-      { purpose: 'generate-world-building', reasoningStage: 'planning', writingSkillStage: 'planning' },
-      context,
-    )
-    if (context.cancelled) throw new Error(text('工作流已取消', 'Workflow was cancelled.'))
+      .withStepGuidance(stepGuidance)
+    const taskPrompt = promptBuilder.build()
+    const systemPrompt = promptBuilder.getSystemRole()
+    const llmOptions = {
+      purpose: 'generate-world-building',
+      reasoningStage: 'planning' as const,
+      writingSkillStage: 'planning' as const,
+    }
+    let result: string
+    let persistedCandidate = seedText
+    try {
+      if (!seedText) {
+        const initial = await this.callLLMResult(
+          taskPrompt,
+          systemPrompt,
+          callbacks,
+          llmOptions,
+          context,
+        )
+        if (initial.finishReason === 'stop') {
+          result = initial.content
+        } else if (initial.finishReason === 'length' && initial.content.trim()) {
+          persistedCandidate = initial.content.trim()
+          await this.persistWorldBuildingCandidate(
+            projectSession,
+            expectedProjectPath,
+            context,
+            persistedCandidate,
+            factsFingerprint,
+            expectedDbHash,
+            stepGuidance,
+          )
+          result = await this.callLLMWithAppendContinuation({
+            taskPrompt,
+            systemPrompt,
+            callbacks,
+            context,
+            llmOptions,
+            seedText: persistedCandidate,
+            maxContinuations: 1,
+            taskLabel: text('世界观', 'Worldbuilding'),
+            onPartialAvailable: mergedText => { persistedCandidate = mergedText.trim() },
+          })
+        } else {
+          throw this.createIncompleteCompletionError(initial.finishReason)
+        }
+      } else {
+        result = await this.callLLMWithAppendContinuation({
+          taskPrompt,
+          systemPrompt,
+          callbacks,
+          context,
+          llmOptions,
+          seedText,
+          maxContinuations: 1,
+          taskLabel: text('世界观恢复', 'Worldbuilding recovery'),
+          onPartialAvailable: mergedText => { persistedCandidate = mergedText.trim() },
+        })
+      }
+    } catch (error) {
+      if (context.cancelled) throw error
+      if (persistedCandidate) {
+        await this.persistWorldBuildingCandidate(
+          projectSession,
+          expectedProjectPath,
+          context,
+          persistedCandidate,
+          factsFingerprint,
+          expectedDbHash,
+          stepGuidance,
+        )
+        const detail = error instanceof Error ? error.message : String(error)
+        throw new WorldBuildingResumeAvailableError(text(
+          `世界观未能完整生成，已保存未完成候选且未覆盖正式世界观。可查看、复制或稍后续写。原因：${detail}`,
+          `Worldbuilding did not complete. The incomplete candidate was saved without overwriting the formal worldbuilding; you can view, copy, or resume it later. Reason: ${detail}`,
+        ))
+      }
+      throw error
+    }
 
     this.assertNotCancelled(context)
+    assertArchitectureProjectSessionCurrent(projectSession, context)
+    const latestCore = await ipc.invokeWithProjectSession(
+      projectSession,
+      'db:project-core-get',
+      expectedProjectPath,
+    )
+    this.assertNotCancelled(context)
+    assertArchitectureProjectSessionCurrent(projectSession, context)
+    if (synopsisFactsFingerprint([latestCore?.worldbuilding || '']) !== expectedDbHash) {
+      await this.persistWorldBuildingCandidate(
+        projectSession,
+        expectedProjectPath,
+        context,
+        result,
+        factsFingerprint,
+        expectedDbHash,
+        stepGuidance,
+      )
+      throw new WorldBuildingResumeAvailableError(text(
+        '世界观生成期间正式内容已被修改，本次结果已保留为候选且未覆盖作者修改；可查看或复制候选。',
+        'The formal worldbuilding changed while generation was running. This result was kept as a candidate and did not overwrite the author edit; you can view or copy it.',
+      ))
+    }
     const heading = promptLanguageText(writingLanguage, '世界观', 'Worldbuilding')
     await writeArchToDb(
       'worldbuilding',
@@ -1685,8 +1856,12 @@ export class GenerateWorldBuildingCommand extends BaseWorkflowCommand<string> {
     )
     this.assertNotCancelled(context)
 
-    const partial = (context.data.partial as PartialArchData) || await loadPartialData(expectedProjectPath, projectSession)
     partial.world_building_result = result
+    delete partial.world_building_partial_result
+    delete partial.world_building_incomplete
+    delete partial.world_building_facts_fingerprint
+    delete partial.world_building_db_hash
+    delete partial.world_building_step_guidance
     this.assertNotCancelled(context)
     await savePartialData(
       expectedProjectPath,
@@ -1702,6 +1877,33 @@ export class GenerateWorldBuildingCommand extends BaseWorkflowCommand<string> {
       'Worldbuilding generated and saved to the database.',
     ))
     return result
+  }
+
+  private async persistWorldBuildingCandidate(
+    projectSession: ProjectSessionContext,
+    expectedProjectPath: string,
+    context: WorkflowContext,
+    candidate: string,
+    factsFingerprint: string,
+    dbHash: string,
+    stepGuidance: string,
+  ): Promise<void> {
+    this.assertNotCancelled(context)
+    assertArchitectureProjectSessionCurrent(projectSession, context)
+    const partial = (context.data.partial as PartialArchData) || await loadPartialData(expectedProjectPath, projectSession)
+    partial.world_building_partial_result = candidate
+    partial.world_building_incomplete = true
+    partial.world_building_facts_fingerprint = factsFingerprint
+    partial.world_building_db_hash = dbHash
+    partial.world_building_step_guidance = stepGuidance
+    await savePartialData(
+      expectedProjectPath,
+      partial,
+      projectSession,
+      workflowUiText(context, '保存世界观未完成候选', 'Save the incomplete worldbuilding candidate'),
+      workflowUiText(context, '保存世界观未完成候选失败', 'Failed to save the incomplete worldbuilding candidate.'),
+    )
+    context.data.partial = partial
   }
 }
 

--- a/src/services/workflows/commands/architecture.command.ts
+++ b/src/services/workflows/commands/architecture.command.ts
@@ -1823,6 +1823,9 @@ export class GenerateWorldBuildingCommand extends BaseWorkflowCommand<string> {
 
     this.assertNotCancelled(context)
     assertArchitectureProjectSessionCurrent(projectSession, context)
+    const latestTemplate = await resolvePromptTemplate('world_building', projectSession, writingLanguage)
+    this.assertNotCancelled(context)
+    assertArchitectureProjectSessionCurrent(projectSession, context)
     const latestCore = await ipc.invokeWithProjectSession(
       projectSession,
       'db:project-core-get',
@@ -1830,7 +1833,20 @@ export class GenerateWorldBuildingCommand extends BaseWorkflowCommand<string> {
     )
     this.assertNotCancelled(context)
     assertArchitectureProjectSessionCurrent(projectSession, context)
-    if (synopsisFactsFingerprint([latestCore?.worldbuilding || '']) !== expectedDbHash) {
+    const latestProject = useProjectStore.getState().currentProject
+    const latestFactsFingerprint = latestProject && latestTemplate
+      ? synopsisFactsFingerprint([
+          latestCore?.premise || '',
+          JSON.stringify(latestProject.novelConfig),
+          stepGuidance,
+          JSON.stringify(latestTemplate),
+        ])
+      : ''
+    const formalWorldBuildingChanged = synopsisFactsFingerprint([
+      latestCore?.worldbuilding || '',
+    ]) !== expectedDbHash
+    const sourceFactsChanged = latestFactsFingerprint !== factsFingerprint
+    if (formalWorldBuildingChanged || sourceFactsChanged) {
       await this.persistWorldBuildingCandidate(
         projectSession,
         expectedProjectPath,
@@ -1841,8 +1857,12 @@ export class GenerateWorldBuildingCommand extends BaseWorkflowCommand<string> {
         stepGuidance,
       )
       throw new WorldBuildingResumeAvailableError(text(
-        '世界观生成期间正式内容已被修改，本次结果已保留为候选且未覆盖作者修改；可查看或复制候选。',
-        'The formal worldbuilding changed while generation was running. This result was kept as a candidate and did not overwrite the author edit; you can view or copy it.',
+        sourceFactsChanged
+          ? '世界观生成期间故事前提、小说配置或模板已变化，本次结果已保留为候选且未写入正式世界观；可查看或复制候选。'
+          : '世界观生成期间正式内容已被修改，本次结果已保留为候选且未覆盖作者修改；可查看或复制候选。',
+        sourceFactsChanged
+          ? 'The premise, novel configuration, or template changed while worldbuilding was being generated. This result was kept as a candidate and was not written to formal worldbuilding; you can view or copy it.'
+          : 'The formal worldbuilding changed while generation was running. This result was kept as a candidate and did not overwrite the author edit; you can view or copy it.',
       ))
     }
     const heading = promptLanguageText(writingLanguage, '世界观', 'Worldbuilding')

--- a/src/services/workflows/commands/generate-draft.command.ts
+++ b/src/services/workflows/commands/generate-draft.command.ts
@@ -61,6 +61,90 @@ const CROSS_CHAPTER_REUSE_LONG_RUN_CHARS = 80
 const ACTIVE_THREAD_CONTEXT_MAX_CHARS = 1200
 const ACTIVE_THREAD_CONTEXT_MAX_ITEMS = 6
 const STREAM_PREVIEW_INTERVAL_MS = 250
+
+type ChapterHeading = Readonly<{
+  lineIndex: number
+  from: number
+  to: number
+  markdownLevel: number
+}>
+
+function parseChapterHeading(line: string, lineIndex: number): ChapterHeading | null {
+  const match = /^\s*(?:(#{1,6})[\t ]+)?(?:第\s*([1-9]\d*)(?:\s*[–—-]\s*([1-9]\d*))?\s*章|Chapters?[\t ]+([1-9]\d*)(?:[\t ]*[–—-][\t ]*([1-9]\d*))?)(?=[\t ]*(?:[:：.．—-]|$))/iu.exec(line)
+  if (!match) return null
+  // Bare headings must use the production outline's explicit title separator.
+  if (!match[1] && !/^[\t ]*[:：]\s*\S/u.test(line.slice(match[0].length))) return null
+  const from = Number(match[2] ?? match[4])
+  const to = Number(match[3] ?? match[5] ?? from)
+  return {
+    lineIndex,
+    from,
+    to,
+    markdownLevel: match[1]?.length ?? 0,
+  }
+}
+
+/**
+ * Project an explicitly chapter-structured synopsis onto one chapter without
+ * cutting any selected section. Ambiguous or unlocatable structures stay
+ * verbatim so author facts are never discarded on a guess.
+ */
+export function synopsisForDraftChapter(synopsis: string, chapterNumber: number): string {
+  // Quoted examples can contain chapter-like headings; do not interpret them.
+  if (/^\s*(?:`{3,}|~{3,})/mu.test(synopsis)) return synopsis.trim()
+  const lines = synopsis.trim().split(/\r?\n/u)
+  const headings = lines
+    .map((line, lineIndex) => parseChapterHeading(line, lineIndex))
+    .filter((heading): heading is ChapterHeading => heading !== null)
+  if (headings.length < 2) return synopsis.trim()
+
+  const firstLevel = headings[0]!.markdownLevel
+  const hasConsistentHeadingStyle = headings.every(heading => heading.markdownLevel === firstLevel)
+  const hasStrictChapterOrder = headings.every((heading, index) => (
+    heading.from <= heading.to
+    && (index === 0 || heading.from > headings[index - 1]!.to)
+  ))
+  const currentHeadings = headings.filter(heading => heading.from <= chapterNumber && chapterNumber <= heading.to)
+  if (!hasConsistentHeadingStyle || !hasStrictChapterOrder || currentHeadings.length !== 1) {
+    return synopsis.trim()
+  }
+
+  const headingsByLine = new Map(headings.map(heading => [heading.lineIndex, heading]))
+  let activeRange: Pick<ChapterHeading, 'from' | 'to'> | null = null
+  const projected: string[] = []
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+    const line = lines[lineIndex]!
+    const chapterHeading = headingsByLine.get(lineIndex)
+    if (chapterHeading) {
+      activeRange = chapterHeading
+    } else {
+      const markdownHeading = /^\s*(#{1,6})\s+/u.exec(line)
+      if (markdownHeading && (firstLevel === 0 || markdownHeading[1]!.length <= firstLevel)) {
+        activeRange = null
+      }
+    }
+    if (
+      activeRange === null
+      || (activeRange.from <= chapterNumber && chapterNumber <= activeRange.to)
+    ) projected.push(line)
+  }
+  return projected.join('\n').trim()
+}
+
+function exactParagraphs(values: readonly string[]): ReadonlySet<string> {
+  return new Set(values.flatMap(value => (
+    value.split(/\r?\n\s*\r?\n/u).map(paragraph => paragraph.trim()).filter(Boolean)
+  )))
+}
+
+function withoutExactParagraphDuplicates(content: string, duplicates: ReadonlySet<string>): string {
+  return content
+    .split(/\r?\n\s*\r?\n/u)
+    .map(paragraph => paragraph.trim())
+    .filter(paragraph => paragraph && !duplicates.has(paragraph))
+    .join('\n\n')
+}
+
 export function sanitizeDraftText(text: string): string {
   const cleaned = stripThinkingTags(text)
     .replace(/^\s*(?:点我继续生成后续内容|继续生成后续内容|请点击继续|未完待续)\s*$/gmi, '')
@@ -344,7 +428,15 @@ export class GenerateDraftCommand extends BaseWorkflowCommand {
       'Building chapter context...',
     ))
 
-    const architecture = await this.readArchitecture(expectedProjectPath, projectSession)
+    const { coreOutline, worldSetting, goldenFinger, protagonistProfile } = novelConfig
+    const authoredConfigFacts = [coreOutline, worldSetting, goldenFinger, protagonistProfile]
+      .filter((value): value is string => typeof value === 'string' && Boolean(value.trim()))
+    const architecture = await this.readArchitecture(
+      expectedProjectPath,
+      projectSession,
+      this.chapterInfo.chapterNumber,
+      authoredConfigFacts,
+    )
     const projectPrompts = await this.readProjectPrompts(
       expectedProjectPath,
       projectSession,
@@ -394,7 +486,6 @@ export class GenerateDraftCommand extends BaseWorkflowCommand {
     // 以最大化 LLM 上下文缓存命中率
     // ==========================================
     const writingStyle = novelConfig.writingStyle?.trim() || ''
-    const { coreOutline, worldSetting, goldenFinger, protagonistProfile } = novelConfig
     const promptOnlyConfigKeys = new Set([
       'globalGuidance',
       'writingStyle',
@@ -525,8 +616,7 @@ export class GenerateDraftCommand extends BaseWorkflowCommand {
     }
     const chapterMaterials = assembleChapterMaterials({
       writingLanguage,
-      authorProjectFacts: [coreOutline, worldSetting, goldenFinger, protagonistProfile]
-        .filter((value): value is string => typeof value === 'string' && Boolean(value.trim())),
+      authorProjectFacts: authoredConfigFacts,
       characterProfiles,
       futurePlans: futureBlueprintsStr,
       references: [
@@ -1096,13 +1186,24 @@ ${visibleTail}`,
   }
 
   // --- 抽取自原文件的辅助方法 ---
-  private async readArchitecture(projectPath: string, projectSession: ProjectSessionContext): Promise<string> {
+  private async readArchitecture(
+    projectPath: string,
+    projectSession: ProjectSessionContext,
+    chapterNumber: number,
+    authoredConfigFacts: readonly string[],
+  ): Promise<string> {
     const core = await ipc.invokeWithProjectSession(projectSession, 'db:project-core-get', projectPath)
+    const duplicates = exactParagraphs(authoredConfigFacts)
     const parts: string[] = []
-    if (core?.premise) parts.push(core.premise.trim())
-    if (core?.worldbuilding) parts.push(core.worldbuilding.trim())
-    if (core?.synopsis) parts.push(core.synopsis.trim())
-    return parts.join('\n\n---\n\n')
+    if (core?.premise) parts.push(withoutExactParagraphDuplicates(core.premise, duplicates))
+    if (core?.worldbuilding) parts.push(withoutExactParagraphDuplicates(core.worldbuilding, duplicates))
+    if (core?.synopsis) {
+      parts.push(withoutExactParagraphDuplicates(
+        synopsisForDraftChapter(core.synopsis, chapterNumber),
+        duplicates,
+      ))
+    }
+    return parts.filter(Boolean).join('\n\n---\n\n')
   }
 
   private async readProjectPrompts(

--- a/src/services/workflows/creative-workflow-launcher.ts
+++ b/src/services/workflows/creative-workflow-launcher.ts
@@ -40,6 +40,8 @@ export type CreativeIntent =
       synopsisRange?: ArchitectureWorkflowParams['synopsisRange']
       /** 从输出长度中断的检查点续写情节大纲。 */
       resumeSynopsis?: ArchitectureWorkflowParams['resumeSynopsis']
+      /** 从输出长度中断的候选续写世界观。 */
+      resumeWorldBuilding?: ArchitectureWorkflowParams['resumeWorldBuilding']
     }
   | { workflow: 'generate_blueprint'; params?: DirectoryWorkflowParams }
   | { workflow: 'review' | 'refine' | 'finalize'; chapterNumber: number }
@@ -125,6 +127,7 @@ async function definitionFor(
       stepGuidance: intent.stepGuidance,
       synopsisRange: intent.synopsisRange ?? null,
       resumeSynopsis: intent.resumeSynopsis,
+      resumeWorldBuilding: intent.resumeWorldBuilding,
     }, uiLocale)
   }
   if (intent.workflow === 'generate_blueprint') {


### PR DESCRIPTION
## 关联 Issue

- Related to #187。仅改进其中的长度报错、世界观截断恢复及下游输入膨胀风险，不代表该 Issue 涉及的全部生成场景已经解决，不自动关闭 Issue。

## 变更说明

- 世界观生成被截断时先保存独立候选，最多自动续写一次；再次截断或网络失败仍保留候选，不覆盖正式世界观。
- 世界观界面可查看、复制和恢复候选；已打开的界面在工作流失败后也会刷新候选状态。
- 恢复与提交检查故事前提、配置、模板和正式内容是否变化，避免旧上下文生成结果覆盖作者修改。
- 写当前章时，只从可明确识别的大纲中选择当前章范围及全局段落；对与作者配置逐段完全相同的材料去重，原始资料不修改。
- 公共错误提示区分本次请求长度限制与模型最大能力，不再无条件声称结果未保存。

### 明确未包含

- 不改变 8K/4K、模型能力边界、总体请求额度、次数或超时保护。
- 不机械截断无结构世界观、歧义大纲、代码围栏内引用或必需作者事实；这些场景仍可能形成较大输入，没有声称实现无损硬上界。
- 不包含设置入口、Windows helper 等其他修复；不涉及 DSH、依赖升级、安装包、版本号或 Release。

## 验证证据

- 本地独立代码审查按 Standards 与 Spec 分开执行；发现的源事实提交前复核缺口已补修并复验。
- 生成及工作流相关单元/集成测试：使用现有匹配原生模块 ABI 的 Electron Node 模式运行 `vitest run src/services/workflows src/services/generation`，40 个文件、695 项通过。
- 中文浏览器回归：`pnpm exec vitest run --config vitest.browser.config.ts src/components/editor/__tests__/world-building-recovery.browser.tsx`，1 项通过。
- `pnpm run typecheck`、变更文件 ESLint、`pnpm run check:i18n`、`git diff --check` 通过。
- 世界观回归覆盖正常结束、先存后续、二次截断、网络失败、重开恢复、取消/切换、作者修改与源事实变化。
- 实际正文请求构造回归覆盖 Markdown/裸章标题、全局及世界观尾部事实、精确去重、歧义与围栏回退；非当前章大纲扩大约四万字，当前章请求长度保持不变。
- 本地首次扩大回归遇到过 Windows 临时测试目录清理 `ENOTEMPTY`；重新执行整组测试通过，未修改测试或绕过门禁。

未运行：正式安装包端到端恢复验收、新一轮真实模型调用和三章产品验收。候选存储的命令与浏览器回归使用隔离 IPC 替身，不等同于安装包真实磁盘恢复验收。云端 CI 以本 PR 的实际检查结果为准。

## 界面变化

世界观卡片新增未完成候选提示，以及查看、复制、断点续写操作。中文浏览器回归已验证失败后的可见性；未附正式安装包截图。

## 提交者确认

- [x] 此 PR 聚焦生成长度限制下的恢复与上下文处理，没有混入无关修复。
- [x] 已逐项审阅并执行上述范围内的验证；未执行的验收明确列出。
- [x] 不包含密钥、真实小说、私人路径、数据库、安装包或整包日志。
- 保持 Draft，不合并、不发布、不打 tag、不关闭 Issue。
